### PR TITLE
[FIX] setup.py imported self

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mock
+-r ../requirements.txt

--- a/fmriprep/__init__.py
+++ b/fmriprep/__init__.py
@@ -9,39 +9,17 @@ the Center for Reproducible Neuroscience (http://reproducibility.stanford.edu/),
 as well as for open-source software distribution.
 """
 
-__version__ = '0.1.1a2'
-
-
-__author__ = 'The CRN developers'
-__copyright__ = 'Copyright 2016, Center for Reproducible Neuroscience, Stanford University'
-__credits__ = ['Craig Moodie', 'Ross Blair', 'Oscar Esteban', 'Chris F. Gorgolewski',
-               'Russell A. Poldrack']
-__license__ = '3-clause BSD'
-__maintainer__ = 'Ross Blair'
-__email__ = 'crn.poldracklab@gmail.com'
-__status__ = 'Prototype'
-__url__ = 'https://github.com/poldracklab/preprocessing-workflow'
-__packagename__ = 'fmriprep'
-
-__description__ = """Fmriprep is a functional magnetic resonance image pre-processing pipeline that
-is designed to provide an easily accessible, state-of-the-art interface that is robust to differences
-in scan acquisition protocols and that requires minimal user input, while providing easily interpretable
-and comprehensive error and output reporting."""
-__longdesc__ = """
-This package is a functional magnetic resonance image preprocessing pipeline that is designed to
-provide an easily accessible, state-of-the-art interface that is robust to differences in scan
-acquisition protocols and that requires minimal user input, while providing easily interpretable
-and comprehensive error and output reporting. This open-source neuroimaging data processing tool
-is being developed as a part of the MRI image analysis and reproducibility platform offered by the
-CRN. This pipeline is heavily influenced by the `Human Connectome Project analysis pipelines
-<https://github.com/Washington-University/Pipelines>`_ and, as such, the backbone of this pipeline
-is a python reimplementation of the HCP `GenericfMRIVolumeProcessingPipeline.sh` script. However, a
-major difference is that this pipeline is executed using a `nipype workflow framework
-<http://nipype.readthedocs.io/en/latest/>`_. This allows for each call to a software module or binary
-to be controlled within the workflows, which removes the need for manual curation at every stage, while
-still providing all the output and error information that would be necessary for debugging and interpretation
-purposes. The fmriprep pipeline primarily utilizes FSL tools, but also utilizes ANTs tools at several stages
-such as skull stripping and template registration. This pipeline was designed to provide the best software
-implementation for each state of preprocessing, and will be updated as newer and better neuroimaging software
-become available.
-"""
+from .info import (
+    __version__,
+    __author__,
+    __copyright__,
+    __credits__,
+    __license__,
+    __maintainer__,
+    __email__,
+    __status__,
+    __url__,
+    __packagename__,
+    __description__,
+    __longdesc__
+)

--- a/fmriprep/info.py
+++ b/fmriprep/info.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""
+Base module variables
+"""
+
+__version__ = '0.1.1a3'
+__author__ = 'The CRN developers'
+__copyright__ = 'Copyright 2016, Center for Reproducible Neuroscience, Stanford University'
+__credits__ = ['Craig Moodie', 'Ross Blair', 'Oscar Esteban', 'Chris F. Gorgolewski',
+               'Russell A. Poldrack']
+__license__ = '3-clause BSD'
+__maintainer__ = 'Ross Blair'
+__email__ = 'crn.poldracklab@gmail.com'
+__status__ = 'Prototype'
+__url__ = 'https://github.com/poldracklab/preprocessing-workflow'
+__packagename__ = 'fmriprep'
+__description__ = """fMRIprep is a functional magnetic resonance image pre-processing pipeline that
+is designed to provide an easily accessible, state-of-the-art interface that is robust to differences
+in scan acquisition protocols and that requires minimal user input, while providing easily interpretable
+and comprehensive error and output reporting."""
+__longdesc__ = """
+This package is a functional magnetic resonance image preprocessing pipeline that is designed to
+provide an easily accessible, state-of-the-art interface that is robust to differences in scan
+acquisition protocols and that requires minimal user input, while providing easily interpretable
+and comprehensive error and output reporting. This open-source neuroimaging data processing tool
+is being developed as a part of the MRI image analysis and reproducibility platform offered by the
+CRN. This pipeline is heavily influenced by the `Human Connectome Project analysis pipelines
+<https://github.com/Washington-University/Pipelines>`_ and, as such, the backbone of this pipeline
+is a python reimplementation of the HCP `GenericfMRIVolumeProcessingPipeline.sh` script. However, a
+major difference is that this pipeline is executed using a `nipype workflow framework
+<http://nipype.readthedocs.io/en/latest/>`_. This allows for each call to a software module or binary
+to be controlled within the workflows, which removes the need for manual curation at every stage, while
+still providing all the output and error information that would be necessary for debugging and interpretation
+purposes. The fmriprep pipeline primarily utilizes FSL tools, but also utilizes ANTs tools at several stages
+such as skull stripping and template registration. This pipeline was designed to provide the best software
+implementation for each state of preprocessing, and will be updated as newer and better neuroimaging software
+become available.
+"""

--- a/setup.py
+++ b/setup.py
@@ -3,31 +3,35 @@
 # @Author: oesteban
 # @Date:   2015-11-19 16:44:27
 # @Last Modified by:   oesteban
-# @Last Modified time: 2016-07-29 16:38:19
+# @Last Modified time: 2016-08-29 18:50:54
 """ fmriprep setup script """
 import os
 import sys
 
-from fmriprep import (__version__, __email__, __url__, __packagename__, __license__,
-                      __description__, __longdesc__, __maintainer__, __author__)
-
-
-REQ_LINKS = []
-with open('requirements.txt', 'r') as rfile:
-    REQUIREMENTS = [line.strip() for line in rfile.readlines()]
-
-for i, req in enumerate(REQUIREMENTS):
-    if req.startswith('-e'):
-        REQUIREMENTS[i] = req.split('=')[1]
-        REQ_LINKS.append(req.split()[1])
-
-if REQUIREMENTS is None:
-    REQUIREMENTS = []
 
 def main():
     """ Install entry-point """
     from glob import glob
-    from setuptools import setup
+    from inspect import getfile, currentframe
+    from setuptools import setup, find_packages
+
+    this_path = os.path.dirname(os.path.abspath(getfile(currentframe())))
+    # Read vars from info file
+    module_file =os.path.join(this_path, 'fmriprep', 'info.py')
+    with open(module_file) as fvars:
+        exec(compile(fvars.read(), module_file, 'exec'))
+
+    REQ_LINKS = []
+    with open('requirements.txt', 'r') as rfile:
+        REQUIREMENTS = [line.strip() for line in rfile.readlines()]
+
+    for i, req in enumerate(REQUIREMENTS):
+        if req.startswith('-e'):
+            REQUIREMENTS[i] = req.split('=')[1]
+            REQ_LINKS.append(req.split()[1])
+
+    if REQUIREMENTS is None:
+        REQUIREMENTS = []
 
     setup(
         name=__packagename__,
@@ -44,14 +48,7 @@ def main():
                      'fmriprep-%s.tar.gz' % __version__,
         license=__license__,
         entry_points={'console_scripts': ['fmriprep=fmriprep.run_workflow:main',]},
-        packages=['fmriprep',
-                  'fmriprep.data',
-                  'fmriprep.interfaces',
-                  'fmriprep.utils',
-                  'fmriprep.viz',
-                  'fmriprep.workflows',
-                  'fmriprep.workflows.fieldmap',
-        ],
+        packages=find_packages(),
         package_data={'fmriprep': ['data/*.json']},
         install_requires=REQUIREMENTS,
         dependency_links=REQ_LINKS,
@@ -67,8 +64,8 @@ def main():
     )
 
 if __name__ == '__main__':
-    local_path = os.path.dirname(os.path.abspath(sys.argv[0]))
-    os.chdir(local_path)
-    sys.path.insert(0, local_path)
+    LOCAL_PATH = os.path.dirname(os.path.abspath(sys.argv[0]))
+    os.chdir(LOCAL_PATH)
+    sys.path.insert(0, LOCAL_PATH)
 
     main()


### PR DESCRIPTION
This fixes the problem that was making niworkflows fail
in its installation. In fmriprep this was not happening because
the main ```__init__.py``` did not import anything.

Added as well a requirements file for building the documentation.

Closes #133