### PR TITLE
[RTM] Turn on ants skull strip reports

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ test:
     - docker run -ti --rm --entrypoint="/usr/bin/run_unittests" poldracklab/fmriprep:latest
     - docker run -i -v /etc/localtime:/etc/localtime:ro -v $HOME/data:/data:ro -v ~/.cache/stanford-crn:/root/.cache/stanford-crn -v $HOME/ds054/out:/out -w /scratch poldracklab/fmriprep:latest /data/ds054 /out/ participant -w work/ -t ds054 --debug :
         timeout: 4800
-    - docker run -i -v /etc/localtime:/etc/localtime:ro -v $HOME/data:/data:ro -v ~/.cache/stanford-crn:/root/.cache/stanford-crn -v $HOME/ds005/out:/out -w /scratch poldracklab/fmriprep:latest /data/ds005 /out/ participant -w work/ -t ds005 --debug :
+    - docker run -i -v /etc/localtime:/etc/localtime:ro -v $HOME/data:/data:ro -v ~/.cache/stanford-crn:/root/.cache/stanford-crn -v $HOME/ds005/out:/out -w /scratch poldracklab/fmriprep:latest /data/ds005 /out/ participant -w work/ -t ds005 --debug --no-skull-strip-ants :
         timeout: 4800
 
 general:

--- a/fmriprep/run_workflow.py
+++ b/fmriprep/run_workflow.py
@@ -61,7 +61,7 @@ def main():
     g_ants = parser.add_argument_group('specific settings for ANTs registrations')
     g_ants.add_argument('--ants-nthreads', action='store', type=int,
                         help='number of threads that will be set in ANTs processes')
-    g_ants.add_argument('--skull-strip-ants', action='store_true', default=False,
+    g_ants.add_argument('--skull-strip-ants', action='store_true', default=True,
                         help='use ANTs-based skull-stripping')
 
     opts = parser.parse_args()

--- a/fmriprep/run_workflow.py
+++ b/fmriprep/run_workflow.py
@@ -63,10 +63,10 @@ def main():
                         help='number of threads that will be set in ANTs processes')
     g_ants.add_argument('--skull-strip-ants', dest="skull_strip_ants",
                         action='store_true',
-                        help='use ANTs-based skull-stripping')
+                        help='use ANTs-based skull-stripping (default, slow))')
     g_ants.add_argument('--no-skull-strip-ants', dest="skull_strip_ants",
                         action='store_false',
-                        help="don't use ANTs-based skull-stripping")
+                        help="don't use ANTs-based skull-stripping (use  AFNI instead, fast)")
     g_ants.set_defaults(skull_strip_ants=True)
 
     opts = parser.parse_args()

--- a/fmriprep/run_workflow.py
+++ b/fmriprep/run_workflow.py
@@ -61,8 +61,13 @@ def main():
     g_ants = parser.add_argument_group('specific settings for ANTs registrations')
     g_ants.add_argument('--ants-nthreads', action='store', type=int,
                         help='number of threads that will be set in ANTs processes')
-    g_ants.add_argument('--skull-strip-ants', action='store_true', default=True,
+    g_ants.add_argument('--skull-strip-ants', dest="skull_strip_ants",
+                        action='store_true',
                         help='use ANTs-based skull-stripping')
+    g_ants.add_argument('--no-skull-strip-ants', dest="skull_strip_ants",
+                        action='store_false',
+                        help="don't use ANTs-based skull-stripping")
+    g_ants.set_defaults(skull_strip_ants=True)
 
     opts = parser.parse_args()
     create_workflow(opts)

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -20,6 +20,7 @@ from nipype.pipeline import engine as pe
 from niworkflows.anat.mni import RobustMNINormalization
 from niworkflows.anat.skullstrip import afni_wf as skullstrip_wf
 from niworkflows.data import get_mni_icbm152_nlin_asym_09c
+from niworkflows.interfaces.masks import BrainExtractionRPT
 
 from fmriprep.interfaces import (DerivativesDataSink, IntraModalMerge,
                                  ImageDataSink)
@@ -299,9 +300,10 @@ def skullstrip_ants(name='ANTsBrainExtraction', settings=None):
     outputnode = pe.Node(niu.IdentityInterface(
         fields=['out_file', 'out_mask']), name='outputnode')
 
-    t1_skull_strip = pe.Node(ants.segmentation.BrainExtraction(
+    t1_skull_strip = pe.Node(BrainExtractionRPT(
         dimension=3, use_floatingpoint_precision=1,
-        debug=settings['debug']), name='Ants_T1_Brain_Extraction')
+        debug=settings['debug'], generate_report=True),
+        name='Ants_T1_Brain_Extraction')
     t1_skull_strip.inputs.brain_template = op.join(
         get_ants_oasis_template_ras(),
         'T_template0.nii.gz'


### PR DESCRIPTION
Comments:

- ants  skull stripping is the default option now
- ants skull stripping is turned off for one of the test datasets - this saves test times and makes sure we test both options.