### PR TITLE
[RTM] multithreading tweaks

### DIFF
--- a/fmriprep/run_workflow.py
+++ b/fmriprep/run_workflow.py
@@ -85,6 +85,7 @@ def create_workflow(opts):
         'write_graph': opts.write_graph,
         'nthreads': opts.nthreads,
         'debug': opts.debug,
+        'ants_nthreads': opts.ants_nthreads,
         'skull_strip_ants': opts.skull_strip_ants,
         'output_dir': op.abspath(opts.output_dir),
         'work_dir': op.abspath(opts.work_dir)
@@ -96,8 +97,6 @@ def create_workflow(opts):
     if opts.debug:
         settings['ants_t1-mni_settings'] = 't1-mni_registration_test'
         logger.setLevel(logging.DEBUG)
-
-    settings['ants_threads'] = opts.ants_nthreads
 
     log_dir = op.join(settings['output_dir'], 'log')
     derivatives = op.join(settings['output_dir'], 'derivatives')

--- a/fmriprep/run_workflow.py
+++ b/fmriprep/run_workflow.py
@@ -59,7 +59,7 @@ def main():
 
     # ANTs options
     g_ants = parser.add_argument_group('specific settings for ANTs registrations')
-    g_ants.add_argument('--ants-nthreads', action='store', type=int,
+    g_ants.add_argument('--ants-nthreads', action='store', type=int, default=0,
                         help='number of threads that will be set in ANTs processes')
     g_ants.add_argument('--skull-strip-ants', dest="skull_strip_ants",
                         action='store_true',
@@ -97,8 +97,7 @@ def create_workflow(opts):
         settings['ants_t1-mni_settings'] = 't1-mni_registration_test'
         logger.setLevel(logging.DEBUG)
 
-    if opts.ants_nthreads is not None:
-        settings['ants_threads'] = opts.ants_nthreads
+    settings['ants_threads'] = opts.ants_nthreads
 
     log_dir = op.join(settings['output_dir'], 'log')
     derivatives = op.join(settings['output_dir'], 'derivatives')
@@ -133,6 +132,9 @@ def create_workflow(opts):
         if settings['nthreads'] > 1:
             plugin_settings['plugin'] = 'MultiProc'
             plugin_settings['plugin_args'] = {'n_procs': settings['nthreads']}
+
+    if settings['ants_nthreads'] == 0:
+        settings['ants_nthreads'] = cpu_count()
 
     # Determine subjects to be processed
     subject_list = opts.participant_label

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -68,7 +68,7 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
     t1_2_mni = pe.Node(
         RobustMNINormalizationRPT(
             generate_report=True,
-            num_threads=settings['ants_threads'],
+            num_threads=settings['ants_nthreads'],
             testing=settings.get('debug', False),
             template='mni_icbm152_nlin_asym_09c'
         ),
@@ -76,7 +76,7 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
     )
     # should not be necesssary byt does not hurt - make sure the multiproc
     # scheduler knows the resource limits
-    t1_2_mni.interface.num_threads = settings['ants_threads']
+    t1_2_mni.interface.num_threads = settings['ants_nthreads']
 
     # Resample the brain mask and the tissue probability maps into mni space
     bmask_mni = pe.Node(

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -68,12 +68,15 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
     t1_2_mni = pe.Node(
         RobustMNINormalizationRPT(
             generate_report=True,
-            num_threads=settings.get('ants_threads', 6),
+            num_threads=settings['ants_threads'],
             testing=settings.get('debug', False),
             template='mni_icbm152_nlin_asym_09c'
         ),
         name='T1_2_MNI_Registration'
     )
+    # should not be necesssary byt does not hurt - make sure the multiproc
+    # scheduler knows the resource limits
+    t1_2_mni.interface.num_threads = settings['ants_threads']
 
     # Resample the brain mask and the tissue probability maps into mni space
     bmask_mni = pe.Node(
@@ -307,8 +310,14 @@ def skullstrip_ants(name='ANTsBrainExtraction', settings=None):
 
     t1_skull_strip = pe.Node(BrainExtractionRPT(
         dimension=3, use_floatingpoint_precision=1,
-        debug=settings['debug'], generate_report=True),
+        debug=settings['debug'], generate_report=True,
+        num_threads=settings['ants_nthreads']),
         name='Ants_T1_Brain_Extraction')
+
+    # should not be necesssary byt does not hurt - make sure the multiproc
+    # scheduler knows the resource limits
+    t1_skull_strip.interface.num_threads = settings['ants_nthreads']
+
     t1_skull_strip.inputs.brain_template = op.join(
         get_ants_oasis_template_ras(),
         'T_template0.nii.gz'

--- a/test/workflows/test_base.py
+++ b/test/workflows/test_base.py
@@ -10,7 +10,8 @@ class TestBase(TestWorkflow):
     def test_wf_ds054_type(self, _):
         # set up
         mock_subject_data = {'t1w': ['um'], 'sbref': ['um'], 'func': 'um'}
-        mock_settings = {'output_dir': '.', 'work_dir': '.'}
+        mock_settings = {'output_dir': '.', 'work_dir': '.',
+                         'ants_nthreads': 1}
 
         # run
         wf054 = wf_ds054_type(mock_subject_data, mock_settings)
@@ -37,7 +38,7 @@ class TestBase(TestWorkflow):
     def test_wf_ds005_type(self, _):
         # set up
         mock_subject_data = {'func': ''}
-        mock_settings = {'output_dir': '.'}
+        mock_settings = {'output_dir': '.', 'ants_nthreads': 1}
 
         # run
         wf005 = wf_ds005_type(mock_subject_data, mock_settings)


### PR DESCRIPTION
- more sensible defaults for ants-threads (use all available cores)
- enable multithreaded processing for brain extraction
- set `num_threads` variables so the MultiProc scheduler would be aware of the required resources