### PR TITLE
[RTM] memory consumption driven scheduling

### DIFF
--- a/fmriprep/utils/misc.py
+++ b/fmriprep/utils/misc.py
@@ -114,5 +114,13 @@ def collect_bids_data(dataset, subject, session=None, run=None):
     return imaging_data
 
 
+def get_biggest_epi_file_size_gb(files):
+    max_size = 0
+    for file in files:
+        size = os.path.getsize(file)/(1024*1024*1024)
+        if size > max_size:
+            max_size = size
+    return max_size
+
 if __name__ == '__main__':
     pass

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -11,7 +11,7 @@ from nipype.pipeline import engine as pe
 from nipype.interfaces import fsl
 
 from fmriprep.interfaces import BIDSDataGrabber
-from fmriprep.utils.misc import collect_bids_data
+from fmriprep.utils.misc import collect_bids_data, get_biggest_epi_file_size_gb
 from fmriprep.workflows import confounds
 
 from fmriprep.workflows.anatomical import t1w_preprocessing
@@ -36,6 +36,9 @@ def base_workflow_enumerator(subject_list, settings):
 
 def base_workflow_generator(subject_id, settings):
     subject_data = collect_bids_data(settings['bids_root'], subject_id)
+
+    settings["biggest_epi_file_size_gb"] = get_biggest_epi_file_size_gb(subject_data['func'])
+
     if subject_data['t1w'] != [] and subject_data['sbref'] != []:
         return wf_ds054_type(subject_data, settings, name=subject_id)
     if subject_data['t1w'] != [] and subject_data['sbref'] == []:

--- a/fmriprep/workflows/confounds.py
+++ b/fmriprep/workflows/confounds.py
@@ -40,17 +40,27 @@ def discover_wf(settings, name="ConfoundDiscoverer"):
     signals = pe.Node(nilearn.SignalExtraction(include_global=True, detrend=True,
                                                class_labels=FAST_DEFAULT_SEGS),
                       name="SignalExtraction")
+    signals.interface.estimated_memory_gb = settings[
+                                              "biggest_epi_file_size_gb"] * 3
     # DVARS
     dvars = pe.Node(confounds.ComputeDVARS(save_all=True, remove_zerovariance=True),
                     name="ComputeDVARS")
+    dvars.interface.estimated_memory_gb = settings[
+                                              "biggest_epi_file_size_gb"] * 3
     # Frame displacement
     frame_displace = pe.Node(confounds.FramewiseDisplacement(), name="FramewiseDisplacement")
+    frame_displace.interface.estimated_memory_gb = settings[
+                                              "biggest_epi_file_size_gb"] * 3
     # CompCor
     tcompcor = pe.Node(confounds.TCompCor(components_file='tcompcor.tsv'), name="tCompCor")
+    tcompcor.interface.estimated_memory_gb = settings[
+                                              "biggest_epi_file_size_gb"] * 3
     acompcor_roi = pe.Node(mask.BinarizeSegmentation(
         false_values=[FAST_DEFAULT_SEGS.index('GrayMatter') + 1, 0]),  # 0 denotes background
                            name="CalcaCompCorROI")
     acompcor = pe.Node(confounds.ACompCor(components_file='acompcor.tsv'), name="aCompCor")
+    acompcor.interface.estimated_memory_gb = settings[
+                                              "biggest_epi_file_size_gb"] * 3
 
     # misc utilities
     concat = pe.Node(utility.Function(function=_gather_confounds, input_names=['signals', 'dvars',

--- a/fmriprep/workflows/epi.py
+++ b/fmriprep/workflows/epi.py
@@ -43,6 +43,7 @@ def epi_hmc(name='EPI_HMC', settings=None):
     # Head motion correction (hmc)
     hmc = pe.Node(fsl.MCFLIRT(
         save_mats=True, save_plots=True, mean_vol=True), name='EPI_hmc')
+    hmc.interface.estimated_memory_gb = settings["biggest_epi_file_size_gb"] * 3
 
     hcm2itk = pe.MapNode(c3.C3dAffineTool(fsl2ras=True, itk_transform=True),
                          iterfield=['transform_file'], name='hcm2itk')
@@ -350,6 +351,8 @@ def epi_mni_transformation(name='EPIMNITransformation', settings=None):
                                          '1mm_T1.nii.gz')
 
     split = pe.Node(fsl.Split(dimension='t'), name='SplitEPI')
+    split.interface.estimated_memory_gb = settings["biggest_epi_file_size_gb"] * 3
+
     merge_transforms = pe.MapNode(niu.Merge(3),
                                   iterfield=['in3'], name='MergeTransforms')
     epi_to_mni_transform = pe.MapNode(
@@ -357,6 +360,8 @@ def epi_mni_transformation(name='EPIMNITransformation', settings=None):
         name='EPIToMNITransform')
     epi_to_mni_transform.terminal_output = 'file'
     merge = pe.Node(fsl.Merge(dimension='t'), name='MergeEPI')
+    merge.interface.estimated_memory_gb = settings[
+                                              "biggest_epi_file_size_gb"] * 3
 
     mask_merge_tfms = pe.Node(niu.Merge(2), name='MaskMergeTfms')
     mask_mni_tfm = pe.Node(

--- a/test/workflows/test_base.py
+++ b/test/workflows/test_base.py
@@ -11,7 +11,7 @@ class TestBase(TestWorkflow):
         # set up
         mock_subject_data = {'t1w': ['um'], 'sbref': ['um'], 'func': 'um'}
         mock_settings = {'output_dir': '.', 'work_dir': '.',
-                         'ants_nthreads': 1}
+                         'ants_nthreads': 1, 'biggest_epi_file_size_gb': 1}
 
         # run
         wf054 = wf_ds054_type(mock_subject_data, mock_settings)
@@ -38,7 +38,8 @@ class TestBase(TestWorkflow):
     def test_wf_ds005_type(self, _):
         # set up
         mock_subject_data = {'func': ''}
-        mock_settings = {'output_dir': '.', 'ants_nthreads': 1}
+        mock_settings = {'output_dir': '.', 'ants_nthreads': 1,
+                         'biggest_epi_file_size_gb': 1}
 
         # run
         wf005 = wf_ds005_type(mock_subject_data, mock_settings)

--- a/test/workflows/test_confounds.py
+++ b/test/workflows/test_confounds.py
@@ -17,7 +17,7 @@ class TestConfounds(TestWorkflow):
 
     def test_discover_wf(self):
         # run
-        workflow = discover_wf(stub.settings())
+        workflow = discover_wf(stub.settings({'biggest_epi_file_size_gb': 1}))
         workflow.write_hierarchical_dotfile()
 
         # assert


### PR DESCRIPTION
This PR is attempting to avoid situations where we processing fails because we are trying to run too many tasks consuming a lot of memory at the same time. Now the size of the biggest _bold file is read and three times this much RAM is requested for each critical 4D jobs.

I did not implement this for the sbref/fieldmaps sub workflows since I know @oesteban is actively refactoring them in #198 