### PR TITLE
[FIX,RTM] Utility function _first crashes with strings

### DIFF
--- a/fmriprep/utils/misc.py
+++ b/fmriprep/utils/misc.py
@@ -12,6 +12,9 @@ from bids.grabbids import BIDSLayout
 INPUTS_SPEC = {'fieldmaps': [], 'func': [], 't1': [], 'sbref': []}
 
 def _first(inlist):
+    if not isinstance(inlist, (list, tuple)):
+        inlist = [inlist]
+
     return sorted(inlist)[0]
 
 def make_folder(folder):


### PR DESCRIPTION
If there is only one sbref file, for instance, the BIDS data source
will return just one string for the file found.

The former implementation didn't check this point.