### PR TITLE
[RTM] fix for derivatives sink when multiple t1s are present (ds000051)

### DIFF
--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -82,7 +82,7 @@ class DerivativesDataSinkInputSpec(BaseInterfaceInputSpec):
         desc='Path to the base directory for storing data.')
     in_file = InputMultiPath(File(exists=True), mandatory=True,
                              desc='the object to be saved')
-    source_file = File(exists=True, mandatory=True, desc='the input func file')
+    source_file = File(exists=False, mandatory=True, desc='the input func file')
     suffix = traits.Str('', mandatory=True, desc='suffix appended to source_file')
     extra_values = traits.List(traits.Str)
 

--- a/fmriprep/utils/misc.py
+++ b/fmriprep/utils/misc.py
@@ -128,5 +128,16 @@ def get_biggest_epi_file_size_gb(files):
             max_size = size
     return max_size
 
+def fix_multi_T1w_source_name(in_files):
+    import os
+    # in case there are multiple T1s we make up a generic source name
+    if isinstance(in_files, list):
+        subject_label = in_files[0].split(os.sep)[-1].split("_")[0].split("-")[
+            -1]
+        base, _ = os.path.split(in_files[0])
+        return os.path.join(base, "sub-%s_T1w.nii.gz" % subject_label)
+    else:
+        return in_files
+
 if __name__ == '__main__':
     pass

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -110,6 +110,7 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
 
     def fix_source_name(in_files):
         import os
+        # in case there are multiple T1s we make up a generic source name
         if isinstance(in_files, list):
             subject_label = in_files[0].split(os.sep)[-1].split("_")[0].split("-")[-1]
             base, _ = os.path.split(in_files[0])
@@ -155,7 +156,7 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
             name='DS_Report'
         )
         workflow.connect([
-            (inputnode, ds_t1_skull_strip_report, [('t1w', 'source_file')]),
+            (inputnode, ds_t1_skull_strip_report, [(('t1w', fix_source_name), 'source_file')]),
             (asw, ds_t1_skull_strip_report, [('outputnode.out_report', 'in_file')])
         ])
 

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -108,6 +108,15 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
         name='DS_T1_2_MNI_Report'
     )
 
+    def fix_source_name(in_files):
+        import os
+        if isinstance(in_files, list):
+            subject_label = in_files[0].split(os.sep)[-1].split("_")[0].split("-")[-1]
+            base, _ = os.path.split(in_files[0])
+            return os.path.join(base, "sub-%s_T1w.nii.gz"%subject_label)
+        else:
+            return in_files
+
     workflow.connect([
         (inputnode, arw, [('t1w', 'in_file')]),
         (arw, inu_n4, [('out_file', 'input_image')]),
@@ -133,9 +142,9 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
                               ('forward_invert_flags', 'invert_transform_flags')]),
         (asw, outputnode, [('outputnode.out_file', 't1_brain'),
                            ('outputnode.out_mask', 't1_mask')]),
-        (inputnode, ds_t1_seg_report, [('t1w', 'source_file')]),
+        (inputnode, ds_t1_seg_report, [(('t1w', fix_source_name), 'source_file')]),
         (t1_seg, ds_t1_seg_report, [('out_report', 'in_file')]),
-        (inputnode, ds_t1_2_mni_report, [('t1w', 'source_file')]),
+        (inputnode, ds_t1_2_mni_report, [(('t1w', fix_source_name), 'source_file')]),
         (t1_2_mni, ds_t1_2_mni_report, [('out_report', 'in_file')])
     ])
 
@@ -212,13 +221,13 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
         ])
 
     workflow.connect([
-        (inputnode, ds_t1_bias, [('t1w', 'source_file')]),
-        (inputnode, ds_t1_seg, [('t1w', 'source_file')]),
-        (inputnode, ds_mask, [('t1w', 'source_file')]),
-        (inputnode, ds_t1_mni, [('t1w', 'source_file')]),
-        (inputnode, ds_t1_mni_aff, [('t1w', 'source_file')]),
-        (inputnode, ds_bmask_mni, [('t1w', 'source_file')]),
-        (inputnode, ds_tpms_mni, [('t1w', 'source_file')]),
+        (inputnode, ds_t1_bias, [(('t1w', fix_source_name), 'source_file')]),
+        (inputnode, ds_t1_seg, [(('t1w', fix_source_name), 'source_file')]),
+        (inputnode, ds_mask, [(('t1w', fix_source_name), 'source_file')]),
+        (inputnode, ds_t1_mni, [(('t1w', fix_source_name), 'source_file')]),
+        (inputnode, ds_t1_mni_aff, [(('t1w', fix_source_name), 'source_file')]),
+        (inputnode, ds_bmask_mni, [(('t1w', fix_source_name), 'source_file')]),
+        (inputnode, ds_tpms_mni, [(('t1w', fix_source_name), 'source_file')]),
         (inu_n4, ds_t1_bias, [('output_image', 'in_file')]),
         (t1_seg, ds_t1_seg, [('tissue_class_map', 'in_file')]),
         (asw, ds_mask, [('outputnode.out_mask', 'in_file')]),

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -43,18 +43,18 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
                 't1_2_mni', 't1_2_mni_forward_transform',
                 't1_2_mni_reverse_transform']), name='outputnode')
 
-    # 0. Align and merge if several T1w images are provided
-    t1wmrg = pe.Node(IntraModalMerge(), name='MergeT1s')
-
     # 1. Reorient T1
-    arw = pe.Node(niu.Function(input_names=['in_file'],
-                               output_names=['out_file'],
-                               function=reorient),
-                  name='Reorient')
+    arw = pe.MapNode(niu.Function(input_names=['in_file'],
+                                  output_names=['out_file'],
+                                  function=reorient),
+                     name='Reorient', iterfield='in_file')
 
     # 2. T1 Bias Field Correction
-    inu_n4 = pe.Node(ants.N4BiasFieldCorrection(dimension=3),
-                     name='CorrectINU')
+    inu_n4 = pe.MapNode(ants.N4BiasFieldCorrection(dimension=3),
+                        name='CorrectINU', iterfield='input_image')
+
+    # 0. Align and merge if several T1w images are provided
+    t1wmrg = pe.Node(IntraModalMerge(), name='MergeT1s')
 
     # 3. Skull-stripping
     asw = skullstrip_wf()
@@ -110,10 +110,10 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
     )
 
     workflow.connect([
-        (inputnode, t1wmrg, [('t1w', 'in_files')]),
-        (t1wmrg, arw, [('out_avg', 'in_file')]),
+        (inputnode, arw, [('t1w', 'in_file')]),
         (arw, inu_n4, [('out_file', 'input_image')]),
-        (inu_n4, asw, [('output_image', 'inputnode.in_file')]),
+        (inu_n4, t1wmrg, [('output_image', 'in_files')]),
+        (t1wmrg, asw, [('out_avg', 'inputnode.in_file')]),
         (asw, t1_seg, [('outputnode.out_file', 'in_files')]),
         (inu_n4, t1_2_mni, [('output_image', 'moving_image')]),
         (asw, t1_2_mni, [('outputnode.out_mask', 'moving_mask')]),

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -24,8 +24,8 @@ from niworkflows.interfaces.segmentation import FASTRPT
 
 from fmriprep.interfaces import (DerivativesDataSink, IntraModalMerge)
 from fmriprep.interfaces.utils import reorient
+from fmriprep.utils.misc import fix_multi_T1w_source_name
 from fmriprep.viz import stripped_brain_overlay
-
 
 #  pylint: disable=R0914
 def t1w_preprocessing(name='t1w_preprocessing', settings=None):
@@ -108,16 +108,6 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
         name='DS_T1_2_MNI_Report'
     )
 
-    def fix_source_name(in_files):
-        import os
-        # in case there are multiple T1s we make up a generic source name
-        if isinstance(in_files, list):
-            subject_label = in_files[0].split(os.sep)[-1].split("_")[0].split("-")[-1]
-            base, _ = os.path.split(in_files[0])
-            return os.path.join(base, "sub-%s_T1w.nii.gz"%subject_label)
-        else:
-            return in_files
-
     workflow.connect([
         (inputnode, t1wmrg, [('t1w', 'in_files')]),
         (t1wmrg, arw, [('out_avg', 'in_file')]),
@@ -143,9 +133,9 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
                               ('forward_invert_flags', 'invert_transform_flags')]),
         (asw, outputnode, [('outputnode.out_file', 't1_brain'),
                            ('outputnode.out_mask', 't1_mask')]),
-        (inputnode, ds_t1_seg_report, [(('t1w', fix_source_name), 'source_file')]),
+        (inputnode, ds_t1_seg_report, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
         (t1_seg, ds_t1_seg_report, [('out_report', 'in_file')]),
-        (inputnode, ds_t1_2_mni_report, [(('t1w', fix_source_name), 'source_file')]),
+        (inputnode, ds_t1_2_mni_report, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
         (t1_2_mni, ds_t1_2_mni_report, [('out_report', 'in_file')])
     ])
 
@@ -156,7 +146,7 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
             name='DS_Report'
         )
         workflow.connect([
-            (inputnode, ds_t1_skull_strip_report, [(('t1w', fix_source_name), 'source_file')]),
+            (inputnode, ds_t1_skull_strip_report, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
             (asw, ds_t1_skull_strip_report, [('outputnode.out_report', 'in_file')])
         ])
 
@@ -214,7 +204,7 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
             return inlist[-1]
 
         workflow.connect([
-            (inputnode, ds_t1_mni_warp, [('t1w', 'source_file')]),
+            (inputnode, ds_t1_mni_warp, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
             (t1_2_mni, ds_t1_mni_aff, [
                 (('forward_transforms', _get_aff), 'in_file')]),
             (t1_2_mni, ds_t1_mni_warp, [
@@ -222,13 +212,13 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
         ])
 
     workflow.connect([
-        (inputnode, ds_t1_bias, [(('t1w', fix_source_name), 'source_file')]),
-        (inputnode, ds_t1_seg, [(('t1w', fix_source_name), 'source_file')]),
-        (inputnode, ds_mask, [(('t1w', fix_source_name), 'source_file')]),
-        (inputnode, ds_t1_mni, [(('t1w', fix_source_name), 'source_file')]),
-        (inputnode, ds_t1_mni_aff, [(('t1w', fix_source_name), 'source_file')]),
-        (inputnode, ds_bmask_mni, [(('t1w', fix_source_name), 'source_file')]),
-        (inputnode, ds_tpms_mni, [(('t1w', fix_source_name), 'source_file')]),
+        (inputnode, ds_t1_bias, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
+        (inputnode, ds_t1_seg, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
+        (inputnode, ds_mask, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
+        (inputnode, ds_t1_mni, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
+        (inputnode, ds_t1_mni_aff, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
+        (inputnode, ds_bmask_mni, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
+        (inputnode, ds_tpms_mni, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
         (inu_n4, ds_t1_bias, [('output_image', 'in_file')]),
         (t1_seg, ds_t1_seg, [('tissue_class_map', 'in_file')]),
         (asw, ds_mask, [('outputnode.out_mask', 'in_file')]),

--- a/fmriprep/workflows/epi.py
+++ b/fmriprep/workflows/epi.py
@@ -24,6 +24,7 @@ from niworkflows.data import get_mni_icbm152_nlin_asym_09c
 from fmriprep.interfaces import (DerivativesDataSink, FormatHMCParam,
                                  ImageDataSink)
 from fmriprep.interfaces.utils import nii_concat
+from fmriprep.utils.misc import fix_multi_T1w_source_name
 from fmriprep.workflows.fieldmap import sdc_unwarp
 from fmriprep.viz import stripped_brain_overlay
 from fmriprep.workflows.sbref import _extract_wm
@@ -224,7 +225,7 @@ def epi_mean_t1_registration(name='EPIMeanNormalization', settings=None):
         (fsl2itk_fwd, outputnode, [('itk_transform', 'itk_epi_to_t1')]),
         (fsl2itk_inv, outputnode, [('itk_transform', 'itk_t1_to_epi')]),
         (inputnode, ds_tfm_fwd, [('epi_name_source', 'source_file')]),
-        (inputnode, ds_tfm_inv, [('t1w', 'source_file')]),
+        (inputnode, ds_tfm_inv, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
         (fsl2itk_fwd, ds_tfm_fwd, [('itk_transform', 'in_file')]),
         (fsl2itk_inv, ds_tfm_inv, [('itk_transform', 'in_file')]),
         (flt_bbr, ds_report, [('out_report', 'in_file')]),

--- a/fmriprep/workflows/epi.py
+++ b/fmriprep/workflows/epi.py
@@ -21,7 +21,8 @@ from niworkflows.interfaces.masks import ComputeEPIMask, BETRPT
 from niworkflows.interfaces.registration import FLIRTRPT
 from niworkflows.data import get_mni_icbm152_nlin_asym_09c
 
-from fmriprep.interfaces import (DerivativesDataSink, FormatHMCParam)
+from fmriprep.interfaces import (DerivativesDataSink, FormatHMCParam,
+                                 ImageDataSink)
 from fmriprep.interfaces.utils import nii_concat
 from fmriprep.workflows.fieldmap import sdc_unwarp
 from fmriprep.viz import stripped_brain_overlay
@@ -89,10 +90,33 @@ def epi_hmc(name='EPI_HMC', settings=None):
         name='DS_Report'
     )
 
+    mean_epi_stripped_overlay = pe.Node(
+        niu.Function(
+            input_names=['in_file', 'overlay_file', 'out_file'],
+            output_names=['out_file'],
+            function=stripped_brain_overlay
+        ),
+        name='MeanEPIStrippedOverlay'
+    )
+    #  name needs to be based on source_file
+    mean_epi_stripped_overlay.inputs.out_file = 'mean_epi_overlay.svg'
+
+    mean_epi_overlay_ds = pe.Node(
+        ImageDataSink(base_directory=settings['output_dir']),
+        name="MeanEPIOverlayDS",
+    )
+
     workflow.connect([
         (inputnode, ds_report, [('epi', 'source_file')]),
         (inputnode, ds_mask, [('epi', 'source_file')]),
+        (inputnode, mean_epi_overlay_ds, [('epi', 'origin_file')]),
         (skullstrip_epi, ds_mask, [('mask_file', 'in_file')]),
+        (hmc, mean_epi_stripped_overlay, [('mean_img', 'overlay_file')]),
+        (skullstrip_epi, mean_epi_stripped_overlay, [('mask_file', 'in_file')]),
+        (hmc, mean_epi_overlay_ds, [('mean_img', 'overlay_file')]),
+        (skullstrip_epi, mean_epi_overlay_ds, [('mask_file', 'base_file')]),
+        (mean_epi_stripped_overlay, mean_epi_overlay_ds,
+         [('out_file', 'in_file')]),
         (skullstrip_epi, ds_report, [('out_report', 'in_file')])
     ])
 
@@ -207,6 +231,32 @@ def epi_mean_t1_registration(name='EPIMeanNormalization', settings=None):
         (inputnode, ds_report, [('epi_name_source', 'source_file')])
     ])
 
+    # Plots for report
+    epi_to_t1 = pe.Node(
+        niu.Function(
+            input_names=['in_file', 'overlay_file', 'out_file'],
+            output_names=['out_file'],
+            function=stripped_brain_overlay
+        ),
+        name='PNG_epi_to_t1'
+    )
+    epi_to_t1.inputs.out_file = 'epi_to_t1.svg'
+
+    # Write corrected file in the designated output dir
+    epi_to_t1_ds = pe.Node(
+        ImageDataSink(base_directory=settings['output_dir']),
+        name="datasink",
+    )
+
+    workflow.connect([
+        (flt_bbr, epi_to_t1, [('out_file', 'overlay_file')]),
+        (inputnode, epi_to_t1, [('t1_seg', 'in_file')]),
+        (flt_bbr, epi_to_t1_ds, [('out_file', 'overlay_file')]),
+        (inputnode, epi_to_t1_ds, [('t1_seg', 'base_file')]),
+        (epi_to_t1, epi_to_t1_ds, [('out_file', 'in_file')]),
+        (inputnode, epi_to_t1_ds, [('epi_name_source', 'origin_file')])
+    ])
+
     return workflow
 
 
@@ -265,6 +315,33 @@ def epi_sbref_registration(settings, name='EPI_SBrefRegistration'):
         (inputnode, ds_sbref, [('epi_name_source', 'source_file')]),
         (inputnode, ds_report, [('epi_name_source', 'source_file')]),
         (epi_sbref, ds_report, [('out_report', 'in_file')])
+    ])
+
+    #  Plot for report
+    post_merge_mean = pe.Node(fsl.MeanImage(), name='PostEPIMean')
+    mean_epi_to_sbref_overlay = pe.Node(
+        niu.Function(
+            input_names=["in_file", "overlay_file", "out_file"],
+            output_names=["out_file"],
+            function=stripped_brain_overlay
+        ),
+        name="MeanEPIToSbref"
+    )
+    mean_epi_to_sbref_overlay.inputs.out_file = "mean_epi_to_sbref.svg"
+
+    mean_epi_to_sbref_ds = pe.Node(
+        ImageDataSink(base_directory=settings['output_dir']),
+        name="datasink",
+    )
+
+    workflow.connect([
+        (epi_merge, post_merge_mean, [('merged_file', 'in_file')]),
+        (inputnode, mean_epi_to_sbref_overlay, [('sbref_mask', 'in_file')]),
+        (post_merge_mean, mean_epi_to_sbref_overlay, [('out_file', 'overlay_file')]),
+        (inputnode, mean_epi_to_sbref_ds, [('sbref_mask', 'base_file')]),
+        (post_merge_mean, mean_epi_to_sbref_ds, [('out_file', 'overlay_file')]),
+        (mean_epi_to_sbref_overlay, mean_epi_to_sbref_ds, [('out_file', 'in_file')]),
+        (inputnode, mean_epi_to_sbref_ds, [('epi_name_source', 'origin_file')])
     ])
 
     return workflow
@@ -399,6 +476,31 @@ def epi_unwarp(name='EPIUnwarpWorkflow', settings=None):
         (unwarp, ds_epi_unwarp, [('outputnode.out_file', 'in_file')]),
         (inputnode, ds_report, [('epi', 'source_file')]),
         (bet, ds_report, [('out_report', 'in_file')])
+    ])
+
+    # Plot result
+    epi_corr = pe.Node(
+        niu.Function(
+            input_names=['in_file', 'overlay_file', 'out_file'],
+            output_names=['out_file'],
+            function=stripped_brain_overlay
+        ),
+        name='EPICorr'
+    )
+    epi_corr.inputs.out_file = 'corrected_EPI.svg'
+
+    epi_corr_ds = pe.Node(
+        ImageDataSink(base_directory=settings['output_dir']),
+        name="datasink",
+    )
+
+    workflow.connect([
+        (bet, epi_corr, [('out_file', 'overlay_file')]),
+        (inputnode, epi_corr, [('fmap_mask', 'in_file')]),
+        (bet, epi_corr_ds, [('out_file', 'overlay_file')]),
+        (inputnode, epi_corr_ds, [('fmap_mask', 'base_file')]),
+        (epi_corr, epi_corr_ds, [('out_file', 'in_file')]),
+        (inputnode, epi_corr_ds, [('epi', 'origin_file')])
     ])
 
     return workflow


### PR DESCRIPTION
I had to pick new source name for derivatives obtained from a combination of T1s. I also had to turn off checking if the `source_file` file exists for this to work - rather controversial, but maybe we can address this when refactoring derivatives datasink.