### PR TITLE
[RTM] Don't keep unnecessary outputs

### DIFF
--- a/fmriprep/run_workflow.py
+++ b/fmriprep/run_workflow.py
@@ -121,8 +121,7 @@ def create_workflow(opts):
     # Set nipype config
     ncfg.update_config({
         'logging': {'log_directory': log_dir, 'log_to_file': True},
-        'execution': {'crashdump_dir': log_dir, 
-                      'remove_unnecessary_outputs': False}
+        'execution': {'crashdump_dir': log_dir}
     })
 
     # nipype plugin configuration


### PR DESCRIPTION
Revert "keep unnecessary outputs until report aggregation and datasinks are sorted out. Will allow us to confirm the correct images are being generated until then"

This reverts commit d04fdca5627f7f7bc86b4520fe85920afe1d95ab.

Hopefully, this will slim down the size of working directories. We were already running into issues with their size when working on the Beast.