### PR TITLE
Use a meaningful dev version tag

### DIFF
--- a/fmriprep/info.py
+++ b/fmriprep/info.py
@@ -6,7 +6,7 @@ Base module variables
 """
 from __future__ import unicode_literals
 
-__version__ = '99.99.99'
+__version__ = '0.2.1-dev'
 __author__ = 'The CRN developers'
 __copyright__ = 'Copyright 2016, Center for Reproducible Neuroscience, Stanford University'
 __credits__ = ['Craig Moodie', 'Ross Blair', 'Oscar Esteban', 'Chris Gorgolewski', 'Shoshana Berleant',


### PR DESCRIPTION
`0.2.1-dev` reflects that the latest release was `0.2.0`, and the next bugfix release would be `0.2.1`.

The following ordering holds, so pip version constraints are usable: `0.2.0 < 0.2.1-dev < 0.2.1 < 0.2.2-dev < 0.3`

Also, should just note that the [version number in 0.2.0 tag/release](https://github.com/poldracklab/fmriprep/blob/0.2.0/fmriprep/info.py#L9) is `dev`.