### PR TITLE
[RTM] Don't use editable flags.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ RUN pip install -r requirements.txt && \
 # Installing FMRIPREP
 COPY . /root/src/fmriprep
 RUN cd /root/src/fmriprep && \
-    pip install -e .[all] && \
+    pip install .[all] && \
     rm -rf ~/.cache/pip
 
 # Precaching atlases

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/nipy/nipype.git@cfca7cce966ccd83ed3921667844466e8b9bc8b1#egg=nipype
--e git+https://github.com/poldracklab/niworkflows.git@f3e11159ba8ddc8c850edc3bd1bf62d7286322d4#egg=niworkflows
+git+https://github.com/nipy/nipype.git@cfca7cce966ccd83ed3921667844466e8b9bc8b1#egg=nipype
+git+https://github.com/poldracklab/niworkflows.git@f3e11159ba8ddc8c850edc3bd1bf62d7286322d4#egg=niworkflows


### PR DESCRIPTION
It turns out that "-e" makes packages appear in sys.path in front of whatever is in PYTHONPATH making it impossible to override installs in singualrity.

This will change installation path and require changes to #317 