### PR TITLE
[RTM] Surface sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Next release
 
 * [ENH] Generate GrayWhite, Pial, MidThickness and inflated surfaces (#398)
 * [ENH] Memory and performance improvements for calculating the EPI reference (#436)
+* [ENH] Sample functional series to subject and ``fsaverage`` surfaces (#391)
 
 0.3.2 (7th of April 2017)
 =========================

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -259,6 +259,29 @@ It also maps the T1w-based mask to MNI space.
 Transforms are concatenated and applied all at once, with one interpolation (Lanczos)
 step, so as little information is lost as possible.
 
+EPI sampled to FreeSurfer surfaces
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:mod:`fmriprep.workflows.epi.epi_surf_sample`
+
+.. workflow::
+    :graph2use: colored
+    :simple_form: yes
+
+    from fmriprep.workflows.epi import epi_surf_sample
+    wf = epi_surf_sample("test",
+                         settings={'output_dir': '.',
+                                   'skip_native': False,
+                                   })
+
+If FreeSurfer processing is enabled, the motion-corrected functional series is sampled to the
+surface by averaging across the cortical ribbon.
+Specifically, at each vertex, the segment normal to the white-matter surface, extending to the pial
+surface, is sampled at 6 intervals and averaged.
+
+Surfaces are generated for the "subject native" surface, as well as transformed to the
+``fsaverage`` template space.
+All surface outputs are in GIFTI format.
+
 Confounds estimation
 ~~~~~~~~~~~~~~~~~~~~
 :mod:`fmriprep.workflows.confounds.discover_wf`
@@ -326,6 +349,8 @@ Derivatives related to EPI files are in the ``func`` subfolder:
 - ``*bold_confounds.tsv`` A tab-separated value file with one column per calculated confound and one row per timepoint/volume
 - ``*bold_space-T1w_preproc.nii.gz`` Motion-corrected (using MCFLIRT for estimation and ANTs for interpolation) EPI file in T1w space
 - ``*bold_space-MNI152NLin2009cAsym_preproc.nii.gz`` Same as above, but in MNI space
+- ``*bold_space-fsnative.[LR].func.gii`` Motion-corrected EPI file sampled to subject's "native" FreeSurfer surfaces
+- ``*bold_space-fsaverage.[LR].func.gii`` Same as above, but in FreeSurfer ``fsaverage`` template space
 
 
 FreeSurfer Derivatives

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -70,7 +70,6 @@ def base_workflow_generator(subject_id, task_id, settings):
         raise Exception("No T1w images found for participant {}. "
                         "All workflows require T1w images.".format(subject_id))
 
-
     if all((subject_data['fmap'] != [],
             subject_data['sbref'] != [],
             "fieldmaps" not in settings['ignore'])):

--- a/fmriprep/workflows/epi.py
+++ b/fmriprep/workflows/epi.py
@@ -542,6 +542,7 @@ def epi_surf_sample(name='SurfaceSample', settings=None):
     sampler = pe.MapNode(
         fs.SampleToSurface(sampling_method='average', sampling_range=(0, 1, 0.2),
                            sampling_units='frac', reg_header=True,
+                           interp_method='trilinear', cortex_mask=True,
                            out_type='gii'),
         iterfield=['source_file', 'target_subject'],
         iterables=('hemi', ['lh', 'rh']),

--- a/fmriprep/workflows/epi.py
+++ b/fmriprep/workflows/epi.py
@@ -186,14 +186,15 @@ def epi_hmc(metadata, name='EPI_HMC', settings=None):
 
             return os.path.abspath(out_file)
 
-        create_custom_slice_timing_file = pe.Node(niu.Function(function=create_custom_slice_timing_file_func,
-                                                               input_names=["metadata"],
-                                                               output_names=["out_file"]),
-                                                  name="create_custom_slice_timing_file")
+        create_custom_slice_timing_file = pe.Node(
+            niu.Function(function=create_custom_slice_timing_file_func,
+                         input_names=["metadata"],
+                         output_names=["out_file"]),
+            name="create_custom_slice_timing_file")
         create_custom_slice_timing_file.inputs.metadata = metadata
 
         slice_timing_correction = pe.Node(interface=afni.TShift(),
-                                               name='slice_timing_correction')
+                                          name='slice_timing_correction')
         slice_timing_correction.inputs.outputtype = 'NIFTI_GZ'
         slice_timing_correction.inputs.tr = str(metadata["RepetitionTime"]) + "s"
 
@@ -204,7 +205,7 @@ def epi_hmc(metadata, name='EPI_HMC', settings=None):
             (inputnode, slice_timing_correction, [('epi', 'in_file')]),
             (gen_ref, slice_timing_correction, [('n_volumes_to_discard', 'ignore')]),
             (create_custom_slice_timing_file, slice_timing_correction, [(('out_file', prefix_at),
-                                                                          'tpattern')]),
+                                                                         'tpattern')]),
             (slice_timing_correction, hmc, [('out_file', 'in_file')])
         ])
 
@@ -521,9 +522,9 @@ def epi_surf_sample(name='SurfaceSample', settings=None):
     targets.inputs.skip_native = settings['skip_native']
 
     rename_src = pe.MapNode(
-            niu.Rename(format_string='%(subject)s', keep_ext=True),
-            iterfield='subject',
-            name='RenameFunc')
+        niu.Rename(format_string='%(subject)s', keep_ext=True),
+        iterfield='subject',
+        name='RenameFunc')
 
     sampler = pe.MapNode(
         fs.SampleToSurface(sampling_method='average',
@@ -531,7 +532,7 @@ def epi_surf_sample(name='SurfaceSample', settings=None):
                            sampling_units='frac',
                            out_type='gii'),
         iterfield=['source_file', 'target_subject'],
-        iterables=[('hemi', ['lh', 'rh'])],
+        iterables=('hemi', ['lh', 'rh']),
         name='vol2surf')
 
     workflow.connect([

--- a/fmriprep/workflows/epi.py
+++ b/fmriprep/workflows/epi.py
@@ -510,8 +510,8 @@ def epi_surf_sample(name='SurfaceSample', settings=None):
 
     sampler = pe.Node(
         # --projfrac 0.5
-        fs.SampleToSurface(sampling_method='point',
-                           sampling_range=0.5,
+        fs.SampleToSurface(sampling_method='average',
+                           sampling_range=(0, 1, 0.2),
                            sampling_units='frac'),
         iterables=[('hemi', ['lh', 'rh']),
                    ('target_subject', subjects)],

--- a/fmriprep/workflows/epi.py
+++ b/fmriprep/workflows/epi.py
@@ -547,7 +547,8 @@ def epi_surf_sample(name='SurfaceSample', settings=None):
         iterables=('hemi', ['lh', 'rh']),
         name='sampler')
 
-    merger = pe.JoinNode(niu.Merge(), name='merger', joinsource='sampler', joinfield=['in_lists'])
+    merger = pe.JoinNode(niu.Merge(1, ravel_inputs=True), name='merger',
+                         joinsource='sampler', joinfield=['in1'])
 
     def normalize_giftis(in_file):
         import os
@@ -576,7 +577,7 @@ def epi_surf_sample(name='SurfaceSample', settings=None):
                               ('subject_id', 'subject_id')]),
         (targets, sampler, [('targets', 'target_subject')]),
         (rename_src, sampler, [('out_file', 'source_file')]),
-        (sampler, merger, [('out_file', 'in_lists')]),
+        (sampler, merger, [('out_file', 'in1')]),
         (merger, normalize, [('out', 'in_file')]),
         (inputnode, bold_surfaces,
          [(('name_source', _first), 'source_file')]),

--- a/fmriprep/workflows/epi.py
+++ b/fmriprep/workflows/epi.py
@@ -504,13 +504,17 @@ def epi_surf_sample(name='SurfaceSample', settings=None):
             'name_source',
         ]), name='inputnode')
 
+    subjects = ['fsaverage']
+    if not settings['skip_native']:
+        subjects.append(Undefined)
+
     sampler = pe.Node(
         # --projfrac 0.5
         fs.SampleToSurface(sampling_method='point',
                            sampling_range=0.5,
                            sampling_units='frac'),
         iterables=[('hemi', ['lh', 'rh']),
-                   ('target_subject', [Undefined, 'fsaverage'])],
+                   ('target_subject', subjects)],
         name='native_vol2surf')
 
     workflow.connect([


### PR DESCRIPTION
Building on #362, this uses the registration produced by `bbregister` to sample volumes to the subject-native and `fsaverage` surfaces.

Looks like this will be fairly simple, but `mri_vol2surf` is pretty flexible in its sampling strategy. For each vertex on the surface, there is a normal vector from the white matter surface to the pial surface, and you can choose a point along that vector (in mm or as a fraction of the cortical thickness from 0-1), the average value along a range (start, stop, step; again in mm or fraction) or the maximum value on a range.

As a starter, I've set it to sample the midpoint of the normal vectors.

Looks like this'll be the thing that finally makes me learn to use `JoinNode`.

Closes #355.