### PR TITLE
[RTM] Switch to composite transforms.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,7 @@ What's new
 0.3.0 (upcoming)
 ================
 
+* [FIX] Affine and warp MNI transforms are now applied in the correct order
 * [ENH] Added preliminary support for reconstruction of cortical surfaces using FreeSurfer
 * [ENH] Switched to bbregister for BOLD to T1 coregistration
 * [ENH] Switched to sinc interpolation of preprocessed BOLD and T1w outputs

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -137,11 +137,10 @@ Derivatives related to t1w files are in the ``anat`` subfolder:
 - ``*T1w_dtissue.nii.gz`` Tissue class map derived using FAST.
 - ``*T1w_preproc.nii.gz`` Bias field corrected t1w file, using ANTS' N4BiasFieldCorrection
 - ``*T1w_space-MNI152NLin2009cAsym_preproc.nii.gz`` Same as above, but in MNI space
-- ``*T1w_target-MNI152NLin2009cAsym_affine.mat`` The affine matrix to transform T1w into MNI space
 - ``*T1w_space-MNI152NLin2009cAsym_class-CSF_probtissue.nii.gz``
 - ``*T1w_space-MNI152NLin2009cAsym_class-GM_probtissue.nii.gz``
 - ``*T1w_space-MNI152NLin2009cAsym_class-WM_probtissue.nii.gz`` Probability tissue maps, transformed into MNI space
-- ``*T1w_target-MNI152NLin2009cAsym_warp.nii.gz`` Warp transform to transform t1w into MNI space
+- ``*T1w_target-MNI152NLin2009cAsym_warp.h5`` Composite (warp and affine) transform to transform t1w into MNI space
 
 Derivatives related to EPI files are in the ``func`` subfolder:
 

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -227,16 +227,13 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
         (t1_seg, outputnode, [('probability_maps', 't1_tpms')]),
         (t1_2_mni, outputnode, [
             ('warped_image', 't1_2_mni'),
-            ('forward_transforms', 't1_2_mni_forward_transform'),
-            ('reverse_transforms', 't1_2_mni_reverse_transform')
+            ('composite_transform', 't1_2_mni_forward_transform'),
+            ('inverse_composite_transform', 't1_2_mni_reverse_transform')
         ]),
         (asw, bmask_mni, [('outputnode.out_mask', 'input_image')]),
-        (t1_2_mni, bmask_mni, [('forward_transforms', 'transforms'),
-                               ('forward_invert_flags',
-                                'invert_transform_flags')]),
+        (t1_2_mni, bmask_mni, [('composite_transform', 'transforms')]),
         (t1_seg, tpms_mni, [('probability_maps', 'input_image')]),
-        (t1_2_mni, tpms_mni, [('forward_transforms', 'transforms'),
-                              ('forward_invert_flags', 'invert_transform_flags')]),
+        (t1_2_mni, tpms_mni, [('composite_transform', 'transforms')]),
         (asw, outputnode, [('outputnode.out_file', 't1_brain'),
                            ('outputnode.out_mask', 't1_mask')]),
         (inputnode, ds_t1_seg_report, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
@@ -301,11 +298,6 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
                             suffix='space-MNI152NLin2009cAsym_preproc'),
         name='DerivT1w_MNI'
     )
-    ds_t1_mni_aff = pe.Node(
-        DerivativesDataSink(base_directory=settings['output_dir'],
-                            suffix='target-MNI152NLin2009cAsym_affine'),
-        name='DerivT1w_MNI_affine'
-    )
     ds_bmask_mni = pe.Node(
         DerivativesDataSink(base_directory=settings['output_dir'],
                             suffix='space-MNI152NLin2009cAsym_brainmask'),
@@ -318,35 +310,21 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
     )
     ds_tpms_mni.inputs.extra_values = ['CSF', 'GM', 'WM']
 
-    if settings.get('debug', False):
-        workflow.connect([
-            (t1_2_mni, ds_t1_mni_aff, [('forward_transforms', 'in_file')])
-        ])
-    else:
-        ds_t1_mni_warp = pe.Node(
-            DerivativesDataSink(base_directory=settings['output_dir'],
-                                suffix='target-MNI152NLin2009cAsym_warp'), name='mni_warp')
+    ds_t1_mni_warp = pe.Node(
+        DerivativesDataSink(base_directory=settings['output_dir'],
+                            suffix='target-MNI152NLin2009cAsym_warp'), name='mni_warp')
 
-        def _get_aff(inlist):
-            return inlist[:-1]
-
-        def _get_warp(inlist):
-            return inlist[-1]
-
-        workflow.connect([
-            (inputnode, ds_t1_mni_warp, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
-            (t1_2_mni, ds_t1_mni_aff, [
-                (('forward_transforms', _get_aff), 'in_file')]),
-            (t1_2_mni, ds_t1_mni_warp, [
-                (('forward_transforms', _get_warp), 'in_file')])
-        ])
+    workflow.connect([
+        (inputnode, ds_t1_mni_warp, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
+        (t1_2_mni, ds_t1_mni_warp, [
+            ('composite_transform', 'in_file')])
+    ])
 
     workflow.connect([
         (inputnode, ds_t1_bias, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
         (inputnode, ds_t1_seg, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
         (inputnode, ds_mask, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
         (inputnode, ds_t1_mni, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
-        (inputnode, ds_t1_mni_aff, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
         (inputnode, ds_bmask_mni, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
         (inputnode, ds_tpms_mni, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
         (asw, ds_t1_bias, [('outputnode.bias_corrected', 'in_file')]),

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -188,14 +188,14 @@ def t1w_preprocessing(name='t1w_preprocessing', settings=None):
 
     # Resample the brain mask and the tissue probability maps into mni space
     bmask_mni = pe.Node(
-        ants.ApplyTransforms(dimension=3, default_value=0,
+        ants.ApplyTransforms(dimension=3, default_value=0, float=True,
                              interpolation='NearestNeighbor'),
         name='brain_mni_warp'
     )
     bmask_mni.inputs.reference_image = op.join(get_mni_icbm152_nlin_asym_09c(),
                                                '1mm_T1.nii.gz')
     tpms_mni = pe.MapNode(
-        ants.ApplyTransforms(dimension=3, default_value=0,
+        ants.ApplyTransforms(dimension=3, default_value=0, float=True,
                              interpolation='Linear'),
         iterfield=['input_image'],
         name='tpms_mni_warp'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/nipy/nipype.git@07a75a64ae917b4ed0839d3b5a79bd63ebed9964#egg=nipype
-git+https://github.com/chrisfilo/niworkflows.git@8bbbfb793ef7f0384e2a1b78f6da394075e5f201#egg=niworkflows
+git+https://github.com/poldracklab/niworkflows.git@8b0f51268f4f5030eac9c2447fb9dea26a312dc0#egg=niworkflows

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/nipy/nipype.git@07a75a64ae917b4ed0839d3b5a79bd63ebed9964#egg=nipype
-git+https://github.com/poldracklab/niworkflows.git@f3e11159ba8ddc8c850edc3bd1bf62d7286322d4#egg=niworkflows
+git+https://github.com/chrisfilo/niworkflows.git@8bbbfb793ef7f0384e2a1b78f6da394075e5f201#egg=niworkflows


### PR DESCRIPTION
As indicated in https://github.com/poldracklab/fmriprep/pull/362#issuecomment-287490389 we have been applying affine and warp transforms in the wrong order causing slight misalignment. To avoid such problems in the future I propose to switching to composite transforms.