### PR TITLE
[RTM] use dataobj instead of get_data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@ Next release
 ============
 
 * [ENH] Generate GrayWhite, Pial, MidThickness and inflated surfaces (#398)
+* [ENH] Memory and performance improvements for calculating the EPI reference (#)
 
 0.3.2 (7th of April 2017)
 =========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@ Next release
 ============
 
 * [ENH] Generate GrayWhite, Pial, MidThickness and inflated surfaces (#398)
-* [ENH] Memory and performance improvements for calculating the EPI reference (#)
+* [ENH] Memory and performance improvements for calculating the EPI reference (#436)
 
 0.3.2 (7th of April 2017)
 =========================

--- a/fmriprep/interfaces/utils.py
+++ b/fmriprep/interfaces/utils.py
@@ -44,7 +44,8 @@ class EstimateReferenceImage(SimpleInterface):
 
     def _run_interface(self, runtime):
         in_nii = nb.load(self.inputs.in_file)
-        global_signal = in_nii.get_data()[:, :, :, :50].mean(axis=0).mean(
+        data_slice = in_nii.dataobj[:, :, :, :50]
+        global_signal = data_slice.mean(axis=0).mean(
             axis=0).mean(axis=0)
 
         n_volumes_to_discard = is_outlier(global_signal)
@@ -53,7 +54,7 @@ class EstimateReferenceImage(SimpleInterface):
 
         if n_volumes_to_discard == 0:
             if in_nii.shape[-1] > 40:
-                slice = in_nii.get_data()[:, :, :, 20:40]
+                slice = data_slice[:, :, :, 20:40]
                 slice_fname = os.path.abspath("slice.nii.gz")
                 nb.Nifti1Image(slice, in_nii.affine,
                                in_nii.header).to_filename(slice_fname)
@@ -70,7 +71,7 @@ class EstimateReferenceImage(SimpleInterface):
                            mc_slice_nii.header).to_filename(out_ref_fname)
         else:
             median_image_data = np.median(
-                in_nii.get_data()[:, :, :, :n_volumes_to_discard], axis=3)
+                data_slice[:, :, :, :n_volumes_to_discard], axis=3)
             nb.Nifti1Image(median_image_data, in_nii.affine,
                            in_nii.header).to_filename(out_ref_fname)
 


### PR DESCRIPTION
Avoids loading all of the big multiband images.