### PR TITLE
[RTM] Remove "sub-" prefix

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -63,7 +63,7 @@ For example: ::
     $ singularity run ~/poldracklab_fmriprep_latest-2016-12-04-5b74ad9a4c4d.img \
         /work/04168/asdf/lonestar/ $WORK/lonestar/output \
         participant \
-        --participant_label sub-387 --nthreads 16 -w $WORK/lonestar/work \
+        --participant_label 387 --nthreads 16 -w $WORK/lonestar/work \
         --ants-nthreads 16
 
 .. note::
@@ -75,7 +75,7 @@ For example: ::
       $ PYTHONPATH="" singularity run ~/poldracklab_fmriprep_latest-2016-12-04-5b74ad9a4c4d.img \
         /work/04168/asdf/lonestar/ $WORK/lonestar/output \
         participant \
-        --participant_label sub-387 --nthreads 16 -w $WORK/lonestar/work \
+        --participant_label 387 --nthreads 16 -w $WORK/lonestar/work \
         --ants-nthreads 16
 
 Manually Prepared Environment


### PR DESCRIPTION
BIDS Apps expect labels without prefixes.