### PR TITLE
CI: Pull latest image before rebuilding

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,6 +33,7 @@ dependencies:
     - if [[ -e $HOME/docker/image.tar ]]; then docker load -i $HOME/docker/image.tar; fi
     - sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'$CIRCLE_TAG'/" fmriprep/info.py
     - sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'$CIRCLE_TAG'/" wrapper/fmriprep_docker.py
+    - docker pull poldracklab/fmriprep:latest || true
     - e=1 && for i in {1..5}; do docker build --rm=false -t poldracklab/fmriprep:latest --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg VERSION=$CIRCLE_TAG . && e=0 && break || sleep 15; done && [ "$e" -eq "0" ] :
         timeout: 21600
     - mkdir -p $HOME/docker; docker save poldracklab/fmriprep:latest > $HOME/docker/image.tar


### PR DESCRIPTION
Because we rebuild from scratch every time, every docker image is unrelated, even though there may be no difference in the docker file. The primary goal of this PR is to reduce redundant downloads for users of the `poldracklab/fmriprep` docker images on new releases.

It has a futher advantage of nearly halving the image creation stage on Circle:

### Before

![no_docker_pull](https://cloud.githubusercontent.com/assets/83442/25289461/b524f64c-2697-11e7-9cad-f1a7f733e8fa.png)

### After

![with_docker_pull](https://cloud.githubusercontent.com/assets/83442/25289485/cd9655d6-2697-11e7-8ea5-126ae3048707.png)

The failure on saving the image is a little weird. I'll see if that keeps happening.