### PR TITLE
DOC: Update niworkflows pin

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -29,4 +29,4 @@ dependencies:
     - nitime
     - nilearn
     - git+https://github.com/nipy/nipype.git@dc68922bf9ac1dd910c3ca9b5b8c0dbb093f4691#egg=nipype
-    - git+https://github.com/poldracklab/niworkflows.git@c855e3fa35beba401de86278e5560dbdbcf00309#egg=niworkflows
+    - git+https://github.com/poldracklab/niworkflows.git@76952e5f2b2822200683981e92df5f1128ad2c69#egg=niworkflows

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/nipy/nipype.git@dc68922bf9ac1dd910c3ca9b5b8c0dbb093f4691#egg=nipype
-git+https://github.com/poldracklab/niworkflows.git@c855e3fa35beba401de86278e5560dbdbcf00309#egg=niworkflows
+git+https://github.com/poldracklab/niworkflows.git@76952e5f2b2822200683981e92df5f1128ad2c69#egg=niworkflows


### PR DESCRIPTION
Fixed docs: https://fmriprep.readthedocs.io/en/fix_docs/workflows.html

Sorry, last night's `BBRegisterRPT` fix actually broke the docs again, but the pin didn't get pushed to `docs/environment.yml`, so it was missed.

No effect on running processes, just on building docs in the absence of FreeSurfer.

[skip ci]