### PR TITLE
[RTM] CI: Remove non-working docker cache

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,4 @@
 machine:
-  pre:
-    - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.1-circleci'
-    - sudo chmod 0755 /usr/bin/docker
   environment:
     OSF_PROJECT: "https://files.osf.io/v1/resources/fvuh8/providers/osfstorage"
     DS005_URL: "${OSF_PROJECT}/57f32a429ad5a101f977eb75"
@@ -12,10 +9,9 @@ machine:
 dependencies:
   cache_directories:
     - "~/data"
-    - "~/docker"
 
   pre:
-    - mkdir -p $HOME/data $HOME/docker
+    - mkdir -p $HOME/data
     - mkdir -p $HOME/ds005 && sudo setfacl -d -m group:ubuntu:rwx $HOME/ds005 && sudo setfacl -m group:ubuntu:rwx $HOME/ds005
     - mkdir -p $HOME/ds054 && sudo setfacl -d -m group:ubuntu:rwx $HOME/ds054 && sudo setfacl -m group:ubuntu:rwx $HOME/ds054
     - mkdir -p $HOME/docs && sudo setfacl -d -m group:ubuntu:rwx $HOME/docs && sudo setfacl -m group:ubuntu:rwx $HOME/docs
@@ -30,13 +26,11 @@ dependencies:
     - python wrapper/setup.py --help
 
   override:
-    - if [[ -e $HOME/docker/image.tar ]]; then docker load -i $HOME/docker/image.tar; fi
     - sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'$CIRCLE_TAG'/" fmriprep/info.py
     - sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'$CIRCLE_TAG'/" wrapper/fmriprep_docker.py
     - docker pull poldracklab/fmriprep:latest || true
     - e=1 && for i in {1..5}; do docker build --rm=false -t poldracklab/fmriprep:latest --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg VERSION=$CIRCLE_TAG . && e=0 && break || sleep 15; done && [ "$e" -eq "0" ] :
         timeout: 21600
-    - mkdir -p $HOME/docker; docker save poldracklab/fmriprep:latest > $HOME/docker/image.tar
     - pip install --upgrade wrapper/
 test:
   override:


### PR DESCRIPTION
We don't seem to be getting any speed-up from maintaining a docker cache. Every pull still grabs a 2.7GB layer; if the cache were actually loading, we should only see the pip builds and on get pulled and rebuilt each time.

Assuming I'm right and there's no speed up granted by the cache, we should be seeing a pull on the order of 5-6 minutes and the same for the build step.

This will end up saving ~4 minutes per build.