### PR TITLE
[RTM] ENH: Use mri_robust_template for T1 merge

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+Next release
+============
+
+* [ENH] Use robust template generation for multiple T1w images (#481)
+
 0.4.1 (20th of April 2017)
 ==========================
 

--- a/fmriprep/interfaces/__init__.py
+++ b/fmriprep/interfaces/__init__.py
@@ -4,4 +4,5 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from fmriprep.interfaces.bids import ReadSidecarJSON, DerivativesDataSink, \
     BIDSDataGrabber, BIDSFreeSurferDir
-from fmriprep.interfaces.images import IntraModalMerge, CopyHeader, StructuralReference
+from fmriprep.interfaces.images import IntraModalMerge, CopyHeader
+from fmriprep.interfaces.freesurfer import StructuralReference

--- a/fmriprep/interfaces/__init__.py
+++ b/fmriprep/interfaces/__init__.py
@@ -4,4 +4,4 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from fmriprep.interfaces.bids import ReadSidecarJSON, DerivativesDataSink, \
     BIDSDataGrabber, BIDSFreeSurferDir
-from fmriprep.interfaces.images import IntraModalMerge, CopyHeader
+from fmriprep.interfaces.images import IntraModalMerge, CopyHeader, StructuralReference

--- a/fmriprep/interfaces/freesurfer.py
+++ b/fmriprep/interfaces/freesurfer.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""
+FreeSurfer tools interfaces
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+"""
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+from nipype.interfaces import freesurfer as fs
+
+
+class StructuralReference(fs.RobustTemplate):
+    """ Variation on RobustTemplate that simply copies the source if a single
+    volume is provided. """
+    @property
+    def cmdline(self):
+        import nibabel as nb
+        from nipype.utils.filemanip import copyfile
+        cmd = super(StructuralReference, self).cmdline
+        if len(self.inputs.in_files) > 1:
+            return cmd
+
+        img = nb.load(self.inputs.in_files[0])
+        if len(img.shape) > 3 and img.shape[3] > 1:
+            return cmd
+
+        out_file = self._list_outputs()['out_file']
+        copyfile(self.inputs.in_files[0], out_file)
+        return "echo Only one time point!"

--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -25,7 +25,6 @@ from nipype.interfaces.base import (
     traits, isdefined, TraitedSpec, BaseInterface, BaseInterfaceInputSpec,
     File, InputMultiPath, OutputMultiPath, traits
 )
-from nipype.interfaces import freesurfer as fs
 
 from fmriprep.interfaces.bids import _splitext
 from fmriprep.utils.misc import make_folder, genfname
@@ -60,26 +59,6 @@ class GenerateSamplingReference(BaseInterface):
         self._results['out_file'] = _gen_reference(self.inputs.fixed_image,
                                                    self.inputs.moving_image)
         return runtime
-
-
-class StructuralReference(fs.RobustTemplate):
-    """ Variation on RobustTemplate that simply copies the source if a single
-    volume is provided. """
-    @property
-    def cmdline(self):
-        import nibabel as nb
-        from nipype.utils.filemanip import copyfile
-        cmd = super(StructuralReference, self).cmdline
-        if len(self.inputs.in_files) > 1:
-            return cmd
-
-        img = nb.load(self.inputs.in_files[0])
-        if len(img.shape) > 3 and img.shape[3] > 1:
-            return cmd
-
-        out_file = self._list_outputs()['out_file']
-        copyfile(self.inputs.in_files[0], out_file)
-        return "echo Only one time point!"
 
 
 class IntraModalMergeInputSpec(BaseInterfaceInputSpec):

--- a/fmriprep/utils/misc.py
+++ b/fmriprep/utils/misc.py
@@ -133,12 +133,18 @@ def fix_multi_T1w_source_name(in_files):
     import os
     # in case there are multiple T1s we make up a generic source name
     if isinstance(in_files, list):
-        subject_label = in_files[0].split(os.sep)[-1].split("_")[0].split("-")[
-            -1]
+        subject_label = in_files[0].split(os.sep)[-1].split("_")[0].split("-")[-1]
         base, _ = os.path.split(in_files[0])
         return os.path.join(base, "sub-%s_T1w.nii.gz" % subject_label)
     else:
         return in_files
+
+
+def add_suffix(in_files, suffix):
+    import os.path as op
+    from nipype.utils.filemanip import fname_presuffix, filename_to_list
+    return op.basename(fname_presuffix(filename_to_list(in_files)[0],
+                                       suffix=suffix))
 
 
 def _extract_wm(in_file):

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -26,7 +26,7 @@ from niworkflows.interfaces.segmentation import FASTRPT, ReconAllRPT
 
 from fmriprep.interfaces import DerivativesDataSink, StructuralReference
 from fmriprep.interfaces.images import reorient
-from fmriprep.utils.misc import fix_multi_T1w_source_name
+from fmriprep.utils.misc import fix_multi_T1w_source_name, add_suffix
 
 
 #  pylint: disable=R0914
@@ -56,7 +56,6 @@ def init_anat_preproc_wf(skull_strip_ants, debug, freesurfer, ants_nthreads,
                             intensity_scaling=True,   # 7-DOF (rigid + intensity)
                             no_iteration=True,
                             subsample_threshold=200,
-                            out_file='template.nii.gz',
                             ), name='t1_merge')
 
     # 1. Reorient T1
@@ -107,7 +106,8 @@ def init_anat_preproc_wf(skull_strip_ants, debug, freesurfer, ants_nthreads,
     )
 
     workflow.connect([
-        (inputnode, t1_merge, [('t1w', 'in_files')]),
+        (inputnode, t1_merge, [('t1w', 'in_files'),
+                               (('t1w', add_suffix, '_template'), 'out_file')]),
         (t1_merge, t1_conform, [('out_file', 'in_file')]),
         (t1_conform, skullstrip_wf, [('out', 'inputnode.in_file')]),
         (skullstrip_wf, t1_seg, [('outputnode.out_file', 'in_files')]),


### PR DESCRIPTION
We've found that FLIRT alignment can sometimes fail on T1 images. Although a 9-DOF affine registration resolves the issue, it appears to be an artifact problem, rather than a scaling issue that would require the extra 3 degrees of freedom.

This PR uses FreeSurfer's `mri_robust_template` to generate a structural reference image.

`mri_robust_template` throws an error on single volumes, so I subclass `freesurfer.RobustTemplate` to copy the input file in that case. (I use a hack similar to that in `freesurfer.ReconAll` to fiddle with the `cmdline`.)

Closes: #439, #473