### PR TITLE
[RTM] RF: Skip mris_expand on pre-existing midthickness files

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -28,5 +28,5 @@ dependencies:
     - svgutils
     - nitime
     - nilearn
-    - git+https://github.com/nipy/nipype.git@dc68922bf9ac1dd910c3ca9b5b8c0dbb093f4691#egg=nipype
+    - git+https://github.com/nipy/nipype.git@ccd0527d65c63b22b86b8e7df0d3103e4f4fe743#egg=nipype
     - git+https://github.com/poldracklab/niworkflows.git@76952e5f2b2822200683981e92df5f1128ad2c69#egg=niworkflows

--- a/fmriprep/interfaces/__init__.py
+++ b/fmriprep/interfaces/__init__.py
@@ -5,4 +5,4 @@
 from fmriprep.interfaces.bids import ReadSidecarJSON, DerivativesDataSink, \
     BIDSDataGrabber, BIDSFreeSurferDir
 from fmriprep.interfaces.images import IntraModalMerge, CopyHeader
-from fmriprep.interfaces.freesurfer import StructuralReference
+from fmriprep.interfaces.freesurfer import StructuralReference, MakeMidthickness

--- a/fmriprep/interfaces/freesurfer.py
+++ b/fmriprep/interfaces/freesurfer.py
@@ -9,6 +9,7 @@ FreeSurfer tools interfaces
 """
 from __future__ import print_function, division, absolute_import, unicode_literals
 
+from nipype.interfaces.base import isdefined, File
 from nipype.interfaces import freesurfer as fs
 
 
@@ -30,3 +31,22 @@ class StructuralReference(fs.RobustTemplate):
         out_file = self._list_outputs()['out_file']
         copyfile(self.inputs.in_files[0], out_file)
         return "echo Only one time point!"
+
+
+class MakeMidthicknessInputSpec(fs.utils.MRIsExpandInputSpec):
+    graymid = File(desc='Existing graymid/midthickness file')
+
+
+class MakeMidthickness(fs.MRIsExpand):
+    """ Variation on RobustTemplate that simply copies the source if a single
+    volume is provided. """
+    input_spec = MakeMidthicknessInputSpec
+
+    @property
+    def cmdline(self):
+        cmd = super(MakeMidthickness, self).cmdline
+        if not isdefined(self.inputs.graymid):
+            return cmd
+
+        return "cp {} {}".format(self.inputs.graymid,
+                                 self._list_outputs()['out_file'])

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -24,7 +24,7 @@ from niworkflows.data import get_mni_icbm152_nlin_asym_09c
 from niworkflows.interfaces.masks import BrainExtractionRPT
 from niworkflows.interfaces.segmentation import FASTRPT, ReconAllRPT
 
-from fmriprep.interfaces import DerivativesDataSink, StructuralReference
+from fmriprep.interfaces import DerivativesDataSink, StructuralReference, MakeMidthickness
 from fmriprep.interfaces.images import reorient
 from fmriprep.utils.misc import fix_multi_T1w_source_name, add_suffix
 
@@ -340,14 +340,17 @@ def init_surface_recon_wf(nthreads, hires, name='surface_recon_wf'):
         fs.Tkregister2(fsl_out='freesurfer2subT1.mat', reg_header=True),
         name='fs_transform')
 
-    midthickness = pe.MapNode(
-        fs.MRIsExpand(thickness=True, distance=0.5, out_name='midthickness'),
-        iterfield='in_file',
-        name='midthickness')
+    get_surfaces = pe.Node(nio.FreeSurferSource(), iterables=('hemi', ('lh', 'rh')),
+                           name='get_surfaces')
+
+    midthickness = pe.Node(MakeMidthickness(thickness=True, distance=0.5, out_name='midthickness'),
+                           name='midthickness')
 
     save_midthickness = pe.Node(nio.DataSink(parameterization=False),
                                 name='save_midthickness')
-    surface_list = pe.Node(niu.Merge(4), name='surface_list')
+
+    surface_list = pe.JoinNode(niu.Merge(4, ravel_inputs=True), name='surface_list',
+                               joinsource='get_surfaces', joinfield=['in1', 'in2', 'in3', 'in4'])
     fs_2_gii = pe.MapNode(fs.MRIsConvert(out_datatype='gii'),
                           iterfield='in_file', name='fs_2_gii')
 
@@ -413,6 +416,10 @@ def init_surface_recon_wf(nthreads, hires, name='surface_recon_wf'):
                                           ('subject_id', 'subject_id')]),
         (skull_strip_extern, reconall, [('subjects_dir', 'subjects_dir'),
                                         ('subject_id', 'subject_id')]),
+        (reconall, get_surfaces, [('subjects_dir', 'subjects_dir'),
+                                  ('subject_id', 'subject_id')]),
+        (reconall, save_midthickness, [('subjects_dir', 'base_directory'),
+                                       ('subject_id', 'container')]),
         (reconall, outputnode, [('subjects_dir', 'subjects_dir'),
                                 ('subject_id', 'subject_id'),
                                 ('out_report', 'out_report')]),
@@ -430,14 +437,13 @@ def init_surface_recon_wf(nthreads, hires, name='surface_recon_wf'):
         (autorecon1, fs_transform, [('T1', 'moving_image')]),
         (fs_transform, outputnode, [('fsl_file', 'fs_2_t1_transform')]),
         # Generate midthickness surfaces and save to FreeSurfer derivatives
-        (reconall, midthickness, [('smoothwm', 'in_file')]),
-        (reconall, save_midthickness, [('subjects_dir', 'base_directory'),
-                                       ('subject_id', 'container')]),
+        (get_surfaces, midthickness, [('smoothwm', 'in_file'),
+                                      ('graymid', 'graymid')]),
         (midthickness, save_midthickness, [('out_file', 'surf.@graymid')]),
         # Produce valid GIFTI surface files (dense mesh)
-        (reconall, surface_list, [('smoothwm', 'in1'),
-                                  ('pial', 'in2'),
-                                  ('inflated', 'in3')]),
+        (get_surfaces, surface_list, [('smoothwm', 'in1'),
+                                      ('pial', 'in2'),
+                                      ('inflated', 'in3')]),
         (save_midthickness, surface_list, [('out_file', 'in4')]),
         (surface_list, fs_2_gii, [('out', 'in_file')]),
         (fs_2_gii, fix_surfs, [('converted', 'in_file')]),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/nipy/nipype.git@dc68922bf9ac1dd910c3ca9b5b8c0dbb093f4691#egg=nipype
+git+https://github.com/nipy/nipype.git@ccd0527d65c63b22b86b8e7df0d3103e4f4fe743#egg=nipype
 git+https://github.com/poldracklab/niworkflows.git@76952e5f2b2822200683981e92df5f1128ad2c69#egg=niworkflows


### PR DESCRIPTION
Just to get this testing, while waiting on upstream. Same style of command-line hack as in #481.

Here I use explicit copying, rather than `copyfile`, since I don't want the datasink to cause an error by overwriting a file with itself. (This might not actually be a problem; I'm not sure.)

Closes #477.