### PR TITLE
[RTM] CI: Fix typo in .circle/tests.sh

### DIFF
--- a/.circle/tests.sh
+++ b/.circle/tests.sh
@@ -24,7 +24,7 @@ case ${CIRCLE_NODE_INDEX} in
         -T -E -b html -d _build/doctrees-readthedocs -W -D language=en docs/ /_build_html 2>&1 \
         | tee $HOME/docs/builddocs.log
     cat $HOME/docs/builddocs.log && if grep -q "ERROR" $HOME/docs/builddocs.log; then false; else true; fi
-    docker run -ti --rm=false -v $HOME/nipype.cfg:/root/.nipype/nipype.cfg:ro -v $HOME/data:/data:ro -v $HOME/ds054/scratch:/scratch -v $HOME/ds054/out:/out poldracklab/fmriprep:latest /data/ds054 /out/ participant --no-freesurfer --debug --write-graph -w /scratch:
+    docker run -ti --rm=false -v $HOME/nipype.cfg:/root/.nipype/nipype.cfg:ro -v $HOME/data:/data:ro -v $HOME/ds054/scratch:/scratch -v $HOME/ds054/out:/out poldracklab/fmriprep:latest /data/ds054 /out/ participant --no-freesurfer --debug --write-graph -w /scratch
     find ~/ds054/scratch -not -name "*.svg" -not -name "*.html" -not -name "*.svg" -not -name "*.rst" -type f -delete
     ;;
   1)


### PR DESCRIPTION
Currently `ds054/scratch` isn't being saved to artifacts as it is supposed to be. This checks whether it's a permissions issue.