### PR TITLE
[RTM] RF: Split recon-all into coarse chunks to improve resource use estimates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@ Next release
 ============
 
 * [ENH] Improved EPI skull stripping and tissue contrast enhancements (#519)
+* [ENH] Improve resource use estimates in FreeSurfer workflow (#506)
 
 0.4.3 (10th of May 2017)
 ========================

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -28,6 +28,6 @@ dependencies:
     - svgutils
     - nitime
     - nilearn
-    - git+https://github.com/nipy/nipype.git@d82a18f80126b4bc99d0b4f6d14ff3b6e075f297#egg=nipype
-    - git+https://github.com/poldracklab/niworkflows.git@c309563cb5763464b607c45a20ffde92293194a1#egg=niworkflows
+    - git+https://github.com/nipy/nipype.git@4e48d2644b19e74581904e5404569e505279835a#egg=nipype
+    - git+https://github.com/poldracklab/niworkflows.git@1f6ee8fe28f85b30398e33424c8b4d0b2f20992f#egg=niworkflows
     - git+https://github.com/INCF/pybids.git@7205ae01fbdca8e8bfd26ac773b1134b84c8af0c#egg=pybids

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -81,7 +81,7 @@ Surface preprocessing
 :mod:`fmriprep.workflows.anatomical.init_surface_recon_wf`
 
 .. workflow::
-    :graph2use: colored
+    :graph2use: orig
     :simple_form: yes
 
     from fmriprep.workflows.anatomical import init_surface_recon_wf
@@ -112,10 +112,25 @@ would be processed by the following command::
 The second phase imports the brainmask calculated in the `T1w/T2w preprocessing`_
 sub-workflow.
 The final phase resumes reconstruction, using the T2w image to assist
-in finding the pial surface, if available::
+in finding the pial surface, if available.
+In order to utilize resources efficiently, this is broken down into six
+sub-stages; the first and last are run serially, while each pair of
+per-hemisphere stages are run in parallel, if possible::
 
     $ recon-all -sd <output dir>/freesurfer -subjid sub-<subject_label> \
-        -all -T2pial
+        -autorecon2-volonly
+    $ recon-all -sd <output dir>/freesurfer -subjid sub-<subject_label> \
+        -autorecon2-perhemi -hemi lh
+    $ recon-all -sd <output dir>/freesurfer -subjid sub-<subject_label> \
+        -autorecon2-perhemi -hemi rh
+    $ recon-all -sd <output dir>/freesurfer -subjid sub-<subject_label> \
+        -autorecon-hemi lh -T2pial \
+        -noparcstats -noparcstats2 -noparcstats3 -nohyporelabel -nobalabels
+    $ recon-all -sd <output dir>/freesurfer -subjid sub-<subject_label> \
+        -autorecon-hemi rh -T2pial \
+        -noparcstats -noparcstats2 -noparcstats3 -nohyporelabel -nobalabels
+    $ recon-all -sd <output dir>/freesurfer -subjid sub-<subject_label> \
+        -autorecon3
 
 Reconstructed white and pial surfaces are included in the report.
 

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -350,6 +350,8 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
     autorecon_surfs = pe.MapNode(
         fs.ReconAll(
             directive='autorecon-hemi',
+            flags=['-noparcstats', '-noparcstats2', '-noparcstats3',
+                   '-nobalabels'],
             openmp=omp_nthreads),
         iterfield='hemi',
         name='autorecon_surfs')
@@ -359,6 +361,7 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
     autorecon3 = pe.Node(
         ReconAllRPT(
             directive='autorecon3',
+            flags=['-cortribbon'],
             openmp=omp_nthreads,
             generate_report=True),
         name='autorecon3')

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -432,6 +432,12 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
         iterfield='in_file',
         name='fix_surfs')
 
+    def _dedup(in_list):
+        vals = set(in_list)
+        if len(vals) > 1:
+            raise ValueError("Non-identical values can't be deduplicated:\n{!r}".format(in_list))
+        return vals.pop()
+
     workflow.connect([
         # Configuration
         (inputnode, recon_config, [('t1w', 't1w_list'),
@@ -446,8 +452,8 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
                                           ('subject_id', 'subject_id')]),
         (autorecon2, reconhemis, [('subjects_dir', 'subjects_dir'),
                                   ('subject_id', 'subject_id')]),
-        (reconhemis, reconall, [('subjects_dir', 'subjects_dir'),
-                                ('subject_id', 'subject_id')]),
+        (reconhemis, reconall, [(('subjects_dir', _dedup), 'subjects_dir'),
+                                (('subject_id', _dedup), 'subject_id')]),
         (reconall, get_surfaces, [('subjects_dir', 'subjects_dir'),
                                   ('subject_id', 'subject_id')]),
         (reconall, save_midthickness, [('subjects_dir', 'base_directory'),

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -405,42 +405,25 @@ def init_autorecon_resume_wf(omp_nthreads, name='autorecon_resume_wf'):
         name='autorecon2_vol')
     autorecon2_vol.interface.num_threads = omp_nthreads
 
-    autorecon2_surfs = pe.Node(
+    autorecon2_surfs = pe.MapNode(
         fs.ReconAll(
             directive='autorecon2-perhemi',
             openmp=omp_nthreads),
-        iterables=('hemi', ('lh', 'rh')),
+        iterfield='hemi',
         name='autorecon2_surfs')
     autorecon2_surfs.interface.num_threads = omp_nthreads
+    autorecon2_surfs.inputs.hemi = ['lh', 'rh']
 
-    def dedup(subjects_dir, subject_id):
-        dirs = set(subjects_dir)
-        ids = set(subject_id)
-        if len(dirs) > 1:
-            raise ValueError(
-                "Non-identical values can't be deduplicated:\n{!r}".format(subjects_dir))
-        if len(ids) > 1:
-            raise ValueError(
-                "Non-identical values can't be deduplicated:\n{!r}".format(subject_id))
-        return dirs.pop(), ids.pop()
-
-    sync1 = pe.JoinNode(
-        niu.Function(function=dedup, output_names=['subjects_dir', 'subject_id']),
-        name='sync1', joinfield=['subjects_dir', 'subject_id'], joinsource='autorecon2_surfs')
-
-    autorecon_surfs = pe.Node(
+    autorecon_surfs = pe.MapNode(
         fs.ReconAll(
             directive='autorecon-hemi',
             flags=['-noparcstats', '-noparcstats2', '-noparcstats3',
                    '-nohyporelabel', '-nobalabels'],
             openmp=omp_nthreads),
-        iterables=('hemi', ('lh', 'rh')),
+        iterfield='hemi',
         name='autorecon_surfs')
     autorecon_surfs.interface.num_threads = omp_nthreads
-
-    sync2 = pe.JoinNode(
-        niu.Function(function=dedup, output_names=['subjects_dir', 'subject_id']),
-        name='sync2', joinfield=['subjects_dir', 'subject_id'], joinsource='autorecon_surfs')
+    autorecon_surfs.inputs.hemi = ['lh', 'rh']
 
     autorecon3 = pe.Node(
         ReconAllRPT(
@@ -450,20 +433,23 @@ def init_autorecon_resume_wf(omp_nthreads, name='autorecon_resume_wf'):
         name='autorecon3')
     autorecon3.interface.num_threads = omp_nthreads
 
+    def _dedup(in_list):
+        vals = set(in_list)
+        if len(vals) > 1:
+            raise ValueError(
+                "Non-identical values can't be deduplicated:\n{!r}".format(in_list))
+        return vals.pop()
+
     workflow.connect([
         (inputnode, autorecon_surfs, [('use_T2', 'use_T2')]),
         (inputnode, autorecon2_vol, [('subjects_dir', 'subjects_dir'),
                                      ('subject_id', 'subject_id')]),
         (autorecon2_vol, autorecon2_surfs, [('subjects_dir', 'subjects_dir'),
                                             ('subject_id', 'subject_id')]),
-        (autorecon2_surfs, sync1, [('subjects_dir', 'subjects_dir'),
-                                   ('subject_id', 'subject_id')]),
-        (sync1, autorecon_surfs, [('subjects_dir', 'subjects_dir'),
-                                  ('subject_id', 'subject_id')]),
-        (autorecon_surfs, sync2, [('subjects_dir', 'subjects_dir'),
-                                  ('subject_id', 'subject_id')]),
-        (sync2, autorecon3, [('subjects_dir', 'subjects_dir'),
-                             ('subject_id', 'subject_id')]),
+        (autorecon2_surfs, autorecon_surfs, [(('subjects_dir', _dedup), 'subjects_dir'),
+                                             (('subject_id', _dedup), 'subject_id')]),
+        (autorecon_surfs, autorecon3, [(('subjects_dir', _dedup), 'subjects_dir'),
+                                       (('subject_id', _dedup), 'subject_id')]),
         (autorecon3, outputnode, [('subjects_dir', 'subjects_dir'),
                                   ('subject_id', 'subject_id'),
                                   ('out_report', 'out_report')]),


### PR DESCRIPTION
This PR eschews the `-parallel` flag in FreeSurfer, preferring the directives that are volume or hemisphere specific. Thus, we run:

* `-autorecon1` - Single thread (`-parallel` has no effect, but `-openmp` does in places)
* Inject externally skull-stripped image
* `-autorecon2-volonly` - Single thread
* `-autorecon-hemi {lh,rh}` - Replace `-parallel` with nipype parallelism
* `-all` - Run stats and any other post-hemisphere-specific processing

Also takes advantage of #494 to get rid of the separate `get_surfaces` node.