### PR TITLE
CI: Add a flag to commits to instruct Circle only to build docs

### DIFF
--- a/.circle/tests.sh
+++ b/.circle/tests.sh
@@ -15,6 +15,20 @@ if [ "${CIRCLE_NODE_TOTAL:-}" != "2" ]; then
   exit 1
 fi
 
+# Only run docs if DOCSONLY or "docs only" (or similar) is in the commit message
+if echo $GIT_COMMIT_DESC | grep -Pi 'docs[ _]?only'; then
+    case ${CIRCLE_NODE_INDEX} in
+        0)
+          docker run -ti --rm=false -v $HOME/docs:/_build_html --entrypoint=sphinx-build poldracklab/fmriprep:latest \
+              -T -E -b html -d _build/doctrees-readthedocs -W -D language=en docs/ /_build_html 2>&1 \
+              | tee $HOME/docs/builddocs.log
+          cat $HOME/docs/builddocs.log && if grep -q "ERROR" $HOME/docs/builddocs.log; then false; else true; fi
+          ;;
+    esac
+    exit 0
+fi
+
+
 # These tests are manually balanced based on previous build timings.
 # They may need to be rebalanced in the future.
 case ${CIRCLE_NODE_INDEX} in

--- a/circle.yml
+++ b/circle.yml
@@ -40,6 +40,8 @@ test:
     - bash .circle/tests.sh :
         timeout: 4800
         parallel: true
+        environment:
+          GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $CIRCLE_SHA1)
 
 general:
   artifacts:


### PR DESCRIPTION
Assuming this works, we'll be able to tag commits that don't need to run real code.