### PR TITLE
[RTM] move missing values to the beginning of the confounds file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@ Next release
 ============
 
 * [ENH] Improved EPI skull stripping and tissue contrast enhancements (#519)
+* [ENH] Moved missing values in the DVARS* and FramewiseDisplacement columns of the _confounds.tsv from last row to the first row (#523)
 
 0.4.3 (10th of May 2017)
 ========================

--- a/fmriprep/workflows/confounds.py
+++ b/fmriprep/workflows/confounds.py
@@ -216,6 +216,14 @@ def _gather_confounds(signals=None, dvars=None, frame_displace=None,
         for column_name in new.columns:
             new.rename(columns={column_name: less_breakable(column_name)},
                        inplace=True)
+
+        # This forces missing values to appear at the beggining of the DataFrame
+        # instead of the end
+        index_diff = len(confounds_data.index) - len(new.index)
+        if index_diff > 0:
+            new.index = range(index_diff, len(new.index) + index_diff)
+        elif index_diff < 0:
+            confounds_data.index = range(-index_diff, len(confounds_data.index) - index_diff)
         confounds_data = pd.concat((confounds_data, new), axis=1)
 
     combined_out = op.abspath('confounds.tsv')

--- a/fmriprep/workflows/confounds.py
+++ b/fmriprep/workflows/confounds.py
@@ -206,6 +206,17 @@ def _gather_confounds(signals=None, dvars=None, frame_displace=None,
         ''' hardens the string to different envs (i.e. case insensitive, no whitespace, '#' '''
         return ''.join(a_string.split()).strip('#')
 
+    def _adjust_indices(left_df, right_df):
+        # This forces missing values to appear at the beggining of the DataFrame
+        # instead of the end
+        index_diff = len(left_df.index) - len(right_df.index)
+        if index_diff > 0:
+            right_df.index = range(index_diff,
+                                   len(right_df.index) + index_diff)
+        elif index_diff < 0:
+            left_df.index = range(-index_diff,
+                                  len(left_df.index) - index_diff)
+
     all_files = [confound for confound in [signals, dvars, frame_displace,
                                            tcompcor, acompcor, motion]
                  if confound is not None]
@@ -217,13 +228,7 @@ def _gather_confounds(signals=None, dvars=None, frame_displace=None,
             new.rename(columns={column_name: less_breakable(column_name)},
                        inplace=True)
 
-        # This forces missing values to appear at the beggining of the DataFrame
-        # instead of the end
-        index_diff = len(confounds_data.index) - len(new.index)
-        if index_diff > 0:
-            new.index = range(index_diff, len(new.index) + index_diff)
-        elif index_diff < 0:
-            confounds_data.index = range(-index_diff, len(confounds_data.index) - index_diff)
+        _adjust_indices(confounds_data, new)
         confounds_data = pd.concat((confounds_data, new), axis=1)
 
     combined_out = op.abspath('confounds.tsv')


### PR DESCRIPTION
It's more intuitive in context of using those for nuissance regression.