### PR TITLE
FIX: Always copy fsaverage

### DIFF
--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -227,7 +227,12 @@ class BIDSFreeSurferDir(SimpleInterface):
         make_folder(subjects_dir)
         self._results['subjects_dir'] = subjects_dir
 
-        for space in self.inputs.spaces:
+        spaces = list(self.inputs.spaces)
+        # Always copy fsaverage, for proper recon-all functionality
+        if 'fsaverage' not in spaces:
+            spaces.append('fsaverage')
+
+        for space in spaces:
             # Skip non-freesurfer spaces and fsnative
             if not space.startswith('fsaverage'):
                 continue


### PR DESCRIPTION
`recon-all` [symlinks](https://github.com/freesurfer/freesurfer/blob/release_6_0_0/scripts/recon-all#L4887-L4895) `fsaverage` if it doesn't exist. This PR guarantees a copy is made even if `fsaverage` is not among the specified output spaces.

Fixes #535.