### PR TITLE
[RTM] ENH: Conform multiple T1w images, resampling if necessary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Next release
 ============
 
-
+* [ENH] Conform and minimally resample multiple T1w images (#545)
 
 0.4.5 (12th of June 2017)
 =========================


### PR DESCRIPTION
The existing anatomical pipeline merges T1w images using `mri_robust_template`, and then realigns the result to RAS in a conformation step.

This PR will swap these steps, and update the conformation step to ensure that each T1w image is in a common space (zooms, dimensions, RAS orientation), prior to passing the resulting series to `mri_robust_template`.

The final zoom in each dimension is the smallest of the input zooms in that dimension, and the number of voxels in that dimension is set to the highest.

If no transformations need to be applied, the original file is copied (or linked) to reduce the possibility of error.

Closes #538.