### PR TITLE
DEP: Update Neurodebian AFNI pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN echo "cHJpbnRmICJrcnp5c3p0b2YuZ29yZ29sZXdza2lAZ21haWwuY29tXG41MTcyXG4gKkN2dW
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
                     fsl-core=5.0.9-1~nd+1+nd16.04+1 \
-                    afni=16.2.07~dfsg.1-2~nd16.04+1
+                    afni=16.2.07~dfsg.1-5~nd16.04+1
 
 ENV FSLDIR=/usr/share/fsl/5.0 \
     FSLOUTPUTTYPE=NIFTI_GZ \


### PR DESCRIPTION
Builds seem to be breaking on this.

@yarikoptic Is this a bug, or does Neurodebian not keep old versions of packages around?