### PR TITLE
[RTM] ENH: Add --anat-only workflow option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Next release
 ============
 
-
+* [ENH] Add --anat-only workflow option (#560)
 
 0.4.6 (14th of June 2017)
 =========================

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -31,6 +31,7 @@ slice-timing information and no fieldmap acquisitions):
                                               'template', 'fsaverage5'],
                                 ignore=[],
                                 debug=False,
+                                anat_only=False,
                                 hires=True,
                                 bold2t1w_dof=9,
                                 fmap_bspline=False,

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -66,6 +66,8 @@ def get_parser():
                          help='upper bound memory limit for FMRIPREP processes')
     g_perfm.add_argument('--use-plugin', action='store', default=None,
                          help='nipype plugin configuration file')
+    g_perfm.add_argument('--anat-only', action='store_true',
+                         help='run anatomical workflows only')
 
     g_conf = parser.add_argument_group('Workflow configuration')
     g_conf.add_argument(
@@ -215,6 +217,7 @@ def create_workflow(opts):
                                    run_uuid=run_uuid,
                                    ignore=opts.ignore,
                                    debug=opts.debug,
+                                   anat_only=opts.anat_only,
                                    omp_nthreads=omp_nthreads,
                                    skull_strip_ants=opts.skull_strip_ants,
                                    reportlets_dir=reportlets_dir,

--- a/test/workflows/test_base.py
+++ b/test/workflows/test_base.py
@@ -15,6 +15,7 @@ class TestBase(TestWorkflow):
                                          task_id='',
                                          ignore=[],
                                          debug=False,
+                                         anat_only=False,
                                          omp_nthreads=1,
                                          skull_strip_ants=False,
                                          reportlets_dir='.',


### PR DESCRIPTION
This may be instant-reject, but it's not clear to me that there is an advantage to rejecting datasets without functional images. We already throw a warning in their absence.

(I created this branch a while ago to test the anat pipeline on a user's T1w image.)