### PR TITLE
[RTM] FIX: Reduce interpolation artifacts in ConformSeries

### DIFF
--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -173,12 +173,11 @@ class ConformSeries(SimpleInterface):
 
                 if resize:
                     # The shift is applied after scaling.
-                    # Apply a shift of half of the new voxels in each direction, to keep the
-                    # origin in the same position relative to the center of the dataset
+                    # Use a proportional shift to maintain relative position in dataset
+                    size_factor = (target_shape.astype(float) + shape) / (2 * shape)
                     # Use integer shifts to avoid unnecessary interpolation
-                    shift = (target_shape - shape) // 2
-                    sign = np.sign(img.affine[:3, 3])
-                    target_affine[:3, 3] = img.affine[:3, 3] + (shift * sign)
+                    offset = (img.affine[:3, 3] * size_factor - img.affine[:3, 3]).astype(int)
+                    target_affine[:3, 3] = img.affine[:3, 3] + offset
                 else:
                     target_affine[:3, 3] = img.affine[:3, 3]
 

--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -163,7 +163,8 @@ class ConformSeries(SimpleInterface):
                 # voxels in each dimension, to keep the padding consistent in each direction
                 shape_factor = (target_shape.astype(float) + shape) / (2 * shape)
                 target_affine[:3, 3] = img.affine[:3, 3] * shape_factor
-                img = nli.resample_img(img, target_affine, target_shape)
+                data = nli.resample_img(img, target_affine, target_shape).get_data()
+                img = img.__class__(data, target_affine, img.header)
 
             resampled_imgs.append(img)
 
@@ -173,7 +174,7 @@ class ConformSeries(SimpleInterface):
         for orig, final, in_name, out_name in zip(orig_imgs, resampled_imgs,
                                                   in_names, out_names):
             if final is orig:
-                copyfile(in_name, out_name, use_hardlink=True)
+                copyfile(in_name, out_name, copy=True, use_hardlink=True)
             else:
                 final.to_filename(out_name)
 


### PR DESCRIPTION
This PR attempts to make the conformation step minimally disruptive.

* Rescaling and resizing operations are logically separated in calculating the target affine
* Rescaling is only applied if there is a > 0.05mm difference between the original and target zooms
* Resizing is restricted to an integer shift, rather than scaling the intercept; this should avoid half-voxel interpolations if an odd number of voxels are tacked on
* The original image header is copied to the target, reducing the divergence of the header only to changes induced by an updated affine

Additionally, symlinks are disallowed for untouched files, so that the working directory can be created by a docker image and inspected outside.

Fixes #562.