### PR TITLE
FIX: update fsl-core from neurodebian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN echo "cHJpbnRmICJrcnp5c3p0b2YuZ29yZ29sZXdza2lAZ21haWwuY29tXG41MTcyXG4gKkN2dW
 # Installing Neurodebian packages (FSL, AFNI, git)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-                    fsl-core=5.0.9-1~nd+1+nd16.04+1 \
+                    fsl-core=5.0.9-4~nd16.04+1 \
                     afni=16.2.07~dfsg.1-5~nd16.04+1
 
 ENV FSLDIR=/usr/share/fsl/5.0 \


### PR DESCRIPTION
Neurodebian doesn't appear to have the [5.0.9-1](http://neuro.debian.net/pkgs/fsl-core.html#binary-pkg-fsl-core) fsl-core version anymore. This update brings the fsl-core version to the version available on neurodebian. I remember seeing a conversation about versioning with neurodebian, so maybe there is a more general solution available.