### PR TITLE
FIX: Remove unused parameters in function node

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Next release
+============
+
+With thanks to James Kent for contributions.
+
+* [ENH] Calculate noise components in functional data with ICA-AROMA (#539)
+* [FIX] Remove unused parameters from function node, resolving crash (#576)
+
 0.5.1 (24th of June 2017)
 =========================
 

--- a/fmriprep/info.py
+++ b/fmriprep/info.py
@@ -6,7 +6,7 @@ Base module variables
 """
 from __future__ import unicode_literals
 
-__version__ = '0.5.1-dev'
+__version__ = '0.5.2-dev'
 __author__ = 'The CRN developers'
 __copyright__ = 'Copyright 2017, Center for Reproducible Neuroscience, Stanford University'
 __credits__ = ['Craig Moodie', 'Ross Blair', 'Oscar Esteban', 'Chris Gorgolewski',

--- a/fmriprep/workflows/epi.py
+++ b/fmriprep/workflows/epi.py
@@ -905,17 +905,16 @@ def init_nonlinear_sdc_wf(bold_file, layout, freesurfer, bold2t1w_dof,
             bbr_i_wf = init_fsl_bbr_wf(bold2t1w_dof, report=False, name='bbr_i_wf')
             bbr_j_wf = init_fsl_bbr_wf(bold2t1w_dof, report=False, name='bbr_j_wf')
 
-        def select_outputs(cost_i, warped_image_i, forward_transforms_i, out_report_i,
-                           cost_j, warped_image_j, forward_transforms_j, out_report_j):
+        def select_outputs(cost_i, warped_image_i, forward_transforms_i,
+                           cost_j, warped_image_j, forward_transforms_j):
             if cost_i < cost_j:
-                return warped_image_i, forward_transforms_i, out_report_i
+                return warped_image_i, forward_transforms_i
             else:
-                return warped_image_j, forward_transforms_j, out_report_j
+                return warped_image_j, forward_transforms_j
 
         pe_chooser = pe.Node(
             niu.Function(function=select_outputs,
-                         out_names=['warped_image', 'forward_transforms',
-                                    'out_report']),
+                         out_names=['warped_image', 'forward_transforms']),
             name='pe_chooser')
 
         workflow.connect([(inputnode, syn_i, [('epi_ref', 'moving_image')]),


### PR DESCRIPTION
Correction: Unused parameters were causing a node crash.

----
Original description:

Workflows without phase-encoding directions are not completing due to two missing connections.