### PR TITLE
[RTM] ENH/FIX: Validate and minimally conform BOLD images

### DIFF
--- a/fmriprep/interfaces/__init__.py
+++ b/fmriprep/interfaces/__init__.py
@@ -3,5 +3,5 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from .bids import ReadSidecarJSON, DerivativesDataSink, BIDSDataGrabber, BIDSFreeSurferDir
-from .images import IntraModalMerge, InvertT1w
+from .images import IntraModalMerge, InvertT1w, ValidateImage
 from .freesurfer import StructuralReference, MakeMidthickness

--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -202,6 +202,56 @@ class ConformSeries(SimpleInterface):
         return runtime
 
 
+class ValidateImageInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc='input image')
+
+
+class ValidateImageOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc='validated image')
+    out_report = File(exists=True, desc='HTML segment containing warning')
+
+
+class ValidateImage(SimpleInterface):
+    input_spec = ValidateImageInputSpec
+    output_spec = ValidateImageOutputSpec
+
+    def _run_interface(self, runtime):
+        img = nb.load(self.inputs.in_file)
+        out_report = os.path.abspath('report.html')
+
+        qform_code = img.header._structarr['qform_code']
+        sform_code = img.header._structarr['sform_code']
+
+        # Valid affine information
+        if (qform_code, sform_code) != (0, 0):
+            self._results['out_file'] = self.inputs.in_file
+            open(out_report, 'w').close()
+            self._results['out_report'] = out_report
+            return runtime
+
+        out_fname = fname_presuffix(self.inputs.in_file, suffix='_valid', newpath=runtime.cwd)
+
+        # Nibabel derives a default LAS affine from the shape and zooms
+        # Use scanner xform code to indicate no alignment has been done
+        img.set_sform(img.affine, nb.nifti1.xform_codes['scanner'])
+
+        img.to_filename(out_fname)
+        self._results['out_file'] = out_fname
+
+        snippet = (r'<h3 class="elem-title">WARNING - Invalid header</h3>',
+                   r'<p class="elem-desc">Input file does not have valid qform or sform matrix.',
+                   r'A default, LAS-oriented affine has been constructed.',
+                   r'A left-right flip may have occurred.',
+                   r'Analyses of this dataset MAY BE INVALID.</p>')
+
+        with open('out_report', 'w') as fobj:
+            fobj.write('\n'.join('\t' * 3 + line for line in snippet))
+            fobj.write('\n')
+
+        self._results['out_report'] = out_report
+
+
+
 class InvertT1wInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True,
                    desc='Skull-stripped T1w structural image')

--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -10,6 +10,7 @@ Image tools interfaces
 """
 from __future__ import print_function, division, absolute_import, unicode_literals
 
+import os
 import numpy as np
 import nibabel as nb
 
@@ -244,12 +245,12 @@ class ValidateImage(SimpleInterface):
                    r'A left-right flip may have occurred.',
                    r'Analyses of this dataset MAY BE INVALID.</p>')
 
-        with open('out_report', 'w') as fobj:
+        with open(out_report, 'w') as fobj:
             fobj.write('\n'.join('\t' * 3 + line for line in snippet))
             fobj.write('\n')
 
         self._results['out_report'] = out_report
-
+        return runtime
 
 
 class InvertT1wInputSpec(BaseInterfaceInputSpec):

--- a/fmriprep/viz/config.json
+++ b/fmriprep/viz/config.json
@@ -49,6 +49,11 @@
         "elements":
         [
             {
+                "name": "epi/validation",
+                "file_pattern": "func/.*_validation\\.",
+                "raw": true
+            },
+            {
                 "name": "epi/fmpa_reg",
                 "file_pattern": "func/.*fmap_reg\\.",
                 "title": "Fieldmap to EPI registration",

--- a/fmriprep/viz/report.tpl
+++ b/fmriprep/viz/report.tpl
@@ -62,8 +62,7 @@ body {
                 {% for elem in run_report.elements %}
                     {% if elem.files_contents %}
                         {% if elem.title %}<h3 class="elem-title">{{ elem.title }}</h3>{% endif %}
-                        <p class="elem-desc">{{ elem.description }}<p>
-                        <br>
+                        {% if elem.description %}<p class="elem-desc">{{ elem.description }}<p><br />{% endif %}
                         {% for image in elem.files_contents %}
                             {% if elem.raw %}{{ image.1 }}{% else %}
                             <div class="elem-image">{{ image.1 }}</div><br>

--- a/fmriprep/viz/report.tpl
+++ b/fmriprep/viz/report.tpl
@@ -61,14 +61,16 @@ body {
                 <h2 class="run-title">Reports for {{ run_report.title }}</h2>
                 {% for elem in run_report.elements %}
                     {% if elem.files_contents %}
-                        <h3 class="elem-title">{{ elem.title }}</h3>
+                        {% if elem.title %}<h3 class="elem-title">{{ elem.title }}</h3>{% endif %}
                         <p class="elem-desc">{{ elem.description }}<p>
                         <br>
                         {% for image in elem.files_contents %}
+                            {% if elem.raw %}{{ image.1 }}{% else %}
                             <div class="elem-image">{{ image.1 }}</div><br>
                             <div class="elem-filename">
                                 Filename: {{ image.0 }}
                             </div>
+                            {% endif %}
                         {% endfor %}
                     {% endif %}
                 {% endfor %}

--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -16,6 +16,7 @@ class Element(object):
         self.title = title
         self.description = description
         self.files_contents = []
+        self.raw = raw
 
 
 class SubReport(object):
@@ -38,7 +39,8 @@ class SubReport(object):
                 if not name:
                     continue
                 new_elem = {'name': element.name, 'file_pattern': element.file_pattern,
-                            'title': element.title, 'description': element.description}
+                            'title': element.title, 'description': element.description,
+                            'raw': element.raw}
                 try:
                     new_element = Element(**new_elem)
                     run_reps[name].elements.append(new_element)
@@ -110,7 +112,8 @@ class Report(object):
                         if element.file_pattern.search(f) and (ext == 'svg' or ext == 'html'):
                             with open(f) as fp:
                                 content = fp.read()
-                                content = '\n'.join(content.split('\n')[1:])
+                                if not element.raw:
+                                    content = content.split('\n', 1)[1]
                                 element.files_contents.append((f, content))
         for sub_report in self.sub_reports:
             sub_report.order_by_run()

--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -10,7 +10,7 @@ from pkg_resources import resource_filename as pkgrf
 
 
 class Element(object):
-    def __init__(self, name, file_pattern, title, description):
+    def __init__(self, name, file_pattern, title=None, description=None, raw=False):
         self.name = name
         self.file_pattern = re.compile(file_pattern)
         self.title = title

--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -23,11 +23,8 @@ class SubReport(object):
     def __init__(self, name, elements, title=''):
         self.name = name
         self.title = title
-        self.elements = []
         self.run_reports = []
-        for e in elements:
-            element = Element(**e)
-            self.elements.append(element)
+        self.elements = [Element(**e) for e in elements]
 
     def order_by_run(self):
         run_reps = {}

--- a/fmriprep/workflows/epi.py
+++ b/fmriprep/workflows/epi.py
@@ -162,6 +162,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
         (epi_hmc_wf, discover_wf, [('outputnode.movpar_file', 'inputnode.movpar_file')]),
         (epi_reg_wf, discover_wf, [('outputnode.epi_t1', 'inputnode.fmri_file'),
                                    ('outputnode.epi_mask_t1', 'inputnode.epi_mask')]),
+        (validate, func_reports_wf, [('out_report', 'inputnode.validation_report')]),
         (epi_reg_wf, func_reports_wf, [
             ('outputnode.out_report', 'inputnode.epi_reg_report'),
             ]),
@@ -1013,10 +1014,15 @@ def init_func_reports_wf(reportlets_dir, freesurfer, use_aroma, use_syn, name='f
 
     inputnode = pe.Node(
         niu.IdentityInterface(
-            fields=['source_file', 'epi_mask_report', 'epi_reg_report', 'acompcor_report',
-                    'tcompcor_report', 'syn_sdc_report', 'ica_aroma_report']
+            fields=['source_file', 'validation_report', 'epi_mask_report', 'epi_reg_report',
+                    'acompcor_report', 'tcompcor_report', 'syn_sdc_report', 'ica_aroma_report']
             ),
         name='inputnode')
+
+    ds_validation_report = pe.Node(
+        DerivativesDataSink(base_directory=reportlets_dir,
+                            suffix='validation'),
+        name='ds_validation_report', run_without_submitting=True)
 
     ds_epi_mask_report = pe.Node(
         DerivativesDataSink(base_directory=reportlets_dir,
@@ -1049,6 +1055,8 @@ def init_func_reports_wf(reportlets_dir, freesurfer, use_aroma, use_syn, name='f
         name='ds_ica_aroma_report', run_without_submitting=True)
 
     workflow.connect([
+        (inputnode, ds_validation_report, [('source_file', 'source_file'),
+                                           ('validation_report', 'in_file')]),
         (inputnode, ds_epi_mask_report, [('source_file', 'source_file'),
                                          ('epi_mask_report', 'in_file')]),
         (inputnode, ds_epi_reg_report, [('source_file', 'source_file'),

--- a/fmriprep/workflows/epi.py
+++ b/fmriprep/workflows/epi.py
@@ -23,7 +23,7 @@ from niworkflows.interfaces.registration import EstimateReferenceImage
 import niworkflows.data as nid
 
 from niworkflows.interfaces import SimpleBeforeAfter
-from fmriprep.interfaces import DerivativesDataSink, InvertT1w
+from fmriprep.interfaces import DerivativesDataSink, InvertT1w, ValidateImage
 
 from fmriprep.interfaces.images import GenerateSamplingReference, extract_wm
 from fmriprep.interfaces.nilearn import Merge
@@ -119,6 +119,8 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
                                            ]),
         ])
 
+    validate = pe.Node(ValidateImage(), name='validate')
+
     # HMC on the EPI
     epi_hmc_wf = init_epi_hmc_wf(name='epi_hmc_wf', metadata=metadata,
                                  bold_file_size_gb=bold_file_size_gb,
@@ -142,7 +144,8 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
     discover_wf.get_node('inputnode').inputs.t1_transform_flags = [False]
 
     workflow.connect([
-        (inputnode, epi_hmc_wf, [('epi', 'inputnode.epi')]),
+        (inputnode, validate, [('epi', 'in_file')]),
+        (validate, epi_hmc_wf, [('out_file', 'inputnode.epi')]),
         (inputnode, epi_reg_wf, [('epi', 'inputnode.name_source'),
                                  ('t1_preproc', 'inputnode.t1_preproc'),
                                  ('t1_brain', 'inputnode.t1_brain'),


### PR DESCRIPTION
As discussed in #573, BOLD series with invalid headers (no valid qform/sform) can cause a number of issues, including failure of skull stripping. I've also found that bbregister will fail to run.

It was decided that, instead of rejecting these images, we allow nibabel to assume an LAS orientation and set a default sform, and note this prominently in the reports.

The current warning is:

-----

### WARNING - Invalid header

Input file does not have valid qform or sform matrix. A default, LAS-oriented affine has been constructed. A left-right flip may have occurred. Analyses of this dataset MAY BE INVALID.

-----

Related #260 

Closes #573