### PR TITLE
ENH: Add version and timestamp

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Next release
 ============
 
+With thanks to Yaroslav Halchenko for contributions.
+
+* [ENH] High-pass filter time series prior to CompCor (#577)
+* [ENH] Validate and minimally conform BOLD images (#581)
+* [FIX] Bug that prevented PE direction estimation (#586)
+* [DOC] Log version/time in report (#587)
 
 0.5.2 (30th of June 2017)
 =========================

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -28,4 +28,4 @@ dependencies:
     - svgutils
     - nitime
     - nilearn
-    - git+https://github.com/poldracklab/niworkflows.git@2de9c245b11f5328743c73d3ec80a969a20c6e5c#egg=niworkflows
+    - niworkflows>=0.1.4

--- a/fmriprep/info.py
+++ b/fmriprep/info.py
@@ -68,7 +68,7 @@ REQUIRES = [
     'grabbit',
     'pybids>=0.2.1',
     'nitime',
-    'niworkflows>=0.1.3',
+    'niworkflows>=0.1.4',
     'statsmodels',
     'nipype',
     'seaborn',

--- a/fmriprep/viz/report.tpl
+++ b/fmriprep/viz/report.tpl
@@ -38,12 +38,13 @@ body {
                     {% for run_report in sub_report.run_reports %}
                         <li><a class="dropdown-item" href="#{{run_report.name}}">{{run_report.title}}</a></li>
                     {% endfor %}
-                    <li><a class="dropdown-item" href="#errors">Errors</a></li>
                     </ul>
                 </li>
             {% else %}
                 <li><a href="#{{sub_report.name}}">{{ sub_report.name }}</a></li>
             {% endif %}
+            <li><a class="dropdown-item" href="#about">About</a></li>
+            <li><a class="dropdown-item" href="#errors">Errors</a></li>
         {% endfor %}
     </ul>
 <div>
@@ -91,6 +92,14 @@ body {
     </div>
 {% endfor %}
 
+<div id="about">
+    <h1 class="sub-report-title">About</h1>
+    <ul>
+        <li>FMRIPREP version: {{ version }}</li>
+        <li>Report generated: {{ date }}</li>
+    </ul>
+</div>
+
 <div id="errors">
     <h1 class="sub-report-title">Errors</h1>
     <ul>
@@ -113,6 +122,8 @@ body {
             </div>
         </div>
         </li>
+    {% else %}
+        <li>No errors to report!</li>
     {% endfor %}
     </ul>
 </div>

--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -3,10 +3,13 @@ from __future__ import unicode_literals
 import json
 import re
 import os
+import time
 
 import jinja2
 from niworkflows.nipype.utils.filemanip import loadcrash
 from pkg_resources import resource_filename as pkgrf
+
+from .. import __version__
 
 
 class Element(object):
@@ -153,7 +156,9 @@ class Report(object):
             trim_blocks=True, lstrip_blocks=True
         )
         report_tpl = env.get_template('viz/report.tpl')
-        report_render = report_tpl.render(sub_reports=self.sub_reports, errors=self.errors)
+        report_render = report_tpl.render(sub_reports=self.sub_reports, errors=self.errors,
+                                          date=time.strftime("%Y-%m-%d %H:%M:%S %z"),
+                                          version=__version__)
         with open(os.path.join(self.out_dir, "fmriprep", self.out_filename), 'w') as fp:
             fp.write(report_render)
         return len(self.errors)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/poldracklab/niworkflows.git@2de9c245b11f5328743c73d3ec80a969a20c6e5c#egg=niworkflows
+niworkflows>=0.1.4


### PR DESCRIPTION
This adds an "About" section, which includes the FMRIPREP version and a timestamp. 

It also pushes "Errors" out from under "Functionals", since we are not currently collating errors by workflow type.