### PR TITLE
[RTM] FIX: Correctly resample T1w images in ConformSeries

### DIFF
--- a/docs/anat/base.rst
+++ b/docs/anat/base.rst
@@ -1,0 +1,12 @@
+:orphan:
+
+.. _conformation:
+
+T1-weighted Conformation
+------------------------
+
+.. autoclass:: fmriprep.interfaces.images.ConformSeries
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -6,6 +6,7 @@
 .. _workflows: workflows.html
 .. _FreeSurfer: https://surfer.nmr.mgh.harvard.edu/
 .. _`submillimeter reconstruction`: https://surfer.nmr.mgh.harvard.edu/fswiki/SubmillimeterRecon
+.. _`mri_robust_register`: https://surfer.nmr.mgh.harvard.edu/fswiki/mri_robust_template
 .. _GIFTI: https://www.nitrc.org/projects/gifti/
 .. _`Connectome Workbench`: https://www.humanconnectome.org/software/connectome-workbench.html
 .. _`fmriprep-docker`: https://pypi.python.org/pypi/fmriprep-docker

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -63,9 +63,13 @@ T1w/T2w preprocessing
                               debug=False,
                               hires=True)
 
-This sub-workflow finds the skull stripping mask and the
-white matter/gray matter/cerebrospinal fluid segments and finds a non-linear
-warp to the MNI space.
+The anatomical sub-workflow begins by constructing a template image by
+:ref:`conforming <conformation>` any T1-weighted images to RAS orientation and
+a common voxel size, and, in the case of multiple images, merges them into a
+single template using `mri_robust_register`_.
+This template is then skull-stripped, and the white matter/gray
+matter/cerebrospinal fluid segments are found.
+Finally, a non-linear registration to the MNI template space is estimated.
 
 .. figure:: _static/brainextraction_t1.svg
     :scale: 100%

--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -23,7 +23,7 @@ from niworkflows.nipype.interfaces.base import (
 from niworkflows.nipype.interfaces import fsl
 from niworkflows.interfaces.base import SimpleInterface
 
-from fmriprep.utils.misc import genfname
+from ..utils.misc import genfname
 
 LOGGER = logging.getLogger('interface')
 

--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -167,7 +167,7 @@ class ConformSeries(SimpleInterface):
                 target_affine = np.eye(4, dtype=img.affine.dtype)
                 if rescale:
                     scale_factor = target_zooms / zooms
-                    target_affine[:3, :3] = np.diag(scale_factor).dot(img.affine[:3, :3])
+                    target_affine[:3, :3] = img.affine[:3, :3].dot(np.diag(scale_factor))
                 else:
                     target_affine[:3, :3] = img.affine[:3, :3]
 
@@ -183,8 +183,6 @@ class ConformSeries(SimpleInterface):
 
                 data = nli.resample_img(img, target_affine, target_shape).get_data()
                 img = img.__class__(data, target_affine, img.header)
-                if rescale:
-                    img.header.set_zooms(target_zooms)
 
             resampled_imgs.append(img)
 

--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -13,9 +13,10 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 import os
 import numpy as np
 import nibabel as nb
+import nilearn.image as nli
 
 from niworkflows.nipype import logging
-from niworkflows.nipype.utils.filemanip import fname_presuffix
+from niworkflows.nipype.utils.filemanip import fname_presuffix, copyfile
 from niworkflows.nipype.interfaces.base import (
     traits, TraitedSpec, BaseInterfaceInputSpec,
     File, InputMultiPath, OutputMultiPath)
@@ -138,9 +139,6 @@ class ConformSeries(SimpleInterface):
     output_spec = ConformSeriesOutputSpec
 
     def _run_interface(self, runtime):
-        import nibabel as nb
-        import nilearn.image as nli
-        from nipype.utils.filemanip import fname_presuffix, copyfile
 
         in_names = self.inputs.t1w_list
         orig_imgs = [nb.load(fname) for fname in in_names]
@@ -269,8 +267,6 @@ class InvertT1w(SimpleInterface):
     output_spec = InvertT1wOutputSpec
 
     def _run_interface(self, runtime):
-        from nilearn import image as nli
-
         t1_img = nli.load_img(self.inputs.in_file)
         t1_data = t1_img.get_data()
         epi_data = nli.load_img(self.inputs.epi_ref).get_data()

--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -154,8 +154,9 @@ class ConformSeries(SimpleInterface):
     """Conform a series of T1w images to enable merging.
 
     Performs two basic functions:
-    - Orient to RAS (left-right, posterior-anterior, inferior-superior)
-    - Along each dimension, resample to minimum voxel size, maximum number of voxels
+
+    #. Orient to RAS (left-right, posterior-anterior, inferior-superior)
+    #. Along each dimension, resample to minimum voxel size, maximum number of voxels
 
     The ``max_scale`` parameter sets a bound on the degree of up-sampling performed.
     By default, an image with a voxel size greater than 3x the smallest voxel size

--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -146,6 +146,7 @@ class ConformSeries(SimpleInterface):
         target_shape = np.max([img.shape for img in reoriented], axis=0)
         target_zooms = np.min([img.header.get_zooms()[:3]
                                for img in reoriented], axis=0)
+        target_span = target_shape * target_zooms
 
         resampled_imgs = []
         for img in reoriented:
@@ -174,7 +175,7 @@ class ConformSeries(SimpleInterface):
                 if resize:
                     # The shift is applied after scaling.
                     # Use a proportional shift to maintain relative position in dataset
-                    size_factor = (target_shape.astype(float) + shape) / (2 * shape)
+                    size_factor = target_span / (zooms * shape)
                     # Use integer shifts to avoid unnecessary interpolation
                     offset = (img.affine[:3, 3] * size_factor - img.affine[:3, 3]).astype(int)
                     target_affine[:3, 3] = img.affine[:3, 3] + offset

--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -183,6 +183,8 @@ class ConformSeries(SimpleInterface):
 
                 data = nli.resample_img(img, target_affine, target_shape).get_data()
                 img = img.__class__(data, target_affine, img.header)
+                if rescale:
+                    img.header.set_zooms(target_zooms)
 
             resampled_imgs.append(img)
 

--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -151,6 +151,19 @@ class ConformSeriesOutputSpec(TraitedSpec):
 
 
 class ConformSeries(SimpleInterface):
+    """Conform a series of T1w images to enable merging.
+
+    Performs two basic functions:
+    - Orient to RAS (left-right, posterior-anterior, inferior-superior)
+    - Along each dimension, resample to minimum voxel size, maximum number of voxels
+
+    The ``max_scale`` parameter sets a bound on the degree of up-sampling performed.
+    By default, an image with a voxel size greater than 3x the smallest voxel size
+    (calculated separately for each dimension) will be discarded.
+
+    To select images that require no scaling (i.e. all have smallest voxel sizes),
+    set ``max_scale=1``.
+    """
     input_spec = ConformSeriesInputSpec
     output_spec = ConformSeriesOutputSpec
 

--- a/fmriprep/viz/config.json
+++ b/fmriprep/viz/config.json
@@ -11,6 +11,11 @@
                 "raw": true
             },
             {
+                "name": "anat/conform",
+                "file_pattern": "anat/.*_conform",
+                "raw": true
+            },
+            {
                 "name": "skullstrip_ants/t1_skull_strip",
                 "file_pattern": "anat/.*skull_strip",
                 "title": "Skull stripped T1",

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -197,8 +197,9 @@ def init_anat_preproc_wf(skull_strip_ants, output_spaces, template, debug, frees
     workflow.connect([
         (inputnode, anat_reports_wf, [
             (('t1w', fix_multi_T1w_source_name), 'inputnode.source_file')]),
-        (t1_seg, anat_reports_wf, [('out_report', 'inputnode.t1_seg_report')]),
         (summary, anat_reports_wf, [('out_report', 'inputnode.summary_report')]),
+        (t1_conform, anat_reports_wf, [('out_report', 'inputnode.t1_conform_report')]),
+        (t1_seg, anat_reports_wf, [('out_report', 'inputnode.t1_seg_report')]),
         ])
 
     if skull_strip_ants:
@@ -571,14 +572,18 @@ def init_anat_reports_wf(reportlets_dir, skull_strip_ants, output_spaces,
 
     inputnode = pe.Node(
         niu.IdentityInterface(
-            fields=['source_file', 'summary_report', 't1_seg_report', 't1_2_mni_report',
-                    't1_skull_strip_report', 'recon_report']),
+            fields=['source_file', 'summary_report', 't1_conform_report', 't1_seg_report',
+                    't1_2_mni_report', 't1_skull_strip_report', 'recon_report']),
         name='inputnode')
 
     ds_summary_report = pe.Node(
         DerivativesDataSink(base_directory=reportlets_dir,
                             suffix='summary'),
         name='ds_summary_report', run_without_submitting=True)
+
+    ds_t1_conform_report = pe.Node(
+        DerivativesDataSink(base_directory=reportlets_dir, suffix='conform'),
+        name='ds_t1_conform_report', run_without_submitting=True)
 
     ds_t1_seg_report = pe.Node(
         DerivativesDataSink(base_directory=reportlets_dir, suffix='t1_seg'),
@@ -599,6 +604,8 @@ def init_anat_reports_wf(reportlets_dir, skull_strip_ants, output_spaces,
     workflow.connect([
         (inputnode, ds_summary_report, [('source_file', 'source_file'),
                                         ('summary_report', 'in_file')]),
+        (inputnode, ds_t1_conform_report, [('source_file', 'source_file'),
+                                           ('t1_conform_report', 'in_file')]),
         (inputnode, ds_t1_seg_report, [('source_file', 'source_file'),
                                        ('t1_seg_report', 'in_file')]),
     ])


### PR DESCRIPTION
This PR stems from #599, which revealed that we've been conforming wrongly. The error was so small that the error only appears for highly anisotropic voxels in an oblique orientation.

In addition, it introduced the case where high- and low-quality T1w scans coexist in the same dataset, and the upsampling involved would ultimately degrade the quality of a template produced by averaging the images.

The following changes are introduced:

* Rescaling is applied to affine columns, as opposed to rows, which will correctly set the zooms in the resampled dataset
* A size (dimension) factor is recalculated to be less sensitive to large differences in dimension
* A `max_scale` factor (default: 3) discards images which require upsampling over a given ratio
* An HTML reportlet is created to describe the conformation step

Todo:

* [x] Integrate reportlet into report
* [x] Test on ds000114 sub-02 (See #538/#545)
* [x] Test on ds000114 sub-07/09 (See #562/#564)
* [x] Test on ds000031

Closes #599.