### PR TITLE
[RTM] FIX: Ensure un-nested lists are not over-flattened

### DIFF
--- a/fmriprep/workflows/fieldmap/unwarp.py
+++ b/fmriprep/workflows/fieldmap/unwarp.py
@@ -447,7 +447,8 @@ def init_prepare_epi_wf(ants_nthreads, name="prepare_epi_wf"):
     workflow = pe.Workflow(name=name)
 
     def _flatten(l):
-        return [item for sublist in l for item in sublist]
+        from niworkflows.nipype.utils.filemanip import filename_to_list
+        return [item for sublist in l for item in filename_to_list(sublist)]
 
     workflow.connect([
         (inputnode, split, [('fmaps', 'in_file')]),


### PR DESCRIPTION
Do we have a good dataset to test this? It showed up with blip-up/blip-down, presumably single volume field maps.

Closes #598.