### PR TITLE
[RTM] ENH: Add non-steady-state detection before CompCor

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -28,4 +28,4 @@ dependencies:
     - svgutils
     - nitime
     - nilearn
-    - git+https://github.com/poldracklab/niworkflows.git@0a71b0f16acec10520b6eb824649d19519e65b59#egg=niworkflows-0.1.5-dev
+    - git+https://github.com/poldracklab/niworkflows.git@c5442127822e88c60e658c7b8e78d1a371eb2637#egg=niworkflows-0.1.5-dev

--- a/fmriprep/workflows/confounds.py
+++ b/fmriprep/workflows/confounds.py
@@ -54,6 +54,7 @@ def init_discover_wf(bold_file_size_gb, use_aroma, ignore_aroma_err, metadata,
                              name="frame_displace")
     frame_displace.interface.estimated_memory_gb = bold_file_size_gb * 3
     # CompCor
+    non_steady_state = pe.Node(confounds.NonSteadyStateDetector(), name='non_steady_state')
     tcompcor = pe.Node(TCompCorRPT(components_file='tcompcor.tsv',
                                    generate_report=True,
                                    pre_filter='cosine',
@@ -173,7 +174,11 @@ def init_discover_wf(bold_file_size_gb, use_aroma, ignore_aroma_err, metadata,
         (inputnode, dvars, [('fmri_file', 'in_file'),
                             ('epi_mask', 'in_mask')]),
         (inputnode, frame_displace, [('movpar_file', 'in_file')]),
+        (inputnode, non_steady_state, [('fmri_file', 'in_file')]),
         (inputnode, tcompcor, [('fmri_file', 'realigned_file')]),
+
+        (non_steady_state, tcompcor, [('n_volumes_to_discard', 'ignore_initial_volumes')]),
+        (non_steady_state, acompcor, [('n_volumes_to_discard', 'ignore_initial_volumes')]),
 
         (inputnode, CSF_roi, [(('t1_tpms', pick_csf), 'in_file')]),
         (inputnode, CSF_roi, [('epi_mask', 'epi_mask')]),

--- a/fmriprep/workflows/confounds.py
+++ b/fmriprep/workflows/confounds.py
@@ -262,6 +262,7 @@ def _gather_confounds(signals=None, dvars=None, frame_displace=None,
                            (frame_displace, 'Framewise displacement'),
                            (tcompcor, 'tCompCor'),
                            (acompcor, 'aCompCor'),
+                           (cosine_basis, 'Cosine basis'),
                            (motion, 'Motion parameters'),
                            (aroma, 'ICA-AROMA')):
         if confound is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/poldracklab/niworkflows.git@0a71b0f16acec10520b6eb824649d19519e65b59#egg=niworkflows-0.1.5-dev
+git+https://github.com/poldracklab/niworkflows.git@c5442127822e88c60e658c7b8e78d1a371eb2637#egg=niworkflows-0.1.5-dev


### PR DESCRIPTION
Closes #361.

Because pin includes poldracklab/niworkflows#188:

Fixes #616
Closes #619