### PR TITLE
[WIP] ENH: Generate conformation transforms

### DIFF
--- a/fmriprep/interfaces/__init__.py
+++ b/fmriprep/interfaces/__init__.py
@@ -7,7 +7,7 @@ from .bids import (
 )
 from .images import IntraModalMerge, InvertT1w, ValidateImage, ConformSeries
 from .freesurfer import (
-    StructuralReference, MakeMidthickness, FSInjectBrainExtracted, FSDetectInputs
+    StructuralReference, MakeMidthickness, FSInjectBrainExtracted, FSDetectInputs, LTAConvert
 )
 from .surf import NormalizeSurf, GiftiNameSource
 from .reports import AnatomicalSummary

--- a/fmriprep/interfaces/freesurfer.py
+++ b/fmriprep/interfaces/freesurfer.py
@@ -46,8 +46,16 @@ class StructuralReference(fs.RobustTemplate):
         if len(img.shape) > 3 and img.shape[3] > 1:
             return cmd
 
+        in_file = self.inputs.in_files[0]
         out_file = self._list_outputs()['out_file']
-        copyfile(self.inputs.in_files[0], out_file)
+        copyfile(in_file, out_file)
+
+        if isdefined(self.inputs.transform_outputs):
+            transform_outputs = self._list_outputs()['transform_outputs']
+            lta = LTAConvert(in_lta='identity.nofile', source=in_file,
+                             target=out_file, out_lta=transform_outputs[0])
+            lta.run()
+
         return "echo Only one time point!"
 
     def _format_arg(self, name, spec, value):

--- a/fmriprep/interfaces/freesurfer.py
+++ b/fmriprep/interfaces/freesurfer.py
@@ -9,23 +9,33 @@ FreeSurfer tools interfaces
 """
 from __future__ import print_function, division, absolute_import, unicode_literals
 
+import os
 import os.path as op
 import nibabel as nb
 
 from nilearn.image import resample_to_img, new_img_like
 
-from niworkflows.nipype.utils.filemanip import copyfile, filename_to_list
+from niworkflows.nipype.utils.filemanip import copyfile, filename_to_list, fname_presuffix
 from niworkflows.nipype.interfaces.base import (
-    isdefined, InputMultiPath, BaseInterfaceInputSpec, TraitedSpec, File, traits, Directory
+    traits, isdefined, InputMultiPath, File, Directory,
+    BaseInterfaceInputSpec, TraitedSpec, CommandLineInputSpec, CommandLine
 )
 from niworkflows.nipype.interfaces import freesurfer as fs
 
 from niworkflows.interfaces.base import SimpleInterface
 
 
+class StructuralReferenceInputSpec(fs.longitudinal.RobustTemplateInputSpec):
+    transform_outputs = traits.Either(
+        True, InputMultiPath(File(exists=False)),
+        argstr='--lta %s', desc='output xforms to template (for each input)')
+
+
 class StructuralReference(fs.RobustTemplate):
     """ Variation on RobustTemplate that simply copies the source if a single
     volume is provided. """
+    input_spec = StructuralReferenceInputSpec
+
     @property
     def cmdline(self):
         cmd = super(StructuralReference, self).cmdline
@@ -39,6 +49,27 @@ class StructuralReference(fs.RobustTemplate):
         out_file = self._list_outputs()['out_file']
         copyfile(self.inputs.in_files[0], out_file)
         return "echo Only one time point!"
+
+    def _format_arg(self, name, spec, value):
+        if name == 'transform_outputs':
+            value = self._list_outputs()['transform_outputs']
+        return super(StructuralReference, self)._format_arg(name, spec, value)
+
+    def _list_outputs(self):
+        outputs = self.output_spec().get()
+        outputs['out_file'] = os.path.abspath(
+            self.inputs.out_file)
+        if isdefined(self.inputs.transform_outputs):
+            fnames = self.inputs.transform_outputs
+            if fnames is True:
+                fnames = [fname_presuffix(in_file, suffix='.lta', newpath=os.getcwd(),
+                                          use_ext=False)
+                          for in_file in self.inputs.in_files]
+            outputs['transform_outputs'] = list(map(os.path.abspath, fnames))
+        if isdefined(self.inputs.scaled_intensity_outputs):
+            outputs['scaled_intensity_outputs'] = [os.path.abspath(
+                x) for x in self.inputs.scaled_intensity_outputs]
+        return outputs
 
 
 class MakeMidthicknessInputSpec(fs.utils.MRIsExpandInputSpec):
@@ -75,6 +106,70 @@ class MakeMidthickness(fs.MRIsExpand):
             return cmd
 
         return "cp {} {}".format(source, self._list_outputs()['out_file'])
+
+
+class LTAConvertInputSpec(CommandLineInputSpec):
+    # Inputs
+    _in_xor = ('in_lta', 'in_fsl', 'in_mni', 'in_reg', 'in_niftyreg')
+    in_lta = traits.Either(File(exists=True), 'identity.nofile', argstr='--inlta %s',
+                           xor=_in_xor, desc='input transform of LTA type')
+    in_fsl = File(exists=True, argstr='--infsl %s',
+                  xor=_in_xor, desc='input transform of FSL type')
+    in_mni = File(exists=True, argstr='--inmni %s',
+                  xor=_in_xor, desc='input transform of MNI/XFM type')
+    in_reg = File(exists=True, argstr='--inreg %s',
+                  xor=_in_xor, desc='input transform of TK REG type (deprecated format)')
+    in_niftyreg = File(exists=True, argstr='--inniftyreg %s',
+                       xor=_in_xor, desc='input transform of Nifty Reg type (inverse RAS2RAS)')
+    # Outputs
+    out_lta = traits.Either(traits.Bool, File, argstr='--outlta %s',
+                            desc='output linear transform (LTA Freesurfer format)')
+    out_fsl = traits.Either(traits.Bool, File, argstr='--outfsl %s',
+                            desc='output transform in FSL format')
+    out_mni = traits.Either(traits.Bool, File, argstr='--outmni %s',
+                            desc='output transform in MNI/XFM format')
+    out_reg = traits.Either(traits.Bool, File, argstr='--outreg %s',
+                            desc='output transform in reg dat format')
+    # Optional flags
+    invert = traits.Bool(argstr='--invert')
+    ltavox2vox = traits.Bool(argstr='--ltavox2vox', requires=['out_lta'])
+    source_file = File(exists=True, argstr='--src %s')
+    target_file = File(exists=True, argstr='--trg %s')
+    target_conform = traits.Bool(argstr='--trgconform')
+
+
+class LTAConvertOutputSpec(TraitedSpec):
+    out_lta = File(exists=True, desc='output linear transform (LTA Freesurfer format)')
+    out_fsl = File(exists=True, desc='output transform in FSL format')
+    out_mni = File(exists=True, desc='output transform in MNI/XFM format')
+    out_reg = File(exists=True, desc='output transform in reg dat format')
+
+
+class LTAConvert(CommandLine):
+    input_spec = LTAConvertInputSpec
+    output_spec = LTAConvertOutputSpec
+    _cmd = 'lta_convert'
+
+    def _format_arg(self, name, spec, value):
+        if name.startswith('out_') and value is True:
+            value = self._list_outputs()[name]
+        return super(LTAConvert, self)._format_arg(name, spec, value)
+
+    def _list_outputs(self):
+        outputs = self.output_spec().get()
+        if self.inputs.out_lta:
+            fname = 'out.lta' if self.inputs.out_lta is True else self.inputs.out_lta
+            outputs['out_lta'] = os.path.abspath(fname)
+        if self.inputs.out_fsl:
+            fname = 'out.mat' if self.inputs.out_fsl is True else self.inputs.out_fsl
+            outputs['out_fsl'] = os.path.abspath(fname)
+        if self.inputs.out_mni:
+            fname = 'out.xfm' if self.inputs.out_mni is True else self.inputs.out_mni
+            outputs['out_mni'] = os.path.abspath(fname)
+        if self.inputs.out_reg:
+            fname = 'out.dat' if self.inputs.out_reg is True else self.inputs.out_reg
+            outputs['out_reg'] = os.path.abspath(fname)
+        return outputs
 
 
 class FSInjectBrainExtractedInputSpec(BaseInterfaceInputSpec):


### PR DESCRIPTION
Insomnia led to playing around with this. Includes an assert to verify that the transform actually does get you from one affine to another. Tested on ds031.

Looks like `mri_robust_template` only outputs [LTA transforms](https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/LtaFormat).

Assuming this is worthwhile, I'd propose the following derivative structure:

```
derivatives/
    fmriprep/
        anat/
            transforms/
                <orig_T1w_name>.mat
```

Related: #624