### PR TITLE
FIX: Require future for fmriprep-docker setup

### DIFF
--- a/wrapper/setup.py
+++ b/wrapper/setup.py
@@ -26,7 +26,7 @@ def main():
         license=info['__license__'],
         classifiers=info['CLASSIFIERS'],
         # Dependencies handling
-        setup_requires=[],
+        setup_requires=['future'],
         install_requires=['future'],
         tests_require=[],
         extras_require={},


### PR DESCRIPTION
#626 showed that `pip install fmriprep-docker` from a clean environment can fail, because `future` isn't installed. This should tell pip to bootstrap installation by installing `future` before reading `setup.py`.