### PR TITLE
[RTM] ENH: Check output spaces for --use-aroma

### DIFF
--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -179,9 +179,13 @@ def main():
 
     # Validity of some inputs - OE should be done in parse_args?
     # ERROR check if use_aroma was specified, but the correct template was not
-    if opts.use_aroma and str(opts.template) != 'MNI152NLin2009cAsym':
-        raise RuntimeError('ERROR: if use_aroma is set, the template must be set '
-                           'to MNI152NLin2009cAsym not %s' % opts.template)
+    if opts.use_aroma and (opts.template != 'MNI152NLin2009cAsym' or
+                           'template' not in opts.output_space):
+        raise RuntimeError('ERROR: --use-aroma requires functional images to be resampled to '
+                           'MNI152NLin2009cAsym.\n'
+                           '\t--template must be set to "MNI152NLin2009cAsym" (was: "{}")\n'
+                           '\t--output-space list must include "template" (was: "{}")'.format(
+                               opts.template, ' '.join(opts.output_space)))
     # Check output_space
     if 'template' not in opts.output_space and (opts.use_syn_sdc or opts.force_syn):
         msg = ('SyN SDC correction requires T1 to MNI registration, but '


### PR DESCRIPTION
This PR alerts users that specify `--use-aroma` if they don't have the necessary flags to sample the BOLD series in MNI space.

This could be replaced with a strategy of calculating the transforms without adding outputs to the derivatives directory, but this approach keeps behavior closely matched with arguments.

Closes #625.