### PR TITLE
[RTM] FIX: Enable inactive slice timing, fieldmap unwarping options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 Next release
 ============
-
+* [FIX] Slice time correction is now being applied to output data (no only to intermediate file used for motion estimation - #662)
+* [FIX] Fieldmap unwarping is now being applied to MNI space outputs (no only to T1w space outputs - #662)
 
 1.0.0-rc1 (8th of August 2017)
 ==============================

--- a/fmriprep/workflows/bold.py
+++ b/fmriprep/workflows/bold.py
@@ -334,6 +334,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
             template=template,
             bold_file_size_gb=bold_file_size_gb,
             output_grid_ref=output_grid_ref,
+            use_fieldwarp=(fmaps is not None or use_syn),
             name='bold_mni_trans_wf'
         )
 

--- a/fmriprep/workflows/bold.py
+++ b/fmriprep/workflows/bold.py
@@ -489,19 +489,20 @@ def init_bold_hmc_wf(metadata, bold_file_size_gb, ignore,
                                                   ('skip_vols', 'ignore')]),
             (create_custom_slice_timing_file, slice_timing_correction, [
                 (('out', _prefix_at), 'tpattern')]),
-            (slice_timing_correction, hmc, [('out_file', 'in_file')])
+            (slice_timing_correction, hmc, [('out_file', 'in_file')]),
+            (slice_timing_correction, split, [('out_file', 'in_file')]),
         ])
 
     else:
         workflow.connect([
-            (inputnode, hmc, [('bold_file', 'in_file')])
+            (inputnode, hmc, [('bold_file', 'in_file')]),
+            (inputnode, split, [('bold_file', 'in_file')]),
         ])
 
     workflow.connect([
         (inputnode, hmc, [('raw_ref_image', 'ref_file')]),
         (inputnode, hcm2itk, [('raw_ref_image', 'source_file'),
                               ('raw_ref_image', 'reference_file')]),
-        (inputnode, split, [('bold_file', 'in_file')]),
         (hmc, hcm2itk, [('mat_file', 'transform_file')]),
         (hmc, normalize_motion, [('par_file', 'in_file')]),
         (hcm2itk, outputnode, [('itk_transform', 'xforms')]),


### PR DESCRIPTION
Currently, head motion correction is being estimated on slice-timing corrected volumes, but applied to the original, uncorrected volumes.

This PR ensures the inputs to HMC and fslsplit are the same, with slice-timing correction applied to both or neither.