### PR TITLE
RF: Drop custom ApplyMask for fsl.ApplyMask

### DIFF
--- a/fmriprep/interfaces/__init__.py
+++ b/fmriprep/interfaces/__init__.py
@@ -11,6 +11,6 @@ from .freesurfer import (
 )
 from .surf import NormalizeSurf, GiftiNameSource, GiftiSetAnatomicalStructure
 from .reports import SubjectSummary, FunctionalSummary, AboutSummary
-from .utils import ApplyMask, TPM2ROI, ConcatROIs, CombineROIs, AddTSVHeader
+from .utils import TPM2ROI, ConcatROIs, CombineROIs, AddTSVHeader
 from .fmap import FieldEnhance
 from .confounds import GatherConfounds, ICAConfounds

--- a/fmriprep/interfaces/utils.py
+++ b/fmriprep/interfaces/utils.py
@@ -16,30 +16,6 @@ from niworkflows.nipype.interfaces.base import (
 from niworkflows.interfaces.base import SimpleInterface
 
 
-class ApplyMaskInputSpec(BaseInterfaceInputSpec):
-    in_file = File(exists=True, mandatory=True, desc='input file')
-    in_mask = File(exists=True, mandatory=True, desc='input mask')
-
-
-class ApplyMaskOutputSpec(TraitedSpec):
-    out_file = File(exists=True, desc='output average file')
-
-
-class ApplyMask(SimpleInterface):
-    input_spec = ApplyMaskInputSpec
-    output_spec = ApplyMaskOutputSpec
-
-    def _run_interface(self, runtime):
-        out_file = fname_presuffix(self.inputs.in_file, suffix='_brainmask',
-                                   newpath=runtime.cwd)
-        nii = nb.load(self.inputs.in_file)
-        data = nii.get_data()
-        data[nb.load(self.inputs.in_mask).get_data() <= 0] = 0
-        nb.Nifti1Image(data, nii.affine, nii.header).to_filename(out_file)
-        self._results['out_file'] = out_file
-        return runtime
-
-
 class TPM2ROIInputSpec(BaseInterfaceInputSpec):
     t1_tpm = File(exists=True, mandatory=True, desc='Tissue probability map file in T1 space')
     t1_mask = File(exists=True, mandatory=True, desc='Binary mask of skull-stripped T1w image')

--- a/fmriprep/workflows/fieldmap/fmap.py
+++ b/fmriprep/workflows/fieldmap/fmap.py
@@ -23,7 +23,7 @@ from niworkflows.nipype.interfaces import utility as niu, fsl, ants
 from niworkflows.nipype.workflows.dmri.fsl.utils import demean_image, cleanup_edge_pipeline
 from niworkflows.interfaces.masks import BETRPT
 
-from ...interfaces import IntraModalMerge, DerivativesDataSink, FieldEnhance, ApplyMask
+from ...interfaces import IntraModalMerge, DerivativesDataSink, FieldEnhance
 
 
 def init_fmap_wf(reportlets_dir, omp_nthreads, fmap_bspline, name='fmap_wf'):
@@ -99,7 +99,7 @@ def init_fmap_wf(reportlets_dir, omp_nthreads, fmap_bspline, name='fmap_wf'):
         demean = pe.Node(niu.Function(function=demean_image), name='demean')
         cleanup_wf = cleanup_edge_pipeline(name='cleanup_wf')
 
-        applymsk = pe.Node(ApplyMask(), name='applymsk')
+        applymsk = pe.Node(fsl.ApplyMask(), name='applymsk')
 
         workflow.connect([
             (bet, prelude, [('mask_file', 'mask_file'),
@@ -113,7 +113,7 @@ def init_fmap_wf(reportlets_dir, omp_nthreads, fmap_bspline, name='fmap_wf'):
             (demean, cleanup_wf, [('out', 'inputnode.in_file')]),
             (bet, cleanup_wf, [('mask_file', 'inputnode.in_mask')]),
             (cleanup_wf, applymsk, [('outputnode.out_file', 'in_file')]),
-            (bet, applymsk, [('mask_file', 'in_mask')]),
+            (bet, applymsk, [('mask_file', 'mask_file')]),
             (applymsk, outputnode, [('out_file', 'fmap')]),
         ])
 


### PR DESCRIPTION
This looks like an unnecessary interface, as [every other instance](https://github.com/poldracklab/fmriprep/search?utf8=%E2%9C%93&q=ApplyMask&type=) uses [fsl.ApplyMask](https://nipype.readthedocs.io/en/latest/interfaces/generated/interfaces.fsl/maths.html#applymask). Rather than add documentation, we can just drop it.

If there's any reason not to do this, feel free to close without discussion.