### PR TITLE
[RTM] FIX: Initialize SyN SDC more robustly

### DIFF
--- a/.circle/tests.sh
+++ b/.circle/tests.sh
@@ -34,7 +34,7 @@ fi
 case ${CIRCLE_NODE_INDEX} in
   0)
     fmriprep-docker -i poldracklab/fmriprep:latest --config $HOME/nipype.cfg -w $HOME/ds054/scratch $HOME/data/ds054 $HOME/ds054/out participant --no-freesurfer --debug --write-graph --force-syn
-    find ~/ds054/scratch -not -name "*.svg" -not -name "*.html" -not -name "*.svg" -not -name "*.rst" -type f -delete
+    find ~/ds054/scratch -not -name "*.svg" -not -name "*.html" -not -name "*.rst" -type f -delete
     ;;
   1)
     docker run -ti --rm=false --entrypoint="/usr/local/miniconda/bin/py.test" poldracklab/fmriprep:latest . --doctest-modules --ignore=docs --ignore=setup.py
@@ -44,6 +44,6 @@ case ${CIRCLE_NODE_INDEX} in
     cat $HOME/docs/builddocs.log && if grep -q "ERROR" $HOME/docs/builddocs.log; then false; else true; fi
     fmriprep-docker -i poldracklab/fmriprep:latest --help
     fmriprep-docker -i poldracklab/fmriprep:latest --config $HOME/nipype.cfg -w $HOME/ds005/scratch $HOME/data/ds005 $HOME/ds005/out participant --debug --write-graph --use-syn-sdc --use-aroma --ignore-aroma-denoising-errors
-    find ~/ds005/scratch -not -name "*.svg" -not -name "*.html" -not -name "*.svg" -not -name "*.rst" -type f -delete
+    find ~/ds005/scratch -not -name "*.svg" -not -name "*.html" -not -name "*.rst" -type f -delete
     ;;
 esac

--- a/.circle/tests.sh
+++ b/.circle/tests.sh
@@ -43,7 +43,7 @@ case ${CIRCLE_NODE_INDEX} in
         | tee $HOME/docs/builddocs.log
     cat $HOME/docs/builddocs.log && if grep -q "ERROR" $HOME/docs/builddocs.log; then false; else true; fi
     fmriprep-docker -i poldracklab/fmriprep:latest --help
-    fmriprep-docker -i poldracklab/fmriprep:latest --config $HOME/nipype.cfg -w $HOME/ds005/scratch $HOME/data/ds005 $HOME/ds005/out participant --debug --write-graph --use-aroma --ignore-aroma-denoising-errors
+    fmriprep-docker -i poldracklab/fmriprep:latest --config $HOME/nipype.cfg -w $HOME/ds005/scratch $HOME/data/ds005 $HOME/ds005/out participant --debug --write-graph --use-syn-sdc --use-aroma --ignore-aroma-denoising-errors
     find ~/ds005/scratch -not -name "*.svg" -not -name "*.html" -not -name "*.svg" -not -name "*.rst" -type f -delete
     ;;
 esac

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ With thanks to Anibal Sólon for contributions.
 * [ENH] Parallelize anatomical conformation step (#666)
 * [FIX] Handle missing functional data in SubjectSummary node (#670)
 * [FIX] Disable --no-skull-strip-ants (AFNI skull-stripping) (#674)
+* [FIX] Initialize SyN SDC more robustly (#680)
 
 1.0.0-rc2 (12th of August 2017)
 ===============================

--- a/fmriprep/data/affine.json
+++ b/fmriprep/data/affine.json
@@ -1,6 +1,7 @@
 {
     "dimension": 3,
     "float": false,
+    "initial_moving_transform_com": 1,
     "winsorize_lower_quantile": 0.005,
     "winsorize_upper_quantile": 0.995,
     "collapse_output_transforms": true,

--- a/fmriprep/workflows/util.py
+++ b/fmriprep/workflows/util.py
@@ -190,7 +190,7 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
         from niworkflows.nipype import logging
         with open(in_file, 'r') as fobj:
             for line in fobj:
-                if line.startswith('>> print U:1'):
+                if line.startswith(' >> print U:1'):
                     costs = next(fobj).split()
                     return float(costs[0])
         logger = logging.getLogger('interface')


### PR DESCRIPTION
A failure of initial alignment appears to have resulted in no-op registration, which cascaded. Adding a center-of-mass initial transform appears to have resolved it, but this may not work for partial FoV's that aren't also centered roughly on the midbrain.

Also found a small bug in reading the BBR cost, so fixing that while here.

Fixes #665.