### PR TITLE
[RTM] FIX: Raise RuntimeError when run.py is run directly

### DIFF
--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -16,7 +16,6 @@ from argparse import ArgumentParser
 from argparse import RawTextHelpFormatter
 from multiprocessing import cpu_count
 from time import strftime
-from ..info import __version__
 
 logging.addLevelName(25, 'INFO')  # Add a new level between INFO and WARNING
 logger = logging.getLogger('cli')
@@ -35,6 +34,7 @@ def _warn_redirect(message, category, filename, lineno, file=None, line=None):
 
 def get_parser():
     """Build parser object"""
+    from ..info import __version__
 
     verstr = 'fmriprep v{}'.format(__version__)
 
@@ -209,6 +209,7 @@ def create_workflow(opts):
     from ..viz.reports import run_reports
     from ..workflows.base import init_fmriprep_wf
     from ..utils.bids import collect_participants
+    from ..info import __version__
 
     # Set up some instrumental utilities
     errno = 0
@@ -334,4 +335,5 @@ def create_workflow(opts):
 
 
 if __name__ == '__main__':
-    main()
+    raise RuntimeError("fmriprep/cli/run.py should not be run directly;\n"
+                       "Please `pip install` fmriprep and use the `fmriprep` command")


### PR DESCRIPTION
Relative imports make directly calling `cli/run.py` impossible. If we used absolute imports, then it would work with the first version of fmriprep in the `PYTHONPATH`, which may not always be expected behavior. The simpler solution (suggested by @oesteban) is to raise an error and explain the situation.

I've moved a top-level relative import into the necessary functions, so that the exception can be raised.

Closes #691.