### PR TITLE
[RTM] ENH: Disable STC on short time series

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -296,8 +296,8 @@ EPI to T1w registration
                           bold2t1w_dof=9)
 
 The reference EPI image of each run is aligned by the ``bbregister`` routine to the
-reconstructed subject using
-the gray/white matter boundary (FreeSurfer's ``?h.white`` surfaces).
+reconstructed subject using the gray/white matter boundary (FreeSurfer's
+``?h.white`` surfaces).
 
 .. figure:: _static/EPIT1Normalization.svg
     :scale: 100%
@@ -322,10 +322,10 @@ EPI to MNI transformation
                                 omp_nthreads=1,
                                 output_grid_ref=None)
 
-This sub-workflow uses the transform from
+This sub-workflow concatenates the transforms calculated upstream (see
 `Head-motion estimation`_, `Susceptibility Distortion Correction (SDC)`_ (if
 fieldmaps are available), `EPI to T1w registration`_, and a T1w-to-MNI
-transform from `T1w/T2w preprocessing`_ to map the EPI image to standardized
+transform from `T1w/T2w preprocessing`_) to map the EPI image to standardized
 MNI space.
 It also maps the T1w-based mask to MNI space.
 

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -210,12 +210,7 @@ Head-motion estimation and slice time correction
     :simple_form: yes
 
     from fmriprep.workflows.bold import init_bold_hmc_wf
-    wf = init_bold_hmc_wf(
-        metadata={"RepetitionTime": 2.0,
-                  "SliceTiming": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]},
-                  ignore=[],
-                  bold_file_size_gb=3,
-                  omp_nthreads=1)
+    wf = init_bold_hmc_wf(bold_file_size_gb=3, omp_nthreads=1)
 
 This workflow performs slice time
 correction (if ``SliceTiming`` field is present in the input dataset metadata), head

--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -136,7 +136,8 @@ class SubjectSummary(SummaryInterface):
 
 
 class FunctionalSummaryInputSpec(BaseInterfaceInputSpec):
-    slice_timing = traits.Bool(False, usedefault=True, desc='Slice timing correction used')
+    slice_timing = traits.Enum(False, True, 'TooShort', usedefault=True,
+                               desc='Slice timing correction used')
     distortion_correction = traits.Enum('epi', 'fieldmap', 'phasediff', 'SyN', 'None',
                                         desc='Susceptibility distortion correction method',
                                         mandatory=True)
@@ -150,6 +151,9 @@ class FunctionalSummary(SummaryInterface):
     input_spec = FunctionalSummaryInputSpec
 
     def _generate_segment(self):
+        stc = {True: 'Applied',
+               False: 'Not applied',
+               'TooShort': 'Skipped (too few volumes)'}[self.inputs.slice_timing]
         stc = "Applied" if self.inputs.slice_timing else "Not applied"
         sdc = {'epi': 'Phase-encoding polarity (pepolar)',
                'fieldmap': 'Direct fieldmapping',

--- a/fmriprep/workflows/bold.py
+++ b/fmriprep/workflows/bold.py
@@ -708,7 +708,7 @@ def init_bold_stc_wf(metadata, name='bold_stc_wf'):
                                               ('skip_vols', 'ignore')]),
         (create_custom_slice_timing_file, slice_timing_correction, [
             (('out', _prefix_at), 'tpattern')]),
-        (slice_timing_correction, outputnode, [('out_file', 'bold_stc_file')]),
+        (slice_timing_correction, outputnode, [('out_file', 'stc_file')]),
     ])
 
     return workflow


### PR DESCRIPTION
BOLD series with < 5 usable volumes (apparently these exist...) can't be slice-timing corrected, at least with 3dTShift. This PR will add a check that the number of volumes minus the skipped volumes is at least 5. In the event that STC is disabled due to this check, it will report that in the summary for that BOLD file.

I factor the STC workflow out of HMC (even though it's currently just two nodes) to keep the issues separated. This will hopefully keep the check from cluttering HMC beyond readability.

Closes #696.