### PR TITLE
LOG: Clarify BOLD surface-sampling log message

### DIFF
--- a/fmriprep/workflows/bold.py
+++ b/fmriprep/workflows/bold.py
@@ -520,7 +520,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
             ])
 
     if freesurfer and any(space.startswith('fs') for space in output_spaces):
-        LOGGER.info('Creating FreeSurfer processing flow.')
+        LOGGER.info('Creating BOLD surface-sampling workflow.')
         bold_surf_wf = init_bold_surf_wf(output_spaces=output_spaces,
                                          medial_surface_nan=medial_surface_nan,
                                          name='bold_surf_wf')


### PR DESCRIPTION
Closes #719.

-----

```Shell
$ git blame fmriprep/workflows/bold.py | grep -C 2 "Creating FreeSurfer"
8cc9b683 fmriprep/workflows/epi.py  (Christopher J. Markiewicz 2017-04-18 09:36:15 -0400  521) 
0bbd2f6b fmriprep/workflows/epi.py  (Chris Gorgolewski         2017-04-22 17:57:41 -0700  522)     if freesurfer and any(space.startswith('fs') for space in output_spaces):
88caddce fmriprep/workflows/epi.py  (oesteban                  2017-04-03 14:35:06 -0700  523)         LOGGER.info('Creating FreeSurfer processing flow.')
23bb9b18 fmriprep/workflows/bold.py (oesteban                  2017-07-31 12:06:40 -0700  524)         bold_surf_wf = init_bold_surf_wf(output_spaces=output_spaces,
fad24b26 fmriprep/workflows/bold.py (mathiasg                  2017-08-31 15:47:06 -0400  525)                                          medial_surface_nan=medial_surface_nan,
```