### PR TITLE
[RTM] ENH: Conformation transforms

### DIFF
--- a/.circle/data/ds005_outputs.txt
+++ b/.circle/data/ds005_outputs.txt
@@ -26,6 +26,7 @@ ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_preproc.nii.
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_target-T1w_warp.h5
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_target-fsnative_affine.txt
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_target-MNI152NLin2009cAsym_warp.h5
+ds005/out/fmriprep/sub-01/anat/sub-01_T1w_target-T1w_affine.txt
 ds005/out/fmriprep/sub-01/func
 ds005/out/fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_bold_AROMAnoiseICs.csv
 ds005/out/fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_bold_confounds.tsv

--- a/.circle/data/ds005_outputs.txt
+++ b/.circle/data/ds005_outputs.txt
@@ -24,9 +24,9 @@ ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_class-WM_pro
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_dtissue.nii.gz
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_preproc.nii.gz
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_target-T1w_warp.h5
+ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-orig_target-T1w_affine.txt
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_target-fsnative_affine.txt
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_target-MNI152NLin2009cAsym_warp.h5
-ds005/out/fmriprep/sub-01/anat/sub-01_T1w_target-T1w_affine.txt
 ds005/out/fmriprep/sub-01/func
 ds005/out/fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_bold_AROMAnoiseICs.csv
 ds005/out/fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_bold_confounds.tsv

--- a/.circle/data/ds054_outputs.txt
+++ b/.circle/data/ds054_outputs.txt
@@ -16,8 +16,8 @@ ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_space-MNI152NLin2009cAsym_clas
 ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_space-MNI152NLin2009cAsym_dtissue.nii.gz
 ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_space-MNI152NLin2009cAsym_preproc.nii.gz
 ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_space-MNI152NLin2009cAsym_target-T1w_warp.h5
+ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_space-orig_target-T1w_affine.txt
 ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_target-MNI152NLin2009cAsym_warp.h5
-ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_target-T1w_affine.txt
 ds054/out/fmriprep/sub-100185/func
 ds054/out/fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_bold_confounds.tsv
 ds054/out/fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_bold_space-MNI152NLin2009cAsym_brainmask.nii.gz

--- a/.circle/data/ds054_outputs.txt
+++ b/.circle/data/ds054_outputs.txt
@@ -17,6 +17,7 @@ ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_space-MNI152NLin2009cAsym_dtis
 ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_space-MNI152NLin2009cAsym_preproc.nii.gz
 ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_space-MNI152NLin2009cAsym_target-T1w_warp.h5
 ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_target-MNI152NLin2009cAsym_warp.h5
+ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_target-T1w_affine.txt
 ds054/out/fmriprep/sub-100185/func
 ds054/out/fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_bold_confounds.tsv
 ds054/out/fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_bold_space-MNI152NLin2009cAsym_brainmask.nii.gz

--- a/fmriprep/interfaces/__init__.py
+++ b/fmriprep/interfaces/__init__.py
@@ -13,7 +13,7 @@ from .freesurfer import (
 )
 from .surf import NormalizeSurf, GiftiNameSource, GiftiSetAnatomicalStructure
 from .reports import SubjectSummary, FunctionalSummary, AboutSummary
-from .utils import TPM2ROI, AddTPMs, AddTSVHeader
+from .utils import TPM2ROI, AddTPMs, AddTSVHeader, ConcatAffines
 from .fmap import FieldEnhance
 from .confounds import GatherConfounds, ICAConfounds
 from .itk import MCFLIRT2ITK, MultiApplyTransforms

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -174,6 +174,7 @@ def init_anat_preproc_wf(skull_strip_template, output_spaces, template, debug,
         fields=['t1_preproc', 't1_brain', 't1_mask', 't1_seg', 't1_tpms',
                 't1_2_mni', 't1_2_mni_forward_transform', 't1_2_mni_reverse_transform',
                 'mni_mask', 'mni_seg', 'mni_tpms',
+                'template_transforms',
                 'subjects_dir', 'subject_id', 't1_2_fsnative_forward_transform',
                 't1_2_fsnative_reverse_transform', 'surfaces']),
         name='outputnode')
@@ -243,6 +244,9 @@ def init_anat_preproc_wf(skull_strip_template, output_spaces, template, debug,
         name='mni_tpms'
     )
 
+    lta_to_fsl = pe.MapNode(fs.utils.LTAConvert(out_fsl=True), iterfield=['in_lta'],
+                            name='lta_to_fsl')
+
     def set_threads(in_list, maximum):
         return min(len(in_list), maximum)
 
@@ -264,6 +268,7 @@ def init_anat_preproc_wf(skull_strip_template, output_spaces, template, debug,
                                           ('outputnode.out_mask', 't1_mask')]),
         (t1_seg, outputnode, [('tissue_class_map', 't1_seg'),
                               ('probability_maps', 't1_tpms')]),
+        (t1_merge, lta_to_fsl, [('transform_outputs', 'in_lta')]),
     ])
 
     if 'template' in output_spaces:

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -227,7 +227,7 @@ def init_anat_preproc_wf(skull_strip_template, output_spaces, template, debug,
 
     workflow.connect([
         (inputnode, anat_template_wf, [('t1w', 'inputnode.t1w')]),
-        (anat_template_wf, skullstrip_wf, [('outputnode.t1_template', 'inputnode.in_file')]),
+        (anat_template_wf, skullstrip_ants_wf, [('outputnode.t1_template', 'inputnode.in_file')]),
         (skullstrip_ants_wf, t1_seg, [('outputnode.out_file', 'in_files')]),
         (skullstrip_ants_wf, outputnode, [('outputnode.bias_corrected', 't1_preproc'),
                                           ('outputnode.out_file', 't1_brain'),
@@ -950,7 +950,7 @@ def init_anat_derivatives_wf(output_dir, output_spaces, template, freesurfer,
     t1_name = pe.Node(niu.Function(function=fix_multi_T1w_source_name), name='t1_name')
 
     ds_t1_template_transforms = pe.MapNode(
-        DerivativesDataSink(base_directory=output_dir, suffix='space-T1w'),
+        DerivativesDataSink(base_directory=output_dir, suffix='target-T1w'),
         iterfield=['source_file', 'in_file'],
         name='ds_t1_template_transforms', run_without_submitting=True)
 
@@ -1039,7 +1039,7 @@ def init_anat_derivatives_wf(output_dir, output_spaces, template, freesurfer,
     if freesurfer:
         workflow.connect([
             (inputnode, lta_2_itk, [('t1_2_fsnative_forward_transform', 'in_lta')]),
-            (inputnode, ds_t1_fsnative, [('source_file', 'source_file')]),
+            (t1_name, ds_t1_fsnative, [('out', 'source_file')]),
             (lta_2_itk, ds_t1_fsnative, [('out_itk', 'in_file')]),
             (inputnode, name_surfs, [('surfaces', 'in_file')]),
             (inputnode, ds_surfs, [('surfaces', 'in_file')]),

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -191,6 +191,7 @@ def init_anat_preproc_wf(skull_strip_template, output_spaces, template, debug,
                             subsample_threshold=200,
                             fixed_timepoint=not longitudinal,
                             no_iteration=not longitudinal,
+                            transform_outputs=True,
                             ),
         name='t1_merge')
 

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -1002,12 +1002,12 @@ def init_anat_derivatives_wf(output_dir, output_spaces, template, freesurfer,
                             suffix=suffix_fmt(template, 'T1w', 'warp')),
         name='ds_t1_mni_inv_warp', run_without_submitting=True)
 
-    suffix_fmt = 'target-{}_{}'.format
     ds_t1_template_transforms = pe.MapNode(
-        DerivativesDataSink(base_directory=output_dir, suffix=suffix_fmt('T1w', 'affine')),
+        DerivativesDataSink(base_directory=output_dir, suffix=suffix_fmt('orig', 'T1w', 'affine')),
         iterfield=['source_file', 'in_file'],
         name='ds_t1_template_transforms', run_without_submitting=True)
 
+    suffix_fmt = 'target-{}_{}'.format
     ds_t1_mni_warp = pe.Node(
         DerivativesDataSink(base_directory=output_dir, suffix=suffix_fmt(template, 'warp')),
         name='ds_t1_mni_warp', run_without_submitting=True)


### PR DESCRIPTION
I took a little time to clean this up post 1.0.0-rc6, including some lessons learned regarding affine derivatives.

Current status:

- This creates a simple transform from each input T1w file to the T1w space (defined by `T1w_preproc.nii.gz`)
- It places it in the associated derivative directory of the input file, i.e. in a session-specific `anat/` directory

Decisions going forward:

- Is this worthwhile?
- Should we organize it differently?
- Should we give the template and spaces/affines more generally their own page to make crystal clear exactly how each non-identical affine relates to each other and how to translate from one to another?

-----

Open to critiques. @satra, this one's for you.

Closes #624.