### PR TITLE
[RTM] ENH: Erode WM mask by proportion

### DIFF
--- a/fmriprep/interfaces/utils.py
+++ b/fmriprep/interfaces/utils.py
@@ -192,7 +192,7 @@ def _tpm2roi(t1_tpm, t1_mask, bold_mask, mask_erosion_mm=0, erosion_mm=0, pthres
         eroded_mask_file = os.path.abspath("eroded_mask.nii.gz")
 
         mask_img = nb.load(t1_mask)
-        iter_n = int(mask_erosion_mm / max(mask_img.header.get_zooms()))
+        iter_n = max(int(mask_erosion_mm / max(mask_img.header.get_zooms())), 1)
         mask_data = nd.binary_erosion(mask_img.get_data().astype(np.uint8), iterations=iter_n)
 
         # Resample to BOLD and save
@@ -206,7 +206,7 @@ def _tpm2roi(t1_tpm, t1_mask, bold_mask, mask_erosion_mm=0, erosion_mm=0, pthres
 
     # shrinking
     if erosion_mm:
-        iter_n = int(erosion_mm / max(tpm_img.header.get_zooms()))
+        iter_n = max(int(erosion_mm / max(tpm_img.header.get_zooms())), 1)
         probability_map_data = nd.binary_erosion(probability_map_data, iterations=iter_n)
 
     # Create image to resample

--- a/fmriprep/workflows/confounds.py
+++ b/fmriprep/workflows/confounds.py
@@ -141,7 +141,9 @@ def init_bold_confs_wf(bold_file_size_gb, use_aroma, ignore_aroma_err, metadata,
                        name="acompcor", mem_gb=bold_file_size_gb * 3)
 
     csf_roi = pe.Node(TPM2ROI(erode_mm=0, mask_erode_mm=30), name='csf_roi')
-    wm_roi = pe.Node(TPM2ROI(erode_mm=6, mask_erode_mm=10), name='wm_roi')
+    wm_roi = pe.Node(TPM2ROI(erode_prop=0.6,
+                             mask_erode_prop=0.6**3),  # 0.6 = radius; 0.6^3 = volume
+                     name='wm_roi')
     merge_rois = pe.Node(niu.Merge(2), name='merge_rois', run_without_submitting=True, mem_gb=0.01)
     combine_rois = pe.Node(CombineROIs(), name='combine_rois')
     concat_rois = pe.Node(ConcatROIs(), name='concat_rois')


### PR DESCRIPTION
This change erodes WM mask (approximately) to target proportions of original white matter voxel counts.

Closes #716 