### PR TITLE
[RTM] ENH: Register FreeSurfer template to FMRIPREP template

### DIFF
--- a/.circle/data/ds005_outputs.txt
+++ b/.circle/data/ds005_outputs.txt
@@ -24,6 +24,7 @@ ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_class-WM_pro
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_dtissue.nii.gz
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_preproc.nii.gz
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_warp.h5
+ds005/out/fmriprep/sub-01/anat/sub-01_T1w_target-fsnative_affine.txt
 ds005/out/fmriprep/sub-01/func
 ds005/out/fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_bold_AROMAnoiseICs.csv
 ds005/out/fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_bold_confounds.tsv

--- a/.circle/data/ds005_outputs.txt
+++ b/.circle/data/ds005_outputs.txt
@@ -23,8 +23,8 @@ ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_class-GM_pro
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_class-WM_probtissue.nii.gz
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_dtissue.nii.gz
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_preproc.nii.gz
-ds005/out/fmriprep/sub-01/anat/sub-01_T1w_space-MNI152NLin2009cAsym_warp.h5
 ds005/out/fmriprep/sub-01/anat/sub-01_T1w_target-fsnative_affine.txt
+ds005/out/fmriprep/sub-01/anat/sub-01_T1w_target-MNI152NLin2009cAsym_warp.h5
 ds005/out/fmriprep/sub-01/func
 ds005/out/fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_bold_AROMAnoiseICs.csv
 ds005/out/fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_bold_confounds.tsv

--- a/.circle/data/ds054_outputs.txt
+++ b/.circle/data/ds054_outputs.txt
@@ -15,7 +15,7 @@ ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_space-MNI152NLin2009cAsym_clas
 ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_space-MNI152NLin2009cAsym_class-WM_probtissue.nii.gz
 ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_space-MNI152NLin2009cAsym_dtissue.nii.gz
 ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_space-MNI152NLin2009cAsym_preproc.nii.gz
-ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_space-MNI152NLin2009cAsym_warp.h5
+ds054/out/fmriprep/sub-100185/anat/sub-100185_T1w_target-MNI152NLin2009cAsym_warp.h5
 ds054/out/fmriprep/sub-100185/func
 ds054/out/fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_bold_confounds.tsv
 ds054/out/fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_bold_space-MNI152NLin2009cAsym_brainmask.nii.gz

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -429,12 +429,12 @@ Derivatives
 There are additional files, called "Derivatives", outputted to ``<output dir>/fmriprep/sub-<subject_label>/``.
 See the `BIDS Derivatives`_ spec for more information.
 
-Derivatives related to t1w files are in the ``anat`` subfolder:
+Derivatives related to T1w files are in the ``anat`` subfolder:
 
 - ``*T1w_brainmask.nii.gz`` Brain mask derived using ANTS or AFNI, depending on the command flag ``--skull-strip-ants``
 - ``*T1w_space-MNI152NLin2009cAsym_brainmask.nii.gz`` Same as above, but in MNI space.
 - ``*T1w_dtissue.nii.gz`` Tissue class map derived using FAST.
-- ``*T1w_preproc.nii.gz`` Bias field corrected t1w file, using ANTS' N4BiasFieldCorrection
+- ``*T1w_preproc.nii.gz`` Bias field corrected T1w file, using ANTS' N4BiasFieldCorrection
 - ``*T1w_smoothwm.[LR].surf.gii`` Smoothed GrayWhite surfaces
 - ``*T1w_pial.[LR].surf.gii`` Pial surfaces
 - ``*T1w_midthickness.[LR].surf.gii`` MidThickness surfaces
@@ -443,7 +443,8 @@ Derivatives related to t1w files are in the ``anat`` subfolder:
 - ``*T1w_space-MNI152NLin2009cAsym_class-CSF_probtissue.nii.gz``
 - ``*T1w_space-MNI152NLin2009cAsym_class-GM_probtissue.nii.gz``
 - ``*T1w_space-MNI152NLin2009cAsym_class-WM_probtissue.nii.gz`` Probability tissue maps, transformed into MNI space
-- ``*T1w_target-MNI152NLin2009cAsym_warp.h5`` Composite (warp and affine) transform to transform t1w into MNI space
+- ``*T1w_target-MNI152NLin2009cAsym_warp.h5`` Composite (warp and affine) transform to transform T1w into MNI space
+- ``*T1w_target-fsnative_affine.txt`` Affine transform to transform T1w into ``fsnative`` space
 
 Derivatives related to EPI files are in the ``func`` subfolder.
 

--- a/fmriprep/interfaces/surf.py
+++ b/fmriprep/interfaces/surf.py
@@ -227,6 +227,18 @@ def normalize_surfs(in_file, transform_file):
 
 
 def load_transform(fname):
+    """Load affine transform from file
+
+    Parameters
+    ----------
+    fname : str or None
+        Filename of an LTA or FSL-style MAT transform file.
+        If ``None``, return an identity transform
+
+    Returns
+    -------
+    affine : (4, 4) numpy.ndarray
+    """
     if fname is None:
         return np.eye(4)
 

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -587,6 +587,8 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
         # reoriented image
         (inputnode, fsnative_2_t1_xfm, [('t1w', 'target_file')]),
         (autorecon1, fsnative_2_t1_xfm, [('T1', 'source_file')]),
+        (fsnative_2_t1_xfm, gifti_surface_wf, [
+            ('out_reg_file', 'inputnode.t1_2_fsnative_reverse_transform')]),
         # Output
         (autorecon_resume_wf, outputnode, [('outputnode.subjects_dir', 'subjects_dir'),
                                            ('outputnode.subject_id', 'subject_id'),
@@ -745,6 +747,8 @@ def init_gifti_surface_wf(name='gifti_surface_wf'):
             FreeSurfer SUBJECTS_DIR
         subject_id
             FreeSurfer subject ID
+        t1_2_fsnative_reverse_transform
+            LTA formatted affine transform file (inverse)
 
     **Outputs**
 
@@ -755,7 +759,9 @@ def init_gifti_surface_wf(name='gifti_surface_wf'):
     """
     workflow = pe.Workflow(name=name)
 
-    inputnode = pe.Node(niu.IdentityInterface(['subjects_dir', 'subject_id']), name='inputnode')
+    inputnode = pe.Node(niu.IdentityInterface(['subjects_dir', 'subject_id',
+                                               't1_2_fsnative_reverse_transform']),
+                        name='inputnode')
     outputnode = pe.Node(niu.IdentityInterface(['surfaces']), name='outputnode')
 
     get_surfaces = pe.Node(nio.FreeSurferSource(), name='get_surfaces')
@@ -790,6 +796,7 @@ def init_gifti_surface_wf(name='gifti_surface_wf'):
         (save_midthickness, surface_list, [('out_file', 'in4')]),
         (surface_list, fs_2_gii, [('out', 'in_file')]),
         (fs_2_gii, fix_surfs, [('converted', 'in_file')]),
+        (inputnode, fix_surfs, [('t1_2_fsnative_reverse_transform', 'transform_file')]),
         (fix_surfs, outputnode, [('out_file', 'surfaces')]),
     ])
     return workflow

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -917,16 +917,16 @@ def init_anat_derivatives_wf(output_dir, output_spaces, template, freesurfer,
         name='ds_mni_tpms', run_without_submitting=True)
     ds_mni_tpms.inputs.extra_values = ['CSF', 'GM', 'WM']
 
+    # Transforms
+    suffix_fmt = 'target-{}_{}'.format
     ds_t1_mni_warp = pe.Node(
         DerivativesDataSink(base_directory=output_dir, suffix=suffix_fmt(template, 'warp')),
         name='ds_t1_mni_warp', run_without_submitting=True)
 
-    # Freesurfer nodes
     lta_2_itk = pe.Node(fs.utils.LTAConvert(out_itk=True, invert=True), name='lta_2_itk')
 
     ds_t1_fsnative = pe.Node(
-        DerivativesDataSink(base_directory=output_dir,
-                            suffix='target-fsnative_affine'),
+        DerivativesDataSink(base_directory=output_dir, suffix=suffix_fmt('fsnative', 'affine')),
         name='ds_t1_fsnative', run_without_submitting=True)
 
     name_surfs = pe.MapNode(GiftiNameSource(pattern=r'(?P<LR>[lr])h.(?P<surf>.+)_converted.gii',


### PR DESCRIPTION
Addresses issue raised in https://github.com/poldracklab/fmriprep/pull/726#issuecomment-333183529.

Given this, I think we should output the registration transform, to give users the tools to move between FMRIPREP and FreeSurfer spaces. I'd recommend the LTA format, since that has more metadata about the source and target spaces; if users need to convert to other formats, they will presumably have access to the `LTAConvert` tool.

To do:

* [x] Ensure output surfaces are aligned with T1_preproc
* [x] Affine