### PR TITLE
[RTM] DOCKER: Download templates before installing fmriprep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,8 +146,15 @@ RUN apt-get update && \
 ENV MKL_NUM_THREADS=1 \
     OMP_NUM_THREADS=1
 
-# Installing dev requirements (packages that are not in pypi)
 WORKDIR /root/
+
+# Precaching atlases
+ENV CRN_SHARED_DATA /niworkflows_data
+ADD docker/scripts/get_templates.sh get_templates.sh
+RUN mkdir $CRN_SHARED_DATA && \
+    /root/get_templates.sh
+
+# Installing dev requirements (packages that are not in pypi)
 ADD requirements.txt requirements.txt
 RUN pip install -r requirements.txt && \
     rm -rf ~/.cache/pip
@@ -157,13 +164,6 @@ COPY . /root/src/fmriprep
 RUN cd /root/src/fmriprep && \
     pip install .[all] && \
     rm -rf ~/.cache/pip
-
-# Precaching atlases
-RUN mkdir /niworkflows_data
-ENV CRN_SHARED_DATA /niworkflows_data
-RUN python -c 'from niworkflows.data.getters import get_mni_template_ras; get_mni_template_ras()' && \
-    python -c 'from niworkflows.data.getters import get_mni_icbm152_nlin_asym_09c; get_mni_icbm152_nlin_asym_09c()' && \
-    python -c 'from niworkflows.data.getters import get_ants_oasis_template_ras; get_ants_oasis_template_ras()'
 
 RUN ldconfig
 

--- a/docker/scripts/get_templates.sh
+++ b/docker/scripts/get_templates.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+MNI_TEMPLATE="https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/57f32a799ad5a101f977eb77"
+MNI_SHA256="c7b7ca347c4bb8b7956d1d10515702f0b5e3a8c630e446a1c980e9bf6a549100"
+ASYM_09C_TEMPLATE="https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/580705089ad5a101f17944a9"
+ASYM_09C_SHA256="a24699ba0d13f72d0f8934cc211cb80bfd9c9a077b481d9b64295cf5275235a9"
+OASIS_TEMPLATE="https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/584123a29ad5a1020913609d"
+OASIS_SHA256="d87300e91346c16f55baf6f54f5f990bc020b61e8d5df9bcc3abb0cc4b943113"
+
+GET(){
+    URL=$1; SHA256=$2;
+    mkfifo pipe.tar.gz
+    cat pipe.tar.gz | tar zxv -C $CRN_SHARED_DATA &
+    SHASUM=$(curl -sSL $URL | tee pipe.tar.gz | sha256sum | cut -d\  -f 1)
+    rm pipe.tar.gz
+
+    if [[ "$SHASUM" != "$SHA256" ]]; then
+        echo "Failed checksum!"
+        return 1
+    fi
+    return 0
+}
+
+set -e
+echo "Getting MNI template"
+GET "$MNI_TEMPLATE" "$MNI_SHA256"
+echo "Getting MNI152NLin2009cAsym template"
+GET "$ASYM_09C_TEMPLATE" "$ASYM_09C_SHA256"
+echo "Getting OASIS template"
+GET "$OASIS_TEMPLATE" "$OASIS_SHA256"
+echo "Done!"


### PR DESCRIPTION
Adapted from #729.

Will only shave a minute off of builds, but it is a lot of unnecessarily repeated work.