### PR TITLE
[RTM] Add James D. Kent to .zenodo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -39,6 +39,11 @@
       "orcid": "0000-0002-9402-2184"
     },
     {
+      "name": "Kent, James D.",
+      "affiliation": "Neuroscience Program, University of Iowa",
+      "orcid": "0000-0002-4892-2659"
+    },
+    {
       "name": "Goncalves, Mathias",
       "affiliation": "MIT",
       "orcid": "0000-0002-7252-7771"


### PR DESCRIPTION
Ran across this commit in the [network](https://github.com/poldracklab/fmriprep/network). Inclusion is overdue, and should go in before next release.