### PR TITLE
[RTM] RF: Assume phase-encoding direction is A-P unless specified L-R

### DIFF
--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -33,6 +33,7 @@ SUBJECT_TEMPLATE = """\t<ul class="elem-desc">
 
 FUNCTIONAL_TEMPLATE = """\t\t<h3 class="elem-title">Summary</h3>
 \t\t<ul class="elem-desc">
+\t\t\t<li>Detected phase-encoding (PE) direction: {pedir}</li>
 \t\t\t<li>Slice timing correction: {stc}</li>
 \t\t\t<li>Susceptibility distortion correction: {sdc}</li>
 \t\t\t<li>Registration: {registration}</li>
@@ -141,6 +142,8 @@ class FunctionalSummaryInputSpec(BaseInterfaceInputSpec):
     distortion_correction = traits.Enum('epi', 'fieldmap', 'phasediff', 'SyN', 'None',
                                         desc='Susceptibility distortion correction method',
                                         mandatory=True)
+    pe_direction = traits.Enum(None, 'i', 'i-', 'j', 'j-', mandatory=True,
+                               desc='Phase-encoding direction detected')
     registration = traits.Enum('FLIRT', 'bbregister', mandatory=True,
                                desc='Functional/anatomical registration method')
     output_spaces = traits.List(desc='Target spaces')
@@ -163,7 +166,11 @@ class FunctionalSummary(SummaryInterface):
         reg = {'FLIRT': 'FLIRT with boundary-based registration (BBR) metric',
                'bbregister': 'FreeSurfer boundary-based registration (bbregister)'
                }[self.inputs.registration]
-        return FUNCTIONAL_TEMPLATE.format(stc=stc, sdc=sdc, registration=reg,
+        if self.inputs.pe_direction is None:
+            pedir = 'MISSING - Assuming Anterior-Posterior'
+        else:
+            pedir = {'i': 'Left-Right', 'j': 'Anterior-Posterior'}[self.inputs.pe_direction[0]]
+        return FUNCTIONAL_TEMPLATE.format(pedir=pedir, stc=stc, sdc=sdc, registration=reg,
                                           output_spaces=', '.join(self.inputs.output_spaces),
                                           confounds=', '.join(self.inputs.confounds))
 

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -153,7 +153,7 @@ def init_anat_preproc_wf(skull_strip_ants, output_spaces, template, debug, frees
             FreeSurfer SUBJECTS_DIR
         subject_id
             FreeSurfer subject ID
-        fs_2_t1_transform
+        t1_2_fsnative_reverse_transform
             Affine transform from FreeSurfer subject space to T1w space
         surfaces
             GIFTI surfaces (gray/white boundary, midthickness, pial, inflated)
@@ -174,7 +174,7 @@ def init_anat_preproc_wf(skull_strip_ants, output_spaces, template, debug, frees
         fields=['t1_preproc', 't1_brain', 't1_mask', 't1_seg', 't1_tpms',
                 't1_2_mni', 't1_2_mni_forward_transform', 't1_2_mni_reverse_transform',
                 'mni_mask', 'mni_seg', 'mni_tpms',
-                'subjects_dir', 'subject_id', 'fs_2_t1_transform', 'surfaces']),
+                'subjects_dir', 'subject_id', 't1_2_fsnative_reverse_transform', 'surfaces']),
         name='outputnode')
 
     # 0. Reorient T1w image(s) to RAS and resample to common voxel space
@@ -314,7 +314,7 @@ def init_anat_preproc_wf(skull_strip_ants, output_spaces, template, debug, frees
             (surface_recon_wf, outputnode, [
                 ('outputnode.subjects_dir', 'subjects_dir'),
                 ('outputnode.subject_id', 'subject_id'),
-                ('outputnode.fs_2_t1_transform', 'fs_2_t1_transform'),
+                ('outputnode.t1_2_fsnative_reverse_transform', 't1_2_fsnative_reverse_transform'),
                 ('outputnode.surfaces', 'surfaces')]),
         ])
 
@@ -499,7 +499,7 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
             FreeSurfer SUBJECTS_DIR
         subject_id
             FreeSurfer subject ID
-        fs_2_t1_transform
+        t1_2_fsnative_reverse_transform
             FSL-style affine matrix translating from FreeSurfer T1.mgz to T1w
         surfaces
             GIFTI surfaces for gray/white matter boundary, pial surface,
@@ -521,7 +521,8 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
         name='inputnode')
     outputnode = pe.Node(
         niu.IdentityInterface(
-            fields=['subjects_dir', 'subject_id', 'fs_2_t1_transform', 'surfaces', 'out_report']),
+            fields=['subjects_dir', 'subject_id', 't1_2_fsnative_reverse_transform', 'surfaces',
+                    'out_report']),
         name='outputnode')
 
     recon_config = pe.Node(FSDetectInputs(hires_enabled=hires), name='recon_config',
@@ -577,7 +578,7 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
                                            ('outputnode.subject_id', 'subject_id'),
                                            ('outputnode.out_report', 'out_report')]),
         (gifti_surface_wf, outputnode, [('outputnode.surfaces', 'surfaces')]),
-        (fs_transform, outputnode, [('fsl_file', 'fs_2_t1_transform')]),
+        (fs_transform, outputnode, [('fsl_file', 't1_2_fsnative_reverse_transform')]),
     ])
 
     return workflow

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -437,7 +437,8 @@ def init_single_subject_wf(subject_id, task_id, name,
                 (anat_preproc_wf, func_preproc_wf,
                  [('outputnode.subjects_dir', 'inputnode.subjects_dir'),
                   ('outputnode.subject_id', 'inputnode.subject_id'),
-                  ('outputnode.fs_2_t1_transform', 'inputnode.fs_2_t1_transform')]),
+                  ('outputnode.t1_2_fsnative_reverse_transform',
+                   'inputnode.t1_2_fsnative_reverse_transform')]),
             ])
 
     return workflow

--- a/fmriprep/workflows/bold.py
+++ b/fmriprep/workflows/bold.py
@@ -878,8 +878,6 @@ def init_bold_reg_wf(freesurfer, bold2t1w_dof, bold_file_size_gb, omp_nthreads,
             Motion-corrected BOLD series in T1 space
         bold_mask_t1
             BOLD mask in T1 space
-        fs_reg_file
-            Affine transform from ``ref_bold_brain`` to T1 space (FreeSurfer ``reg`` format)
         out_report
             Reportlet visualizing quality of registration
 
@@ -896,7 +894,7 @@ def init_bold_reg_wf(freesurfer, bold2t1w_dof, bold_file_size_gb, omp_nthreads,
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['mat_bold_to_t1', 'mat_t1_to_bold',
                                       'itk_bold_to_t1', 'itk_t1_to_bold',
-                                      'bold_t1', 'bold_mask_t1', 'fs_reg_file',
+                                      'bold_t1', 'bold_mask_t1',
                                       'out_report']),
         name='outputnode'
     )
@@ -932,7 +930,6 @@ def init_bold_reg_wf(freesurfer, bold2t1w_dof, bold_file_size_gb, omp_nthreads,
         (bbr_wf, fsl2itk_fwd, [('outputnode.out_matrix_file', 'transform_file')]),
         (invt_bbr, fsl2itk_inv, [('out_file', 'transform_file')]),
         (bbr_wf, outputnode, [('outputnode.out_matrix_file', 'mat_bold_to_t1'),
-                              ('outputnode.out_reg_file', 'fs_reg_file'),
                               ('outputnode.out_report', 'out_report')]),
         (invt_bbr, outputnode, [('out_file', 'mat_t1_to_bold')]),
         (fsl2itk_fwd, outputnode, [('itk_transform', 'itk_bold_to_t1')]),

--- a/fmriprep/workflows/bold.py
+++ b/fmriprep/workflows/bold.py
@@ -897,9 +897,9 @@ def init_bold_reg_wf(freesurfer, bold2t1w_dof, bold_file_size_gb, omp_nthreads,
     )
 
     if freesurfer:
-        bbr_wf = init_bbreg_wf(bold2t1w_dof, report=True)
+        bbr_wf = init_bbreg_wf(bold2t1w_dof)
     else:
-        bbr_wf = init_fsl_bbr_wf(bold2t1w_dof, report=True)
+        bbr_wf = init_fsl_bbr_wf(bold2t1w_dof)
 
     workflow.connect([
         (inputnode, bbr_wf, [

--- a/fmriprep/workflows/bold.py
+++ b/fmriprep/workflows/bold.py
@@ -866,10 +866,6 @@ def init_bold_reg_wf(freesurfer, bold2t1w_dof, bold_file_size_gb, omp_nthreads,
 
     Outputs
 
-        mat_bold_to_t1
-            Affine transform from ``ref_bold_brain`` to T1 space (FSL format)
-        mat_t1_to_bold
-            Affine transform from T1 space to BOLD space (FSL format)
         itk_bold_to_t1
             Affine transform from ``ref_bold_brain`` to T1 space (ITK format)
         itk_t1_to_bold
@@ -892,8 +888,7 @@ def init_bold_reg_wf(freesurfer, bold2t1w_dof, bold_file_size_gb, omp_nthreads,
         name='inputnode'
     )
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=['mat_bold_to_t1', 'mat_t1_to_bold',
-                                      'itk_bold_to_t1', 'itk_t1_to_bold',
+        niu.IdentityInterface(fields=['itk_bold_to_t1', 'itk_t1_to_bold',
                                       'bold_t1', 'bold_mask_t1',
                                       'out_report']),
         name='outputnode'
@@ -929,9 +924,7 @@ def init_bold_reg_wf(freesurfer, bold2t1w_dof, bold_file_size_gb, omp_nthreads,
         (bbr_wf, invt_bbr, [('outputnode.out_matrix_file', 'in_file')]),
         (bbr_wf, fsl2itk_fwd, [('outputnode.out_matrix_file', 'transform_file')]),
         (invt_bbr, fsl2itk_inv, [('out_file', 'transform_file')]),
-        (bbr_wf, outputnode, [('outputnode.out_matrix_file', 'mat_bold_to_t1'),
-                              ('outputnode.out_report', 'out_report')]),
-        (invt_bbr, outputnode, [('out_file', 'mat_t1_to_bold')]),
+        (bbr_wf, outputnode, [('outputnode.out_report', 'out_report')]),
         (fsl2itk_fwd, outputnode, [('itk_transform', 'itk_bold_to_t1')]),
         (fsl2itk_inv, outputnode, [('itk_transform', 'itk_t1_to_bold')]),
     ])

--- a/fmriprep/workflows/bold.py
+++ b/fmriprep/workflows/bold.py
@@ -222,6 +222,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
             'magnitude2': 'sub-03/ses-2/fmap/sub-03_ses-2_run-1_magnitude2.nii.gz'
         }]
         run_stc = True
+        bold_pe = 'j'
     else:
         metadata = layout.get_metadata(bold_file)
         # Find fieldmaps. Options: (phase1|phase2|phasediff|epi|fieldmap)
@@ -232,6 +233,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
         run_stc = ("SliceTiming" in metadata and
                    'slicetiming' not in ignore and
                    (_get_series_len(bold_file) > 4 or "TooShort"))
+        bold_pe = metadata.get("PhaseEncodingDirection")
 
     # TODO: To be removed (supported fieldmaps):
     if not set([fmap['type'] for fmap in fmaps]).intersection(['phasediff', 'fieldmap', 'epi']):
@@ -254,7 +256,8 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
                 'aroma_noise_ics', 'melodic_mix', 'nonaggr_denoised_file']),
         name='outputnode')
 
-    summary = pe.Node(FunctionalSummary(output_spaces=output_spaces), name='summary',
+    summary = pe.Node(FunctionalSummary(output_spaces=output_spaces,
+                                        pe_direction=bold_pe), name='summary',
                       mem_gb=0.05)
     summary.inputs.slice_timing = run_stc
     summary.inputs.registration = 'bbregister' if freesurfer else 'FLIRT'
@@ -462,16 +465,14 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
 
     if use_syn:
         nonlinear_sdc_wf = init_nonlinear_sdc_wf(
-            bold_file=bold_file, layout=layout, freesurfer=freesurfer, bold2t1w_dof=bold2t1w_dof,
+            bold_file=bold_file, bold_pe=bold_pe, freesurfer=freesurfer, bold2t1w_dof=bold2t1w_dof,
             template=template, omp_nthreads=omp_nthreads)
 
         workflow.connect([
             (inputnode, nonlinear_sdc_wf, [
                 ('t1_brain', 'inputnode.t1_brain'),
                 ('t1_seg', 'inputnode.t1_seg'),
-                ('t1_2_mni_reverse_transform', 'inputnode.t1_2_mni_reverse_transform'),
-                ('subjects_dir', 'inputnode.subjects_dir'),
-                ('subject_id', 'inputnode.subject_id')]),
+                ('t1_2_mni_reverse_transform', 'inputnode.t1_2_mni_reverse_transform')]),
             (bold_reference_wf, nonlinear_sdc_wf, [
                 ('outputnode.ref_image_brain', 'inputnode.bold_ref')]),
             (nonlinear_sdc_wf, func_reports_wf, [
@@ -1242,7 +1243,7 @@ def init_bold_mni_trans_wf(template, bold_file_size_gb, omp_nthreads,
     return workflow
 
 
-def init_nonlinear_sdc_wf(bold_file, layout, freesurfer, bold2t1w_dof,
+def init_nonlinear_sdc_wf(bold_file, bold_pe, freesurfer, bold2t1w_dof,
                           template, omp_nthreads,
                           atlas_threshold=3, name='nonlinear_sdc_wf'):
     """
@@ -1251,11 +1252,8 @@ def init_nonlinear_sdc_wf(bold_file, layout, freesurfer, bold2t1w_dof,
     normalization (SyN) and the average fieldmap atlas described in
     [Treiber2016]_.
 
-    If the phase-encoding (PE) direction is known, the SyN deformation is
-    restricted to that direction; otherwise, deformation fields are calculated
-    for both the right-left and anterior-posterior directions, and selected
-    based on the unwarped file that can be aligned to the T1w image with the
-    lowest boundary-based registration (BBR) cost.
+    SyN deformation is restricted to the phase-encoding (PE) direction.
+    If no PE direction is specified, anterior-posterior PE is assumed.
 
     SyN deformation is also restricted to regions that are expected to have a
     >3mm (approximately 1 voxel) warp, based on the fieldmap atlas.
@@ -1270,7 +1268,7 @@ def init_nonlinear_sdc_wf(bold_file, layout, freesurfer, bold2t1w_dof,
         from fmriprep.workflows.bold import init_nonlinear_sdc_wf
         wf = init_nonlinear_sdc_wf(
             bold_file='/dataset/sub-01/func/sub-01_task-rest_bold.nii.gz',
-            layout=None,
+            bold_pe='j',
             freesurfer=True,
             bold2t1w_dof=9,
             template='MNI152NLin2009cAsym',
@@ -1286,10 +1284,6 @@ def init_nonlinear_sdc_wf(bold_file, layout, freesurfer, bold2t1w_dof,
             FAST segmentation white and gray matter, in native T1w space
         t1_2_mni_reverse_transform
             inverse registration transform of T1w image to MNI template
-        subjects_dir
-            FreeSurfer subjects directory (if applicable)
-        subject_id
-            FreeSurfer subject_id (if applicable)
 
     Outputs
 
@@ -1320,7 +1314,7 @@ def init_nonlinear_sdc_wf(bold_file, layout, freesurfer, bold2t1w_dof,
     workflow = pe.Workflow(name=name)
     inputnode = pe.Node(
         niu.IdentityInterface(['t1_brain', 'bold_ref', 't1_2_mni_reverse_transform',
-                               'subjects_dir', 'subject_id', 't1_seg']),  # BBR requirements
+                               't1_seg']),
         name='inputnode')
     outputnode = pe.Node(
         niu.IdentityInterface(['out_reference_brain', 'out_mask', 'out_warp',
@@ -1369,22 +1363,13 @@ def init_nonlinear_sdc_wf(bold_file, layout, freesurfer, bold2t1w_dof,
                                 mem_gb=DEFAULT_MEMORY_MIN_GB)
     fixed_image_masks.inputs.in1 = 'NULL'
 
-    if layout is None:
-        bold_pe = None
-    else:
-        bold_pe = layout.get_metadata(bold_file).get("PhaseEncodingDirection")
-
     restrict_i = [[1, 0, 0], [1, 0, 0]]
     restrict_j = [[0, 1, 0], [0, 1, 0]]
 
-    syn_i = pe.Node(
+    syn = pe.Node(
         ants.Registration(from_file=syn_transform, num_threads=omp_nthreads,
-                          restrict_deformation=restrict_i),
-        name='syn_i', n_procs=omp_nthreads)
-    syn_j = pe.Node(
-        ants.Registration(from_file=syn_transform, num_threads=omp_nthreads,
-                          restrict_deformation=restrict_j),
-        name='syn_j', n_procs=omp_nthreads)
+                          restrict_deformation=restrict_i if bold_pe[0] == 'i' else restrict_j),
+        name='syn', n_procs=omp_nthreads)
 
     seg_2_ref = pe.Node(
         ants.ApplyTransforms(interpolation='NearestNeighbor', float=True,
@@ -1411,79 +1396,23 @@ def init_nonlinear_sdc_wf(bold_file, layout, freesurfer, bold2t1w_dof,
         (transform_list, atlas_2_ref, [('out', 'transforms')]),
         (atlas_2_ref, threshold_atlas, [('output_image', 'in_file')]),
         (threshold_atlas, fixed_image_masks, [('out_file', 'in2')]),
-    ])
-
-    if bold_pe is None:
-        if freesurfer:
-            bbr_i_wf = init_bbreg_wf(bold2t1w_dof, report=False, reregister=False, name='bbr_i_wf')
-            bbr_j_wf = init_bbreg_wf(bold2t1w_dof, report=False, reregister=False, name='bbr_j_wf')
-        else:
-            bbr_i_wf = init_fsl_bbr_wf(bold2t1w_dof, report=False, name='bbr_i_wf')
-            bbr_j_wf = init_fsl_bbr_wf(bold2t1w_dof, report=False, name='bbr_j_wf')
-
-        def select_outputs(cost_i, warped_image_i, forward_transforms_i,
-                           cost_j, warped_image_j, forward_transforms_j):
-            if cost_i < cost_j:
-                return warped_image_i, forward_transforms_i
-            else:
-                return warped_image_j, forward_transforms_j
-
-        pe_chooser = pe.Node(
-            niu.Function(function=select_outputs,
-                         output_names=['warped_image', 'forward_transforms']),
-            name='pe_chooser', mem_gb=DEFAULT_MEMORY_MIN_GB)
-
-        workflow.connect([(inputnode, syn_i, [('bold_ref', 'moving_image')]),
-                          (t1_2_ref, syn_i, [('output_image', 'fixed_image')]),
-                          (fixed_image_masks, syn_i, [('out', 'fixed_image_masks')]),
-                          (inputnode, syn_j, [('bold_ref', 'moving_image')]),
-                          (t1_2_ref, syn_j, [('output_image', 'fixed_image')]),
-                          (fixed_image_masks, syn_j, [('out', 'fixed_image_masks')]),
-                          (inputnode, bbr_i_wf, [('subjects_dir', 'inputnode.subjects_dir'),
-                                                 ('subject_id', 'inputnode.subject_id'),
-                                                 ('t1_seg', 'inputnode.t1_seg'),
-                                                 ('t1_brain', 'inputnode.t1_brain')]),
-                          (inputnode, bbr_j_wf, [('subjects_dir', 'inputnode.subjects_dir'),
-                                                 ('subject_id', 'inputnode.subject_id'),
-                                                 ('t1_seg', 'inputnode.t1_seg'),
-                                                 ('t1_brain', 'inputnode.t1_brain')]),
-                          (syn_i, bbr_i_wf, [('warped_image', 'inputnode.in_file')]),
-                          (syn_j, bbr_j_wf, [('warped_image', 'inputnode.in_file')]),
-                          (bbr_i_wf, pe_chooser, [('outputnode.final_cost', 'cost_i')]),
-                          (bbr_j_wf, pe_chooser, [('outputnode.final_cost', 'cost_j')]),
-                          (syn_i, pe_chooser, [('warped_image', 'warped_image_i'),
-                                               ('forward_transforms', 'forward_transforms_i')]),
-                          (syn_j, pe_chooser, [('warped_image', 'warped_image_j'),
-                                               ('forward_transforms', 'forward_transforms_j')]),
-                          ])
-        syn_out = pe_chooser
-    elif bold_pe[0] == 'i':
-        workflow.connect([(inputnode, syn_i, [('bold_ref', 'moving_image')]),
-                          (t1_2_ref, syn_i, [('output_image', 'fixed_image')]),
-                          (fixed_image_masks, syn_i, [('out', 'fixed_image_masks')]),
-                          ])
-        syn_out = syn_i
-    elif bold_pe[0] == 'j':
-        workflow.connect([(inputnode, syn_j, [('bold_ref', 'moving_image')]),
-                          (t1_2_ref, syn_j, [('output_image', 'fixed_image')]),
-                          (fixed_image_masks, syn_j, [('out', 'fixed_image_masks')]),
-                          ])
-        syn_out = syn_j
-
-    workflow.connect([(inputnode, seg_2_ref, [('t1_seg', 'input_image')]),
-                      (ref_2_t1, seg_2_ref, [('forward_transforms', 'transforms')]),
-                      (syn_out, seg_2_ref, [('warped_image', 'reference_image')]),
-                      (seg_2_ref, sel_wm, [('output_image', 'in_seg')]),
-                      (inputnode, syn_rpt, [('bold_ref', 'before')]),
-                      (syn_out, syn_rpt, [('warped_image', 'after')]),
-                      (sel_wm, syn_rpt, [('out', 'wm_seg')]),
-                      (syn_out, skullstrip_bold_wf, [('warped_image', 'inputnode.in_file')]),
-                      (syn_out, outputnode, [('forward_transforms', 'out_warp')]),
-                      (skullstrip_bold_wf, outputnode, [
-                          ('outputnode.skull_stripped_file', 'out_reference_brain'),
-                          ('outputnode.mask_file', 'out_mask'),
-                          ('outputnode.out_report', 'out_mask_report')]),
-                      (syn_rpt, outputnode, [('out_report', 'out_warp_report')])])
+        (inputnode, syn, [('bold_ref', 'moving_image')]),
+        (t1_2_ref, syn, [('output_image', 'fixed_image')]),
+        (fixed_image_masks, syn, [('out', 'fixed_image_masks')]),
+        (inputnode, seg_2_ref, [('t1_seg', 'input_image')]),
+        (ref_2_t1, seg_2_ref, [('forward_transforms', 'transforms')]),
+        (syn, seg_2_ref, [('warped_image', 'reference_image')]),
+        (seg_2_ref, sel_wm, [('output_image', 'in_seg')]),
+        (inputnode, syn_rpt, [('bold_ref', 'before')]),
+        (syn, syn_rpt, [('warped_image', 'after')]),
+        (sel_wm, syn_rpt, [('out', 'wm_seg')]),
+        (syn, skullstrip_bold_wf, [('warped_image', 'inputnode.in_file')]),
+        (syn, outputnode, [('forward_transforms', 'out_warp')]),
+        (skullstrip_bold_wf, outputnode, [
+            ('outputnode.skull_stripped_file', 'out_reference_brain'),
+            ('outputnode.mask_file', 'out_mask'),
+            ('outputnode.out_report', 'out_mask_report')]),
+        (syn_rpt, outputnode, [('out_report', 'out_warp_report')])])
 
     return workflow
 

--- a/fmriprep/workflows/util.py
+++ b/fmriprep/workflows/util.py
@@ -200,7 +200,7 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
 
         in_file
             Reference BOLD image to be registered
-        fs_2_t1_transform
+        t1_2_fsnative_reverse_transform
             FSL-style affine matrix translating from FreeSurfer T1.mgz to T1w
         subjects_dir
             FreeSurfer SUBJECTS_DIR
@@ -225,9 +225,10 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
     workflow = pe.Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(['in_file',
-                               'fs_2_t1_transform', 'subjects_dir', 'subject_id',  # BBRegister
-                               't1_seg', 't1_brain']),  # FLIRT BBR
+        niu.IdentityInterface([
+            'in_file',
+            't1_2_fsnative_reverse_transform', 'subjects_dir', 'subject_id',  # BBRegister
+            't1_seg', 't1_brain']),  # FLIRT BBR
         name='inputnode')
     outputnode = pe.Node(
         niu.IdentityInterface(['out_matrix_file', 'out_report', 'final_cost']),
@@ -271,7 +272,7 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
 
     if reregister:
         workflow.connect([
-            (inputnode, transformer, [('fs_2_t1_transform', 'fs_2_t1_transform')]),
+            (inputnode, transformer, [('t1_2_fsnative_reverse_transform', 'fs_2_t1_transform')]),
             (bbregister, transformer, [('out_fsl_file', 'bbreg_transform')]),
             (transformer, outputnode, [('out', 'out_matrix_file')]),
             ])
@@ -321,7 +322,7 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
             Skull-stripped T1-weighted structural image
         t1_seg
             FAST segmentation of ``t1_brain``
-        fs_2_t1_transform
+        t1_2_fsnative_reverse_transform
             Unused (see :py:func:`~fmriprep.workflows.util.init_bbreg_wf`)
         subjects_dir
             Unused (see :py:func:`~fmriprep.workflows.util.init_bbreg_wf`)
@@ -342,9 +343,10 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
     workflow = pe.Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(['in_file',
-                               'fs_2_t1_transform', 'subjects_dir', 'subject_id',  # BBRegister
-                               't1_seg', 't1_brain']),  # FLIRT BBR
+        niu.IdentityInterface([
+            'in_file',
+            't1_2_fsnative_reverse_transform', 'subjects_dir', 'subject_id',  # BBRegister
+            't1_seg', 't1_brain']),  # FLIRT BBR
         name='inputnode')
     outputnode = pe.Node(
         niu.IdentityInterface(['out_matrix_file', 'out_report', 'final_cost']),

--- a/fmriprep/workflows/util.py
+++ b/fmriprep/workflows/util.py
@@ -16,11 +16,13 @@ import os.path as op
 
 from niworkflows.nipype.pipeline import engine as pe
 from niworkflows.nipype.interfaces import utility as niu
-from niworkflows.nipype.interfaces import fsl, afni, ants, freesurfer as fs
+from niworkflows.nipype.interfaces import fsl, afni, c3, ants, freesurfer as fs
 from niworkflows.interfaces.registration import FLIRTRPT, BBRegisterRPT
 from niworkflows.interfaces.masks import SimpleShowMaskRPT
 
 from ..interfaces.images import extract_wm
+
+DEFAULT_MEMORY_MIN_GB = 0.01
 
 
 def init_enhance_and_skullstrip_bold_wf(name='enhance_and_skullstrip_bold_wf',
@@ -214,8 +216,10 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
 
     Outputs
 
-        out_matrix_file
-            FSL-style registration matrix
+        itk_bold_to_t1
+            Affine transform from ``ref_bold_brain`` to T1 space (ITK format)
+        itk_t1_to_bold
+            Affine transform from T1 space to BOLD space (ITK format)
         final_cost
             Value of cost function at final registration
         out_report
@@ -231,29 +235,18 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
             't1_seg', 't1_brain']),  # FLIRT BBR
         name='inputnode')
     outputnode = pe.Node(
-        niu.IdentityInterface(['out_matrix_file', 'out_report', 'final_cost']),
+        niu.IdentityInterface(['itk_bold_to_t1', 'itk_t1_to_bold', 'out_report', 'final_cost']),
         name='outputnode')
 
     _BBRegister = BBRegisterRPT if report else fs.BBRegister
     bbregister = pe.Node(
         _BBRegister(dof=bold2t1w_dof, contrast_type='t2', init='coreg',
-                    registered_file=True, out_fsl_file=True),
+                    registered_file=True, out_lta_file=True),
         name='bbregister')
 
-    def apply_fs_transform(fs_2_t1_transform, bbreg_transform):
-        import os
-        import numpy as np
-        out_file = os.path.abspath('transform.mat')
-        fs_xfm = np.loadtxt(fs_2_t1_transform)
-        bbrxfm = np.loadtxt(bbreg_transform)
-        out_xfm = fs_xfm.dot(bbrxfm)
-        assert np.allclose(out_xfm[3], [0, 0, 0, 1])
-        out_xfm[3] = [0, 0, 0, 1]
-        np.savetxt(out_file, out_xfm, fmt=str('%.12g'))
-        return out_file
-
-    transformer = pe.Node(niu.Function(function=apply_fs_transform),
-                          name='transformer')
+    lta_concat = pe.Node(fs.ConcatenateLTA(out_file='out.lta'), name='lta_concat')
+    lta2itk_fwd = pe.Node(fs.utils.LTAConvert(out_itk=True), name='lta2itk_fwd')
+    lta2itk_inv = pe.Node(fs.utils.LTAConvert(out_itk=True, invert=True), name='lta2itk_inv')
 
     def get_final_cost(in_file):
         import numpy as np
@@ -268,17 +261,21 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
                                  ('in_file', 'source_file')]),
         (bbregister, get_cost, [('min_cost_file', 'in_file')]),
         (get_cost, outputnode, [('out', 'final_cost')]),
+        (lta2itk_fwd, outputnode, [('out_itk', 'itk_bold_to_t1')]),
+        (lta2itk_inv, outputnode, [('out_itk', 'itk_t1_to_bold')]),
         ])
 
     if reregister:
         workflow.connect([
-            (inputnode, transformer, [('t1_2_fsnative_reverse_transform', 'fs_2_t1_transform')]),
-            (bbregister, transformer, [('out_fsl_file', 'bbreg_transform')]),
-            (transformer, outputnode, [('out', 'out_matrix_file')]),
+            (inputnode, lta_concat, [('t1_2_fsnative_reverse_transform', 'in_lta2')]),
+            (bbregister, lta_concat, [('out_lta_file', 'in_lta1')]),
+            (lta_concat, lta2itk_fwd, [('out_file', 'in_lta')]),
+            (lta_concat, lta2itk_inv, [('out_file', 'in_lta')]),
             ])
     else:
         workflow.connect([
-            (bbregister, outputnode, [('out_fsl_file', 'out_matrix_file')]),
+            (bbregister, lta2itk_fwd, [('out_lta_file', 'in_lta')]),
+            (bbregister, lta2itk_inv, [('out_lta_file', 'in_lta')]),
             ])
 
     if report:
@@ -332,8 +329,10 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
 
     Outputs
 
-        out_matrix_file
-            FSL-style registration matrix
+        itk_bold_to_t1
+            Affine transform from ``ref_bold_brain`` to T1 space (ITK format)
+        itk_t1_to_bold
+            Affine transform from T1 space to BOLD space (ITK format)
         final_cost
             Value of cost function at final registration
         out_report
@@ -349,7 +348,7 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
             't1_seg', 't1_brain']),  # FLIRT BBR
         name='inputnode')
     outputnode = pe.Node(
-        niu.IdentityInterface(['out_matrix_file', 'out_report', 'final_cost']),
+        niu.IdentityInterface(['itk_bold_to_t1', 'itk_t1_to_bold', 'out_report', 'final_cost']),
         name='outputnode')
 
     wm_mask = pe.Node(niu.Function(function=extract_wm), name='wm_mask')
@@ -358,6 +357,17 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
     flt_bbr = pe.Node(_FLIRT(cost_func='bbr', dof=bold2t1w_dof, save_log=True), name='flt_bbr')
     flt_bbr.inputs.schedule = op.join(os.getenv('FSLDIR'),
                                       'etc/flirtsch/bbr.sch')
+
+    # make equivalent warp fields
+    invt_bbr = pe.Node(fsl.ConvertXFM(invert_xfm=True), name='invt_bbr',
+                       mem_gb=DEFAULT_MEMORY_MIN_GB)
+
+    #  BOLD to T1 transform matrix is from fsl, using c3 tools to convert to
+    #  something ANTs will like.
+    fsl2itk_fwd = pe.Node(c3.C3dAffineTool(fsl2ras=True, itk_transform=True),
+                          name='fsl2itk_fwd', mem_gb=DEFAULT_MEMORY_MIN_GB)
+    fsl2itk_inv = pe.Node(c3.C3dAffineTool(fsl2ras=True, itk_transform=True),
+                          name='fsl2itk_inv', mem_gb=DEFAULT_MEMORY_MIN_GB)
 
     def get_final_cost(in_file):
         from niworkflows.nipype import logging
@@ -381,7 +391,15 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
         (inputnode, flt_bbr, [('in_file', 'in_file'),
                               ('t1_brain', 'reference')]),
         (wm_mask, flt_bbr, [('out', 'wm_seg')]),
-        (flt_bbr, outputnode, [('out_matrix_file', 'out_matrix_file')]),
+        (inputnode, fsl2itk_fwd, [('t1_brain', 'reference_file'),
+                                  ('in_file', 'source_file')]),
+        (inputnode, fsl2itk_inv, [('in_file', 'reference_file'),
+                                  ('t1_brain', 'source_file')]),
+        (flt_bbr, invt_bbr, [('out_matrix_file', 'in_file')]),
+        (flt_bbr, fsl2itk_fwd, [('out_matrix_file', 'transform_file')]),
+        (invt_bbr, fsl2itk_inv, [('out_file', 'transform_file')]),
+        (fsl2itk_fwd, outputnode, [('itk_transform', 'itk_bold_to_t1')]),
+        (fsl2itk_inv, outputnode, [('itk_transform', 'itk_t1_to_bold')]),
         (flt_bbr, get_cost, [('out_log', 'in_file')]),
         (get_cost, outputnode, [('out', 'final_cost')]),
         ])

--- a/fmriprep/workflows/util.py
+++ b/fmriprep/workflows/util.py
@@ -216,8 +216,6 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
 
         out_matrix_file
             FSL-style registration matrix
-        out_reg_file
-            FreeSurfer-style registration matrix (.dat)
         final_cost
             Value of cost function at final registration
         out_report
@@ -232,7 +230,7 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
                                't1_seg', 't1_brain']),  # FLIRT BBR
         name='inputnode')
     outputnode = pe.Node(
-        niu.IdentityInterface(['out_matrix_file', 'out_reg_file', 'out_report', 'final_cost']),
+        niu.IdentityInterface(['out_matrix_file', 'out_report', 'final_cost']),
         name='outputnode')
 
     _BBRegister = BBRegisterRPT if report else fs.BBRegister
@@ -268,7 +266,6 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
                                  ('subject_id', 'subject_id'),
                                  ('in_file', 'source_file')]),
         (bbregister, get_cost, [('min_cost_file', 'in_file')]),
-        (bbregister, outputnode, [('out_reg_file', 'out_reg_file')]),
         (get_cost, outputnode, [('out', 'final_cost')]),
         ])
 
@@ -336,8 +333,6 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
 
         out_matrix_file
             FSL-style registration matrix
-        out_reg_file
-            Unused (see :py:func:`~fmriprep.workflows.util.init_bbreg_wf`)
         final_cost
             Value of cost function at final registration
         out_report
@@ -352,7 +347,7 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
                                't1_seg', 't1_brain']),  # FLIRT BBR
         name='inputnode')
     outputnode = pe.Node(
-        niu.IdentityInterface(['out_matrix_file', 'out_reg_file', 'out_report', 'final_cost']),
+        niu.IdentityInterface(['out_matrix_file', 'out_report', 'final_cost']),
         name='outputnode')
 
     wm_mask = pe.Node(niu.Function(function=extract_wm), name='wm_mask')


### PR DESCRIPTION
As discussed in #714, the simplest way to build in a prior of A-P phase-encoding is to always use A-P unless otherwise specified. When this produces a discernible error, the correct response would be to update the dataset metadata.

With this change, we can eliminate the cost function machinery from the BBR workflows, which should simplify #694, if this goes in first.

Closes #714.