### PR TITLE
[RTM] RF: Miscellaneous registration refactorings

### DIFF
--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -153,7 +153,7 @@ def init_anat_preproc_wf(skull_strip_ants, output_spaces, template, debug, frees
             FreeSurfer SUBJECTS_DIR
         subject_id
             FreeSurfer subject ID
-        fs_2_t1_transform
+        t1_2_fsnative_reverse_transform
             Affine transform from FreeSurfer subject space to T1w space
         surfaces
             GIFTI surfaces (gray/white boundary, midthickness, pial, inflated)
@@ -174,7 +174,7 @@ def init_anat_preproc_wf(skull_strip_ants, output_spaces, template, debug, frees
         fields=['t1_preproc', 't1_brain', 't1_mask', 't1_seg', 't1_tpms',
                 't1_2_mni', 't1_2_mni_forward_transform', 't1_2_mni_reverse_transform',
                 'mni_mask', 'mni_seg', 'mni_tpms',
-                'subjects_dir', 'subject_id', 'fs_2_t1_transform', 'surfaces']),
+                'subjects_dir', 'subject_id', 't1_2_fsnative_reverse_transform', 'surfaces']),
         name='outputnode')
 
     # 0. Reorient T1w image(s) to RAS and resample to common voxel space
@@ -314,7 +314,7 @@ def init_anat_preproc_wf(skull_strip_ants, output_spaces, template, debug, frees
             (surface_recon_wf, outputnode, [
                 ('outputnode.subjects_dir', 'subjects_dir'),
                 ('outputnode.subject_id', 'subject_id'),
-                ('outputnode.fs_2_t1_transform', 'fs_2_t1_transform'),
+                ('outputnode.t1_2_fsnative_reverse_transform', 't1_2_fsnative_reverse_transform'),
                 ('outputnode.surfaces', 'surfaces')]),
         ])
 
@@ -499,7 +499,7 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
             FreeSurfer SUBJECTS_DIR
         subject_id
             FreeSurfer subject ID
-        fs_2_t1_transform
+        t1_2_fsnative_reverse_transform
             FSL-style affine matrix translating from FreeSurfer T1.mgz to T1w
         surfaces
             GIFTI surfaces for gray/white matter boundary, pial surface,
@@ -521,7 +521,8 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
         name='inputnode')
     outputnode = pe.Node(
         niu.IdentityInterface(
-            fields=['subjects_dir', 'subject_id', 'fs_2_t1_transform', 'surfaces', 'out_report']),
+            fields=['subjects_dir', 'subject_id', 't1_2_fsnative_reverse_transform', 'surfaces',
+                    'out_report']),
         name='outputnode')
 
     recon_config = pe.Node(FSDetectInputs(hires_enabled=hires), name='recon_config',
@@ -577,7 +578,7 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
                                            ('outputnode.subject_id', 'subject_id'),
                                            ('outputnode.out_report', 'out_report')]),
         (gifti_surface_wf, outputnode, [('outputnode.surfaces', 'surfaces')]),
-        (fs_transform, outputnode, [('fsl_file', 'fs_2_t1_transform')]),
+        (fs_transform, outputnode, [('fsl_file', 't1_2_fsnative_reverse_transform')]),
     ])
 
     return workflow

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -437,7 +437,8 @@ def init_single_subject_wf(subject_id, task_id, name,
                 (anat_preproc_wf, func_preproc_wf,
                  [('outputnode.subjects_dir', 'inputnode.subjects_dir'),
                   ('outputnode.subject_id', 'inputnode.subject_id'),
-                  ('outputnode.fs_2_t1_transform', 'inputnode.fs_2_t1_transform')]),
+                  ('outputnode.t1_2_fsnative_reverse_transform',
+                   'inputnode.t1_2_fsnative_reverse_transform')]),
             ])
 
     return workflow

--- a/fmriprep/workflows/bold.py
+++ b/fmriprep/workflows/bold.py
@@ -878,8 +878,6 @@ def init_bold_reg_wf(freesurfer, bold2t1w_dof, bold_file_size_gb, omp_nthreads,
             Motion-corrected BOLD series in T1 space
         bold_mask_t1
             BOLD mask in T1 space
-        fs_reg_file
-            Affine transform from ``ref_bold_brain`` to T1 space (FreeSurfer ``reg`` format)
         out_report
             Reportlet visualizing quality of registration
 
@@ -896,7 +894,7 @@ def init_bold_reg_wf(freesurfer, bold2t1w_dof, bold_file_size_gb, omp_nthreads,
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['mat_bold_to_t1', 'mat_t1_to_bold',
                                       'itk_bold_to_t1', 'itk_t1_to_bold',
-                                      'bold_t1', 'bold_mask_t1', 'fs_reg_file',
+                                      'bold_t1', 'bold_mask_t1',
                                       'out_report']),
         name='outputnode'
     )
@@ -932,7 +930,6 @@ def init_bold_reg_wf(freesurfer, bold2t1w_dof, bold_file_size_gb, omp_nthreads,
         (bbr_wf, fsl2itk_fwd, [('outputnode.out_matrix_file', 'transform_file')]),
         (invt_bbr, fsl2itk_inv, [('out_file', 'transform_file')]),
         (bbr_wf, outputnode, [('outputnode.out_matrix_file', 'mat_bold_to_t1'),
-                              ('outputnode.out_reg_file', 'fs_reg_file'),
                               ('outputnode.out_report', 'out_report')]),
         (invt_bbr, outputnode, [('out_file', 'mat_t1_to_bold')]),
         (fsl2itk_fwd, outputnode, [('itk_transform', 'itk_bold_to_t1')]),

--- a/fmriprep/workflows/bold.py
+++ b/fmriprep/workflows/bold.py
@@ -866,10 +866,6 @@ def init_bold_reg_wf(freesurfer, bold2t1w_dof, bold_file_size_gb, omp_nthreads,
 
     Outputs
 
-        mat_bold_to_t1
-            Affine transform from ``ref_bold_brain`` to T1 space (FSL format)
-        mat_t1_to_bold
-            Affine transform from T1 space to BOLD space (FSL format)
         itk_bold_to_t1
             Affine transform from ``ref_bold_brain`` to T1 space (ITK format)
         itk_t1_to_bold
@@ -892,8 +888,7 @@ def init_bold_reg_wf(freesurfer, bold2t1w_dof, bold_file_size_gb, omp_nthreads,
         name='inputnode'
     )
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=['mat_bold_to_t1', 'mat_t1_to_bold',
-                                      'itk_bold_to_t1', 'itk_t1_to_bold',
+        niu.IdentityInterface(fields=['itk_bold_to_t1', 'itk_t1_to_bold',
                                       'bold_t1', 'bold_mask_t1',
                                       'out_report']),
         name='outputnode'
@@ -929,9 +924,7 @@ def init_bold_reg_wf(freesurfer, bold2t1w_dof, bold_file_size_gb, omp_nthreads,
         (bbr_wf, invt_bbr, [('outputnode.out_matrix_file', 'in_file')]),
         (bbr_wf, fsl2itk_fwd, [('outputnode.out_matrix_file', 'transform_file')]),
         (invt_bbr, fsl2itk_inv, [('out_file', 'transform_file')]),
-        (bbr_wf, outputnode, [('outputnode.out_matrix_file', 'mat_bold_to_t1'),
-                              ('outputnode.out_report', 'out_report')]),
-        (invt_bbr, outputnode, [('out_file', 'mat_t1_to_bold')]),
+        (bbr_wf, outputnode, [('outputnode.out_report', 'out_report')]),
         (fsl2itk_fwd, outputnode, [('itk_transform', 'itk_bold_to_t1')]),
         (fsl2itk_inv, outputnode, [('itk_transform', 'itk_t1_to_bold')]),
     ])

--- a/fmriprep/workflows/util.py
+++ b/fmriprep/workflows/util.py
@@ -200,7 +200,7 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
 
         in_file
             Reference BOLD image to be registered
-        fs_2_t1_transform
+        t1_2_fsnative_reverse_transform
             FSL-style affine matrix translating from FreeSurfer T1.mgz to T1w
         subjects_dir
             FreeSurfer SUBJECTS_DIR
@@ -225,9 +225,10 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
     workflow = pe.Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(['in_file',
-                               'fs_2_t1_transform', 'subjects_dir', 'subject_id',  # BBRegister
-                               't1_seg', 't1_brain']),  # FLIRT BBR
+        niu.IdentityInterface([
+            'in_file',
+            't1_2_fsnative_reverse_transform', 'subjects_dir', 'subject_id',  # BBRegister
+            't1_seg', 't1_brain']),  # FLIRT BBR
         name='inputnode')
     outputnode = pe.Node(
         niu.IdentityInterface(['out_matrix_file', 'out_report', 'final_cost']),
@@ -271,7 +272,7 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
 
     if reregister:
         workflow.connect([
-            (inputnode, transformer, [('fs_2_t1_transform', 'fs_2_t1_transform')]),
+            (inputnode, transformer, [('t1_2_fsnative_reverse_transform', 'fs_2_t1_transform')]),
             (bbregister, transformer, [('out_fsl_file', 'bbreg_transform')]),
             (transformer, outputnode, [('out', 'out_matrix_file')]),
             ])
@@ -321,7 +322,7 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
             Skull-stripped T1-weighted structural image
         t1_seg
             FAST segmentation of ``t1_brain``
-        fs_2_t1_transform
+        t1_2_fsnative_reverse_transform
             Unused (see :py:func:`~fmriprep.workflows.util.init_bbreg_wf`)
         subjects_dir
             Unused (see :py:func:`~fmriprep.workflows.util.init_bbreg_wf`)
@@ -342,9 +343,10 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
     workflow = pe.Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(['in_file',
-                               'fs_2_t1_transform', 'subjects_dir', 'subject_id',  # BBRegister
-                               't1_seg', 't1_brain']),  # FLIRT BBR
+        niu.IdentityInterface([
+            'in_file',
+            't1_2_fsnative_reverse_transform', 'subjects_dir', 'subject_id',  # BBRegister
+            't1_seg', 't1_brain']),  # FLIRT BBR
         name='inputnode')
     outputnode = pe.Node(
         niu.IdentityInterface(['out_matrix_file', 'out_report', 'final_cost']),

--- a/fmriprep/workflows/util.py
+++ b/fmriprep/workflows/util.py
@@ -16,11 +16,13 @@ import os.path as op
 
 from niworkflows.nipype.pipeline import engine as pe
 from niworkflows.nipype.interfaces import utility as niu
-from niworkflows.nipype.interfaces import fsl, afni, ants, freesurfer as fs
+from niworkflows.nipype.interfaces import fsl, afni, c3, ants, freesurfer as fs
 from niworkflows.interfaces.registration import FLIRTRPT, BBRegisterRPT
 from niworkflows.interfaces.masks import SimpleShowMaskRPT
 
 from ..interfaces.images import extract_wm
+
+DEFAULT_MEMORY_MIN_GB = 0.01
 
 
 def init_enhance_and_skullstrip_bold_wf(name='enhance_and_skullstrip_bold_wf',
@@ -214,8 +216,10 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
 
     Outputs
 
-        out_matrix_file
-            FSL-style registration matrix
+        itk_bold_to_t1
+            Affine transform from ``ref_bold_brain`` to T1 space (ITK format)
+        itk_t1_to_bold
+            Affine transform from T1 space to BOLD space (ITK format)
         final_cost
             Value of cost function at final registration
         out_report
@@ -231,29 +235,18 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
             't1_seg', 't1_brain']),  # FLIRT BBR
         name='inputnode')
     outputnode = pe.Node(
-        niu.IdentityInterface(['out_matrix_file', 'out_report', 'final_cost']),
+        niu.IdentityInterface(['itk_bold_to_t1', 'itk_t1_to_bold', 'out_report', 'final_cost']),
         name='outputnode')
 
     _BBRegister = BBRegisterRPT if report else fs.BBRegister
     bbregister = pe.Node(
         _BBRegister(dof=bold2t1w_dof, contrast_type='t2', init='coreg',
-                    registered_file=True, out_fsl_file=True),
+                    registered_file=True, out_lta_file=True),
         name='bbregister')
 
-    def apply_fs_transform(fs_2_t1_transform, bbreg_transform):
-        import os
-        import numpy as np
-        out_file = os.path.abspath('transform.mat')
-        fs_xfm = np.loadtxt(fs_2_t1_transform)
-        bbrxfm = np.loadtxt(bbreg_transform)
-        out_xfm = fs_xfm.dot(bbrxfm)
-        assert np.allclose(out_xfm[3], [0, 0, 0, 1])
-        out_xfm[3] = [0, 0, 0, 1]
-        np.savetxt(out_file, out_xfm, fmt=str('%.12g'))
-        return out_file
-
-    transformer = pe.Node(niu.Function(function=apply_fs_transform),
-                          name='transformer')
+    lta_concat = pe.Node(fs.ConcatenateLTA(out_file='out.lta'), name='lta_concat')
+    lta2itk_fwd = pe.Node(fs.utils.LTAConvert(out_itk=True), name='lta2itk_fwd')
+    lta2itk_inv = pe.Node(fs.utils.LTAConvert(out_itk=True, invert=True), name='lta2itk_inv')
 
     def get_final_cost(in_file):
         import numpy as np
@@ -268,17 +261,21 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
                                  ('in_file', 'source_file')]),
         (bbregister, get_cost, [('min_cost_file', 'in_file')]),
         (get_cost, outputnode, [('out', 'final_cost')]),
+        (lta2itk_fwd, outputnode, [('out_itk', 'itk_bold_to_t1')]),
+        (lta2itk_inv, outputnode, [('out_itk', 'itk_t1_to_bold')]),
         ])
 
     if reregister:
         workflow.connect([
-            (inputnode, transformer, [('t1_2_fsnative_reverse_transform', 'fs_2_t1_transform')]),
-            (bbregister, transformer, [('out_fsl_file', 'bbreg_transform')]),
-            (transformer, outputnode, [('out', 'out_matrix_file')]),
+            (inputnode, lta_concat, [('t1_2_fsnative_reverse_transform', 'in_lta2')]),
+            (bbregister, lta_concat, [('out_lta_file', 'in_lta1')]),
+            (lta_concat, lta2itk_fwd, [('out_file', 'in_lta')]),
+            (lta_concat, lta2itk_inv, [('out_file', 'in_lta')]),
             ])
     else:
         workflow.connect([
-            (bbregister, outputnode, [('out_fsl_file', 'out_matrix_file')]),
+            (bbregister, lta2itk_fwd, [('out_lta_file', 'in_lta')]),
+            (bbregister, lta2itk_inv, [('out_lta_file', 'in_lta')]),
             ])
 
     if report:
@@ -332,8 +329,10 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
 
     Outputs
 
-        out_matrix_file
-            FSL-style registration matrix
+        itk_bold_to_t1
+            Affine transform from ``ref_bold_brain`` to T1 space (ITK format)
+        itk_t1_to_bold
+            Affine transform from T1 space to BOLD space (ITK format)
         final_cost
             Value of cost function at final registration
         out_report
@@ -349,7 +348,7 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
             't1_seg', 't1_brain']),  # FLIRT BBR
         name='inputnode')
     outputnode = pe.Node(
-        niu.IdentityInterface(['out_matrix_file', 'out_report', 'final_cost']),
+        niu.IdentityInterface(['itk_bold_to_t1', 'itk_t1_to_bold', 'out_report', 'final_cost']),
         name='outputnode')
 
     wm_mask = pe.Node(niu.Function(function=extract_wm), name='wm_mask')
@@ -358,6 +357,17 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
     flt_bbr = pe.Node(_FLIRT(cost_func='bbr', dof=bold2t1w_dof, save_log=True), name='flt_bbr')
     flt_bbr.inputs.schedule = op.join(os.getenv('FSLDIR'),
                                       'etc/flirtsch/bbr.sch')
+
+    # make equivalent warp fields
+    invt_bbr = pe.Node(fsl.ConvertXFM(invert_xfm=True), name='invt_bbr',
+                       mem_gb=DEFAULT_MEMORY_MIN_GB)
+
+    #  BOLD to T1 transform matrix is from fsl, using c3 tools to convert to
+    #  something ANTs will like.
+    fsl2itk_fwd = pe.Node(c3.C3dAffineTool(fsl2ras=True, itk_transform=True),
+                          name='fsl2itk_fwd', mem_gb=DEFAULT_MEMORY_MIN_GB)
+    fsl2itk_inv = pe.Node(c3.C3dAffineTool(fsl2ras=True, itk_transform=True),
+                          name='fsl2itk_inv', mem_gb=DEFAULT_MEMORY_MIN_GB)
 
     def get_final_cost(in_file):
         from niworkflows.nipype import logging
@@ -381,7 +391,15 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
         (inputnode, flt_bbr, [('in_file', 'in_file'),
                               ('t1_brain', 'reference')]),
         (wm_mask, flt_bbr, [('out', 'wm_seg')]),
-        (flt_bbr, outputnode, [('out_matrix_file', 'out_matrix_file')]),
+        (inputnode, fsl2itk_fwd, [('t1_brain', 'reference_file'),
+                                  ('in_file', 'source_file')]),
+        (inputnode, fsl2itk_inv, [('in_file', 'reference_file'),
+                                  ('t1_brain', 'source_file')]),
+        (flt_bbr, invt_bbr, [('out_matrix_file', 'in_file')]),
+        (flt_bbr, fsl2itk_fwd, [('out_matrix_file', 'transform_file')]),
+        (invt_bbr, fsl2itk_inv, [('out_file', 'transform_file')]),
+        (fsl2itk_fwd, outputnode, [('itk_transform', 'itk_bold_to_t1')]),
+        (fsl2itk_inv, outputnode, [('itk_transform', 'itk_t1_to_bold')]),
         (flt_bbr, get_cost, [('out_log', 'in_file')]),
         (get_cost, outputnode, [('out', 'final_cost')]),
         ])

--- a/fmriprep/workflows/util.py
+++ b/fmriprep/workflows/util.py
@@ -216,8 +216,6 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
 
         out_matrix_file
             FSL-style registration matrix
-        out_reg_file
-            FreeSurfer-style registration matrix (.dat)
         final_cost
             Value of cost function at final registration
         out_report
@@ -232,7 +230,7 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
                                't1_seg', 't1_brain']),  # FLIRT BBR
         name='inputnode')
     outputnode = pe.Node(
-        niu.IdentityInterface(['out_matrix_file', 'out_reg_file', 'out_report', 'final_cost']),
+        niu.IdentityInterface(['out_matrix_file', 'out_report', 'final_cost']),
         name='outputnode')
 
     _BBRegister = BBRegisterRPT if report else fs.BBRegister
@@ -268,7 +266,6 @@ def init_bbreg_wf(bold2t1w_dof, report, reregister=True, name='bbreg_wf'):
                                  ('subject_id', 'subject_id'),
                                  ('in_file', 'source_file')]),
         (bbregister, get_cost, [('min_cost_file', 'in_file')]),
-        (bbregister, outputnode, [('out_reg_file', 'out_reg_file')]),
         (get_cost, outputnode, [('out', 'final_cost')]),
         ])
 
@@ -336,8 +333,6 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
 
         out_matrix_file
             FSL-style registration matrix
-        out_reg_file
-            Unused (see :py:func:`~fmriprep.workflows.util.init_bbreg_wf`)
         final_cost
             Value of cost function at final registration
         out_report
@@ -352,7 +347,7 @@ def init_fsl_bbr_wf(bold2t1w_dof, report, name='fsl_bbr_wf'):
                                't1_seg', 't1_brain']),  # FLIRT BBR
         name='inputnode')
     outputnode = pe.Node(
-        niu.IdentityInterface(['out_matrix_file', 'out_reg_file', 'out_report', 'final_cost']),
+        niu.IdentityInterface(['out_matrix_file', 'out_report', 'final_cost']),
         name='outputnode')
 
     wm_mask = pe.Node(niu.Function(function=extract_wm), name='wm_mask')


### PR DESCRIPTION
Because I have three PRs (#694, #733, #740) all working in the same areas of code, to work on one almost invariably causes collisions with the others. This PR simply tracks what I think are uncontroversial changes that have come up while working in one that don't impact the *functioning* of the others.

* Cleans up unused workflow inputs/outputs
* Makes `fs_2_t1_transform` follow the `t1_2_<space>_(forward|reverse)_transform` convention
* Moves ITK affine matrix creation into the BBR workflows
  * In the case of FreeSurfer's `bbregister`, uses FreeSurfer's native LTA format until ready to convert to ITK

If this list grows, I will rebase the other PRs against it.