### PR TITLE
[RTM] DOCKER: Add rX permissions to make life easier on Singularity users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,7 @@ RUN conda install -y mkl=2017.0.1 mkl-service;  sync &&\
                      libxml2=2.9.4 \
                      libxslt=1.1.29\
                      traits=4.6.0; sync &&  \
+    chmod -R a+rX /usr/local/miniconda; sync && \
     chmod +x /usr/local/miniconda/bin/*; sync && \
     conda clean --all -y; sync && \
     conda clean -tipsy && sync
@@ -152,7 +153,8 @@ WORKDIR /root/
 ENV CRN_SHARED_DATA /niworkflows_data
 ADD docker/scripts/get_templates.sh get_templates.sh
 RUN mkdir $CRN_SHARED_DATA && \
-    /root/get_templates.sh
+    /root/get_templates.sh && \
+    chmod -R a+rX $CRN_SHARED_DATA
 
 # Installing dev requirements (packages that are not in pypi)
 ADD requirements.txt requirements.txt


### PR DESCRIPTION
See https://github.com/poldracklab/fmriprep/issues/749#issuecomment-336170941

This should be merged shortly before the next release. Doing so before then will waste time during builds to no benefit, since users won't see the images built until release.