### PR TITLE
FIX: Only use unbiased template with --longitudinal

### DIFF
--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -189,6 +189,8 @@ def init_anat_preproc_wf(skull_strip_template, output_spaces, template, debug,
                             initial_timepoint=1,      # For deterministic behavior
                             intensity_scaling=True,   # 7-DOF (rigid + intensity)
                             subsample_threshold=200,
+                            fixed_timepoint=not longitudinal,
+                            no_iteration=not longitudinal,
                             ),
         name='t1_merge')
 
@@ -244,11 +246,6 @@ def init_anat_preproc_wf(skull_strip_template, output_spaces, template, debug,
     def set_threads(in_list, maximum):
         return min(len(in_list), maximum)
 
-    def len_above_thresh(in_list, threshold, longitudinal):
-        if longitudinal:
-            return False
-        return len(in_list) > threshold
-
     workflow.connect([
         (inputnode, t1_template_dimensions, [('t1w', 't1w_list')]),
         (t1_template_dimensions, t1_conform, [
@@ -258,8 +255,6 @@ def init_anat_preproc_wf(skull_strip_template, output_spaces, template, debug,
         (t1_conform, t1_merge, [
             ('out_file', 'in_files'),
             (('out_file', set_threads, omp_nthreads), 'num_threads'),
-            (('out_file', len_above_thresh, 2, longitudinal), 'fixed_timepoint'),
-            (('out_file', len_above_thresh, 2, longitudinal), 'no_iteration'),
             (('out_file', add_suffix, '_template'), 'out_file')]),
         (t1_merge, t1_reorient, [('out_file', 'in_file')]),
         (t1_reorient, skullstrip_ants_wf, [('out_file', 'inputnode.in_file')]),


### PR DESCRIPTION
The issue presented in #767 occurs when trying to find a mean transform between the two images (what we've been calling "unbiased"). The two images had a large translation in the I/S direction, which I assume caused the issue.

This fix disables unbiased templates for 2 image subjects unless `--longitudinal` is passed.

Closes #767.