### PR TITLE
[FIX] Reduce FoV of outputs in T1w space

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -28,4 +28,4 @@ dependencies:
     - svgutils
     - nitime
     - nilearn
-    - git+https://github.com/poldracklab/niworkflows.git@cad7fb7cec09b4ac6ad39757697d71a8b1a8b144#egg=niworkflows-0.1.9-dev
+    - git+https://github.com/poldracklab/niworkflows.git@710b73301e391ef6f9e184384187cfd2d921fbe2#egg=niworkflows-0.1.9-dev

--- a/fmriprep/info.py
+++ b/fmriprep/info.py
@@ -74,8 +74,8 @@ REQUIRES = [
 ]
 
 LINKS_REQUIRES = [
-    'git+https://github.com/oesteban/niworkflows.git'
-    '@3ead8ad752b1aa5b8a79035ce104e1e44d78596c#egg=niworkflows-0.1.9-dev',
+    'git+https://github.com/poldracklab/niworkflows.git'
+    '@710b73301e391ef6f9e184384187cfd2d921fbe2#egg=niworkflows-0.1.9-dev',
 ]
 
 TESTS_REQUIRES = [

--- a/fmriprep/info.py
+++ b/fmriprep/info.py
@@ -74,8 +74,8 @@ REQUIRES = [
 ]
 
 LINKS_REQUIRES = [
-    'git+https://github.com/poldracklab/niworkflows.git'
-    '@aa459cffe118bbf2036300f3d4856a3ec049b326#egg=niworkflows-0.1.9-dev',
+    'git+https://github.com/oesteban/niworkflows.git'
+    '@3ead8ad752b1aa5b8a79035ce104e1e44d78596c#egg=niworkflows-0.1.9-dev',
 ]
 
 TESTS_REQUIRES = [

--- a/fmriprep/interfaces/itk.py
+++ b/fmriprep/interfaces/itk.py
@@ -273,7 +273,7 @@ def _applytfms(args):
             nii.set_data_dtype(in_dtype)
             nii.to_filename(out_file)
 
-    return (out_file, runtime.merged)
+    return (out_file, runtime.cmdline)
 
 
 def _arrange_xfms(transforms, num_files, tmp_folder):

--- a/fmriprep/workflows/bold.py
+++ b/fmriprep/workflows/bold.py
@@ -677,7 +677,7 @@ def init_bold_reference_wf(omp_nthreads, bold_file=None, name='bold_reference_wf
             ('outputnode.mask_file', 'bold_mask'),
             ('outputnode.out_report', 'bold_mask_report'),
             ('outputnode.skull_stripped_file', 'ref_image_brain')]),
-        ])
+    ])
 
     return workflow
 
@@ -979,7 +979,8 @@ def init_bold_reg_wf(freesurfer, use_bbr, bold2t1w_dof, bold_file_size_gb, omp_n
 
     workflow.connect([
         (inputnode, gen_ref, [('ref_bold_brain', 'moving_image'),
-                              ('t1_brain', 'fixed_image')]),
+                              ('t1_brain', 'fixed_image'),
+                              ('t1_mask', 'fov_mask')]),
         (gen_ref, mask_t1w_tfm, [('out_file', 'reference_image')]),
         (bbr_wf, mask_t1w_tfm, [('outputnode.itk_bold_to_t1', 'transforms')]),
         (inputnode, mask_t1w_tfm, [('ref_bold_mask', 'input_image')]),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/poldracklab/niworkflows.git@aa459cffe118bbf2036300f3d4856a3ec049b326#egg=niworkflows-0.1.9-dev
+git+https://github.com/oesteban/niworkflows.git@3ead8ad752b1aa5b8a79035ce104e1e44d78596c#egg=niworkflows-0.1.9-dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/oesteban/niworkflows.git@3ead8ad752b1aa5b8a79035ce104e1e44d78596c#egg=niworkflows-0.1.9-dev
+git+https://github.com/poldracklab/niworkflows.git@710b73301e391ef6f9e184384187cfd2d921fbe2#egg=niworkflows-0.1.9-dev


### PR DESCRIPTION
Adds the new `fov_mask` connection to the node that generates the registration target reference in T1w space, but with BOLD resolution.

This could also be added to the MNI resampling target, however, the MNI space is already restrictive enough in terms of FoV.

Closes #722