### PR TITLE
[FIX] Memory issues in LS5

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -352,7 +352,8 @@ EPI sampled to FreeSurfer surfaces
     :simple_form: yes
 
     from fmriprep.workflows.bold import init_bold_surf_wf
-    wf = init_bold_surf_wf(output_spaces=['T1w', 'fsnative',
+    wf = init_bold_surf_wf(bold_file_size_gb=0.1,
+                           output_spaces=['T1w', 'fsnative',
                                          'template', 'fsaverage5'],
                            medial_surface_nan=False)
 

--- a/fmriprep/interfaces/itk.py
+++ b/fmriprep/interfaces/itk.py
@@ -52,7 +52,7 @@ class MCFLIRT2ITK(SimpleInterface):
         if num_threads < 1:
             num_threads = None
 
-        with TemporaryDirectory() as tmp_folder:
+        with TemporaryDirectory(prefix='tmp-', dir=runtime.cwd) as tmp_folder:
             # Inputs are ready to run in parallel
             if num_threads is None or num_threads > 1:
                 from multiprocessing import Pool
@@ -123,7 +123,7 @@ class MultiApplyTransforms(SimpleInterface):
             ifargs.pop(key, None)
 
         # Get a temp folder ready
-        tmp_folder = TemporaryDirectory()
+        tmp_folder = TemporaryDirectory(prefix='tmp-', dir=runtime.cwd)
 
         xfms_list = _arrange_xfms(transforms, num_files, tmp_folder)
         assert len(xfms_list) == num_files

--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -101,7 +101,8 @@ class Report(object):
         self._load_config(config)
 
     def _load_config(self, config):
-        config = json.load(open(config, 'r'))
+        with open(config, 'r') as configfh:
+            config = json.load(configfh)
 
         for e in config['sub_reports']:
             sub_report = SubReport(**e)

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -469,6 +469,13 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
     See :py:func:`~fmriprep.workflows.anatomical.init_autorecon_resume_wf` for details.
 
 
+    Memory annotations for FreeSurfer are based off `their documentation
+    <https://surfer.nmr.mgh.harvard.edu/fswiki/SystemRequirements>`_.
+    They specify an allocation of 4GB per subject. Here we define 5GB
+    to have a certain margin.
+
+
+
     .. workflow::
         :graph2use: orig
         :simple_form: yes
@@ -536,7 +543,7 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
 
     autorecon1 = pe.Node(
         fs.ReconAll(directive='autorecon1', flags='-noskullstrip', openmp=omp_nthreads),
-        name='autorecon1', n_procs=omp_nthreads, mem_gb=32)
+        name='autorecon1', n_procs=omp_nthreads, mem_gb=5)
     autorecon1.interface._can_resume = False
 
     skull_strip_extern = pe.Node(FSInjectBrainExtracted(), name='skull_strip_extern',
@@ -673,20 +680,20 @@ def init_autorecon_resume_wf(omp_nthreads, name='autorecon_resume_wf'):
                    '-nohyporelabel', '-noaparc2aseg', '-noapas2aseg',
                    '-nosegstats', '-nowmparc', '-nobalabels'],
             openmp=omp_nthreads),
-        iterfield='hemi', n_procs=omp_nthreads, mem_gb=32,
+        iterfield='hemi', n_procs=omp_nthreads, mem_gb=5,
         name='autorecon_surfs')
     autorecon_surfs.inputs.hemi = ['lh', 'rh']
 
     autorecon3 = pe.MapNode(
         fs.ReconAll(directive='autorecon3', openmp=omp_nthreads),
-        iterfield='hemi', n_procs=omp_nthreads, mem_gb=32,
+        iterfield='hemi', n_procs=omp_nthreads, mem_gb=5,
         name='autorecon3')
     autorecon3.inputs.hemi = ['lh', 'rh']
 
     # Only generate the report once; should be nothing to do
     recon_report = pe.Node(
         ReconAllRPT(directive='autorecon3', generate_report=True),
-        name='recon_report', mem_gb=8)
+        name='recon_report', mem_gb=5)
 
     def _dedup(in_list):
         vals = set(in_list)

--- a/fmriprep/workflows/bold.py
+++ b/fmriprep/workflows/bold.py
@@ -576,7 +576,8 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
 
     if freesurfer and any(space.startswith('fs') for space in output_spaces):
         LOGGER.info('Creating BOLD surface-sampling workflow.')
-        bold_surf_wf = init_bold_surf_wf(output_spaces=output_spaces,
+        bold_surf_wf = init_bold_surf_wf(bold_file_size_gb=bold_file_size_gb,
+                                         output_spaces=output_spaces,
                                          medial_surface_nan=medial_surface_nan,
                                          name='bold_surf_wf')
         workflow.connect([
@@ -1021,7 +1022,7 @@ def init_bold_reg_wf(freesurfer, use_bbr, bold2t1w_dof, bold_file_size_gb, omp_n
     return workflow
 
 
-def init_bold_surf_wf(output_spaces, medial_surface_nan, name='bold_surf_wf'):
+def init_bold_surf_wf(bold_file_size_gb, output_spaces, medial_surface_nan, name='bold_surf_wf'):
     """
     This workflow samples functional images to FreeSurfer surfaces
 
@@ -1035,7 +1036,8 @@ def init_bold_surf_wf(output_spaces, medial_surface_nan, name='bold_surf_wf'):
         :simple_form: yes
 
         from fmriprep.workflows.bold import init_bold_surf_wf
-        wf = init_bold_surf_wf(output_spaces=['T1w', 'fsnative',
+        wf = init_bold_surf_wf(bold_file_size_gb=0.1,
+                               output_spaces=['T1w', 'fsnative',
                                              'template', 'fsaverage5'],
                                medial_surface_nan=False)
 
@@ -1104,7 +1106,7 @@ def init_bold_surf_wf(output_spaces, medial_surface_nan, name='bold_surf_wf'):
                            override_reg_subj=True, out_type='gii'),
         iterfield=['source_file', 'target_subject'],
         iterables=('hemi', ['lh', 'rh']),
-        name='sampler', mem_gb=3)
+        name='sampler', mem_gb=bold_file_size_gb * 3)
 
     def medial_wall_to_nan(in_file, subjects_dir, target_subject):
         """ Convert values on medial wall to NaNs
@@ -1260,7 +1262,7 @@ def init_bold_mni_trans_wf(template, bold_file_size_gb, omp_nthreads,
     mask_mni_tfm = pe.Node(
         ApplyTransforms(interpolation='NearestNeighbor', float=True),
         name='mask_mni_tfm',
-        mem_gb=3
+        mem_gb=bold_file_size_gb * 3
     )
 
     # Write corrected file in the designated output dir


### PR DESCRIPTION
It seems like the memory issues are caused by LS5's particular setting that maps `/tmp` into RAM. You can consume up to 32GB in `/tmp` that are discounted from the overal RAM.

FMRIPREP was using `/tmp` in the resampling of all BOLD scans into T1 and MNI. For long runs and/or many runs, the 32GB limit was reached in fact reducing the total amount of memory for processes to only 32GB (the total in LS5 is 64GB).

In this PR some other optimizations are also done: make sure we always close file handlers and memory annotations have been revised to more sensible values.