### PR TITLE
FIX: Immediately fix headers of AFNI outputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@ Next release
 ============
 
 * [FIX] Adopt new FreeSurfer license mechanism (#787)
-
+* [FIX] Correct headers in AFNI-generated NIfTI files (#818)
 
 1.0.0-rc9 (2nd of November 2017)
 ================================


### PR DESCRIPTION
As noted in #743, AFNI doesn't believe in NIfTI headers. #807 introduced a bug by targeting an antsApplyTransform at an image with an AFNI-corrupted header.

Fortunately, every AFNI tool we use doesn't change the affine space, so we can overwrite the qform/sform with the original affine. This change adds/moves header correction to immediately after each AFNI process.