### PR TITLE
FIX: Check q/sform is not None

### DIFF
--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -504,7 +504,8 @@ def normalize_xform(img):
     # Check desired codes
     qform, qform_code = img.get_qform(coded=True)
     sform, sform_code = img.get_sform(coded=True)
-    if all((np.allclose(qform, xform), np.allclose(sform, xform),
+    if all((qform is not None and np.allclose(qform, xform),
+            sform is not None and np.allclose(sform, xform),
             int(qform_code) == xform_code, int(sform_code) == xform_code)):
         return img
 


### PR DESCRIPTION
`img.get_qform(coded=True)` [returns `(None, 0)`](https://github.com/nipy/nibabel/blob/master/nibabel/nifti1.py#L915-L916) if the code is 0, but otherwise returns the qform. The same is true for `get_sform`.

Thus, adding the `is not None` check is required to make this function work as expected.

Fixes #822.