### PR TITLE
[REF] Fine-grained logging (make FMRIPREP less shy)

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -220,9 +220,8 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
             'largemem': (0.007 * max(bold_tlen, 100) + 1.5) * bold_size_gb,
         }
 
-    LOGGER.info('Creating bold processing workflow for "%s" '
-                '(%.2f GB / %d TRs).',
-                bold_file, mem_gb['filesize'], bold_tlen)
+    LOGGER.log(25, 'Creating bold processing workflow for "%s" (%.2f GB / %d TRs).',
+               bold_file, mem_gb['filesize'], bold_tlen)
     fname = split_filename(bold_file)[1]
     fname_nosub = '_'.join(fname.split("_")[1:])
     name = "func_preproc_" + fname_nosub.replace(
@@ -231,7 +230,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
     # For doc building purposes
     if layout is None or bold_file == 'bold_preprocesing':
 
-        LOGGER.info('No valid layout: building empty workflow.')
+        LOGGER.log(25, 'No valid layout: building empty workflow.')
         metadata = {"RepetitionTime": 2.0,
                     "SliceTiming": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]}
         fmaps = [{
@@ -413,7 +412,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
         fmaps.sort(key=lambda fmap: {'epi': 0, 'fieldmap': 1, 'phasediff': 2}[fmap['type']])
         fmap = fmaps[0]
 
-        LOGGER.info('Fieldmap estimation: type "%s" found', fmap['type'])
+        LOGGER.log(25, 'Fieldmap estimation: type "%s" found', fmap['type'])
         summary.inputs.distortion_correction = fmap['type']
 
         if fmap['type'] == 'epi':
@@ -614,7 +613,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
         ])
 
     if freesurfer and any(space.startswith('fs') for space in output_spaces):
-        LOGGER.info('Creating BOLD surface-sampling workflow.')
+        LOGGER.log(25, 'Creating BOLD surface-sampling workflow.')
         bold_surf_wf = init_bold_surf_wf(mem_gb=mem_gb['resampled'],
                                          output_spaces=output_spaces,
                                          medial_surface_nan=medial_surface_nan,

--- a/fmriprep/workflows/bold/stc.py
+++ b/fmriprep/workflows/bold/stc.py
@@ -57,7 +57,7 @@ def init_bold_stc_wf(metadata, name='bold_stc_wf'):
     inputnode = pe.Node(niu.IdentityInterface(fields=['bold_file', 'skip_vols']), name='inputnode')
     outputnode = pe.Node(niu.IdentityInterface(fields=['stc_file']), name='outputnode')
 
-    LOGGER.info('Slice-timing correction will be included.')
+    LOGGER.log(25, 'Slice-timing correction will be included.')
 
     def create_custom_slice_timing_file_func(metadata):
         import os

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -153,7 +153,7 @@ def merge_help(wrapper_help, target_help):
 
     # Make sure we're not clobbering options we don't mean to
     overlap = set(w_flags).intersection(t_flags)
-    expected_overlap = set(['h', 'v', 'w', 'output-grid-reference',
+    expected_overlap = set(['h', 'version', 'w', 'output-grid-reference',
                             'fs-license-file'])
     assert overlap == expected_overlap, "Clobbering options: {}".format(
         ', '.join(overlap - expected_overlap))
@@ -167,7 +167,7 @@ def merge_help(wrapper_help, target_help):
         w_options[:2],
         [opt for opt, flag in zip(t_options, t_flags) if flag not in overlap],
         w_options[2:]
-        ), [])
+    ), [])
     opt_line_length = 79 - len(start)
     length = 0
     opt_lines = [start]

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -148,7 +148,7 @@ def merge_help(wrapper_help, target_help):
     t_flags = sum(map(flag_re.findall, t_options), [])
 
     # The following code makes this assumption
-    assert w_flags[:2] == ['h', 'v']
+    assert w_flags[:2] == ['h', 'version']
     assert w_posargs.replace(']', '').replace('[', '') == t_posargs
 
     # Make sure we're not clobbering options we don't mean to
@@ -370,7 +370,7 @@ def main():
         return 0
     elif opts.version:
         # Get version to be run and exit
-        command.append('-v')
+        command.append('--version')
         ret = subprocess.run(command)
         return ret.returncode
 

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -214,7 +214,7 @@ def get_parser():
 
     parser.add_argument('-h', '--help', action='store_true',
                         help="show this help message and exit")
-    parser.add_argument('-v', '--version', action='store_true',
+    parser.add_argument('--version', action='store_true',
                         help="show program's version number and exit")
 
     # Allow alternative images (semi-developer)


### PR DESCRIPTION
Enables the `-v` flag for fine-grained tunning of FMRIPREP's quietness.
The default level is 25, only IMPORTANT messages or above (WARNING, ERROR)
will be written.
With one `-v` the level goes to 20 (INFO). Two (`-vv`) maps to the VERBOSE
new level. Finally, three (`-vvv`) is the DEBUG level.