### PR TITLE
DOC: Use non-hierarchical graph for bold_preproc_trans_wf

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -298,7 +298,7 @@ Pre-processed BOLD in native space
 :mod:`fmriprep.workflows.bold.resampling.init_bold_preproc_trans_wf`
 
 .. workflow::
-    :graph2use: colored
+    :graph2use: orig
     :simple_form: yes
 
     from fmriprep.workflows.bold import init_bold_preproc_trans_wf


### PR DESCRIPTION
Quick cleanup of the workflows page, noticed while reviewing #828.