### PR TITLE
[FIX] MultiApplyTransforms failed with nthreads=1

### DIFF
--- a/fmriprep/interfaces/itk.py
+++ b/fmriprep/interfaces/itk.py
@@ -132,7 +132,7 @@ class MultiApplyTransforms(SimpleInterface):
 
         if num_threads == 1:
             out_files = [_applytfms((
-                in_file, in_xfm, ifargs, runtime.cwd))
+                in_file, in_xfm, ifargs, i, runtime.cwd))
                 for i, (in_file, in_xfm) in enumerate(zip(in_files, xfms_list))
             ]
         else:


### PR DESCRIPTION
The error was:

```
Traceback (most recent call last):
  File "/usr/local/miniconda/lib/python3.6/site-packages/niworkflows/nipype/pipeline/plugins/linear.py", line 43, in run
    node.run(updatehash=updatehash)
  File "/usr/local/miniconda/lib/python3.6/site-packages/niworkflows/nipype/pipeline/engine/nodes.py", line 407, in run
    self._run_interface()
  File "/usr/local/miniconda/lib/python3.6/site-packages/niworkflows/nipype/pipeline/engine/nodes.py", line 517, in _run_interface
    self._result = self._run_command(execute)
  File "/usr/local/miniconda/lib/python3.6/site-packages/niworkflows/nipype/pipeline/engine/nodes.py", line 650, in _run_command
    result = self._interface.run()
  File "/usr/local/miniconda/lib/python3.6/site-packages/niworkflows/nipype/interfaces/base.py", line 1088, in run
    runtime = self._run_interface(runtime)
  File "/usr/local/miniconda/lib/python3.6/site-packages/fmriprep/interfaces/itk.py", line 136, in _run_interface
    for i, (in_file, in_xfm) in enumerate(zip(in_files, xfms_list))
  File "/usr/local/miniconda/lib/python3.6/site-packages/fmriprep/interfaces/itk.py", line 136, in <listcomp>
    for i, (in_file, in_xfm) in enumerate(zip(in_files, xfms_list))
  File "/usr/local/miniconda/lib/python3.6/site-packages/fmriprep/interfaces/itk.py", line 253, in _applytfms
    in_file, in_xform, ifargs, index, newpath = args
ValueError: not enough values to unpack (expected 5, got 4)
```