### PR TITLE
[RFC] ENH: Always sync qforms, refactor error messaging

### DIFF
--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -370,47 +370,54 @@ class ValidateImage(SimpleInterface):
         # Check affine information is valid
         valid_codes = (qform_code, sform_code) != (0, 0)
 
+        # Matching affines
+        matching_affines = np.allclose(img.get_qform(), img.get_sform())
+
         # Both okay -> do nothing, empty report
-        if valid_qform and valid_codes:
+        if valid_qform and valid_codes and matching_affines:
             self._results['out_file'] = self.inputs.in_file
             open(out_report, 'w').close()
             self._results['out_report'] = out_report
             return runtime
 
-        snippet = ''
         out_fname = fname_presuffix(self.inputs.in_file, suffix='_valid', newpath=runtime.cwd)
         self._results['out_file'] = out_fname
 
+        warning = False
+        warning_txt = ''
+        description = ''
         # Fix sform if needed
         if not valid_codes:
             # Nibabel derives a default LAS affine from the shape and zooms
             # Use scanner xform code to indicate no alignment has been done
             img.set_sform(img.affine, nb.nifti1.xform_codes['scanner'])
-            snippet += """\
-<h3 class="elem-title">WARNING - Invalid header</h3>
+            warning = True
+            warning_txt = 'Invalid header'
+            description += """\
 <p class="elem-desc">Input file does not have valid qform or sform matrix.
   A default, LAS-oriented affine has been constructed.
   A left-right flip may have occurred.
   Analyses of this dataset MAY BE INVALID.
 </p>
 """
-        if not valid_qform:
+        if not valid_qform and old_qform_code != 0:
+            if not warning:
+                warning = True
+                warning_txt = 'Invalid qform'
+            description += """\
+<p class="elem-desc">Input file does not have a valid qform matrix.</p>
+"""
+
+        if not (valid_qform and matching_affines):
+            if not warning:
+                warning_txt = 'Mismatched qform/sform matrices'
+            description += '<p class="elem-desc">qform matrix synced to sform.</p>\n'
+            sform, sform_code = img.get_sform(coded=True)
             # Copy sform into qform
-            img.set_qform(img.get_sform(), nb.nifti1.xform_codes['scanner'])
+            img.set_qform(sform, int(sform_code))
 
-            extra_msg = ''
-            if old_qform_code == nb.nifti1.xform_codes['unknown']:
-                extra_msg = ('Additionally, please note that the original q-form code '
-                             'was 0 (unknown), which is potentially problematic.')
-
-            snippet += """\
-<h3 class="elem-title">WARNING - Invalid q-form matrix</h3>
-<p class="elem-desc">Input file does not have a valid qform matrix.
-  To fix the q-form matrix, FMRIPREP copied the s-form matrix over, and
-  set 2 (aligned) as the q-form code. %s
-  Analyses of this dataset MAY BE INVALID.
-</p>
-""" % extra_msg
+        snippet = '<h3 class="elem-title">%s%s</h3>\n%s\n' % ('WARNING - ' if warning else '',
+                                                              warning_txt, description)
 
         # Store new file and report
         img.to_filename(out_fname)

--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -371,7 +371,7 @@ class ValidateImage(SimpleInterface):
         valid_codes = (qform_code, sform_code) != (0, 0)
 
         # Matching affines
-        matching_affines = np.allclose(img.get_qform(), img.get_sform())
+        matching_affines = valid_qform and np.allclose(img.get_qform(), img.get_sform())
 
         # Both okay -> do nothing, empty report
         if valid_qform and valid_codes and matching_affines:
@@ -408,7 +408,7 @@ class ValidateImage(SimpleInterface):
 <p class="elem-desc">Input file does not have a valid qform matrix.</p>
 """
 
-        if not (valid_qform and matching_affines):
+        if not matching_affines:  # Guaranteed if not valid_qform
             if not warning:
                 warning_txt = 'Mismatched qform/sform matrices'
             description += '<p class="elem-desc">qform matrix synced to sform.</p>\n'


### PR DESCRIPTION
Follow-up to #847, intended to clarify my opinions on this interface.

First, I think this is the easiest place to go ahead and sync qforms and sforms, unconditionally.

Second, I've refactored the warnings to follow this logic:

1) If qform/sform codes are bad, declare "WARNING - Invalid header"; if only qform is invalid, declare "WARNING - Invalid qform".
2) If the qform is invalid (and is not marked invalid), note it simply in the description.
3) If qform/sform are valid, but out of sync, make a note (without "WARNING") that they're mismatched.

Just as some after-the-fact commentary on #847: I think the warnings for invalid qforms are weird, in that a qform_code of 0 is treated as intensifying the problem with invalid qforms, rather than mitigating it. It's bad and marked as bad. That seems like some software did a reasonable thing, even if it's now something we have to clean up after.

Relatedly, I think the only time that we need to say analyses "MAY BE INVALID" is when there is no usable qform or sform. A good sform but bad qform is a totally reasonable situation to be in, if it weren't for *our choice* of using ANTs. It's thus our responsibility to handle that case, and make clear what we've done, but we know from the headers what the correct orientation of the image is.

I'm okay with keeping code 1 as the default. I think that makes sense when we use the default affine. However, if we sync the sform, we should use whatever code it has.