### PR TITLE
[FIX] Controlling memory explosion

### DIFF
--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -198,6 +198,8 @@ def get_parser():
 def main():
     """Entry point"""
     from niworkflows.nipype import logging as nlogging
+    from multiprocessing import set_start_method
+    set_start_method('forkserver')
 
     warnings.showwarning = _warn_redirect
     opts = get_parser().parse_args()

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -192,7 +192,7 @@ def main():
     """Entry point"""
     from niworkflows.nipype import logging as nlogging
     from multiprocessing import set_start_method, Process, Manager
-    from ..vis.reports import generate_reports
+    from ..viz.reports import generate_reports
     set_start_method('forkserver')
 
     warnings.showwarning = _warn_redirect

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -413,7 +413,6 @@ def create_workflow(opts, retval):
     retval['run_uuid'] = run_uuid
 
 
-
 if __name__ == '__main__':
     raise RuntimeError("fmriprep/cli/run.py should not be run directly;\n"
                        "Please `pip install` fmriprep and use the `fmriprep` command")

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -281,6 +281,7 @@ def create_workflow(opts):
             plugin_settings['plugin_args'] = {
                 'n_procs': nthreads,
                 'raise_insufficient': False,
+                'maxtasksperchild': 1,
             }
             if opts.mem_mb:
                 plugin_settings['plugin_args']['memory_gb'] = opts.mem_mb / 1024
@@ -290,9 +291,9 @@ def create_workflow(opts):
         omp_nthreads = min(nthreads - 1 if nthreads > 1 else cpu_count(), 8)
 
     if 1 < nthreads < omp_nthreads:
-        raise RuntimeError(
-            'Per-process threads (--omp-nthreads={:d}) cannot exceed total '
-            'threads (--nthreads/--n_cpus={:d})'.format(omp_nthreads, nthreads))
+        logger.warning(
+            'Per-process threads (--omp-nthreads=%d) exceed total '
+            'threads (--nthreads/--n_cpus=%d)', omp_nthreads, nthreads)
 
     # Set up directories
     output_dir = op.abspath(opts.output_dir)

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -253,9 +253,10 @@ def generate_reports(fmriprep_wf):
 def create_workflow(args):
     """Build workflow"""
     from niworkflows.nipype import config as ncfg
+    from ..info import __version__
     from ..workflows.base import init_fmriprep_wf
     from ..utils.bids import collect_participants
-    from ..info import __version__
+    from ..viz.reports import run_reports
 
     INIT_MSG = """
     Running fMRIPREP version {version}:

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -348,8 +348,15 @@ def build_workflow(opts, retval):
 
     # Nipype config (logs and execution)
     ncfg.update_config({
-        'logging': {'log_directory': log_dir, 'log_to_file': True},
-        'execution': {'crashdump_dir': log_dir, 'crashfile_format': 'txt'},
+        'logging': {
+            'log_directory': log_dir,
+            'log_to_file': True
+        },
+        'execution': {
+            'crashdump_dir': log_dir,
+            'crashfile_format': 'txt',
+            'get_linked_libs': False,
+        },
     })
 
     # Called with reports only

--- a/fmriprep/viz/__init__.py
+++ b/fmriprep/viz/__init__.py
@@ -5,4 +5,4 @@
 """
 The fmriprep reporting engine for visual assessment
 """
-from .reports import run_reports
+from .reports import run_reports, generate_reports

--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -223,3 +223,24 @@ def run_reports(reportlets_dir, out_dir, subject_label, run_uuid):
     out_filename = 'sub-{}.html'.format(subject_label)
     report = Report(reportlet_path, config, out_dir, run_uuid, out_filename)
     return report.generate_report()
+
+
+def generate_reports(subject_list, output_dir, work_dir, run_uuid):
+    """
+    A wrapper to run_reports on a given ``subject_list``
+    """
+    reports_dir = os.path.join(work_dir, 'reportlets')
+    report_errors = [
+        run_reports(reports_dir, output_dir, subject_label, run_uuid=run_uuid)
+        for subject_label in subject_list
+    ]
+
+    errno = sum(report_errors)
+    if errno:
+        import logging
+        logger = logging.getLogger('cli')
+        logger.warning(
+            'Errors occurred while generating reports for participants: %s.',
+            ', '.join(['%s (%d)' % (subid, err)
+                       for subid, err in zip(subject_list, report_errors)]))
+    return errno


### PR DESCRIPTION
In this PR:

  - [x] `multiprocessing` is forced to perform on `forkserver` mode
  - [x] The workflow creation is encapsulated in one function that allows wrapping it into a `multiprocessing.Process`, forcing OS level garbage collection (and thus, the main thread of Nipype starts thinner)
  - [x] Minor changes to generating reports, code moved to the `fmriprep.viz.reports` module.
  - [x] Use new nipype option `get_linked_libs=False` 

Fixes #833 