### PR TITLE
MEM: Annotate t1_merge with approximate memory usage

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -66,7 +66,8 @@ T1w/T2w preprocessing
                               freesurfer=True,
                               longitudinal=False,
                               debug=False,
-                              hires=True)
+                              hires=True,
+                              num_t1w=1)
 
 The anatomical sub-workflow begins by constructing a template image by
 :ref:`conforming <conformation>` any T1-weighted images to RAS orientation and

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -76,7 +76,8 @@ def init_anat_preproc_wf(skull_strip_template, output_spaces, template, debug,
                                   freesurfer=True,
                                   longitudinal=False,
                                   debug=False,
-                                  hires=True)
+                                  hires=True,
+                                  num_t1w=1)
 
     **Parameters**
 
@@ -350,7 +351,7 @@ def init_anat_template_wf(longitudinal, omp_nthreads, num_t1w, name='anat_templa
         :simple_form: yes
 
         from fmriprep.workflows.anatomical import init_anat_template_wf
-        wf = init_anat_template_wf(longitudinal=False, omp_nthreads=1)
+        wf = init_anat_template_wf(longitudinal=False, omp_nthreads=1, num_t1w=1)
 
     **Parameters**
 

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -47,7 +47,8 @@ from ..utils.misc import fix_multi_T1w_source_name, add_suffix
 
 #  pylint: disable=R0914
 def init_anat_preproc_wf(skull_strip_template, output_spaces, template, debug,
-                         freesurfer, longitudinal, omp_nthreads, hires, reportlets_dir, output_dir,
+                         freesurfer, longitudinal, omp_nthreads, hires, reportlets_dir,
+                         output_dir, num_t1w,
                          name='anat_preproc_wf'):
     r"""
     This workflow controls the anatomical preprocessing stages of FMRIPREP.
@@ -180,7 +181,8 @@ def init_anat_preproc_wf(skull_strip_template, output_spaces, template, debug,
                 't1_2_fsnative_reverse_transform', 'surfaces']),
         name='outputnode')
 
-    anat_template_wf = init_anat_template_wf(longitudinal=longitudinal, omp_nthreads=omp_nthreads)
+    anat_template_wf = init_anat_template_wf(longitudinal=longitudinal, omp_nthreads=omp_nthreads,
+                                             num_t1w=num_t1w)
 
     # 3. Skull-stripping
     # Bias field correction is handled in skull strip workflows.
@@ -337,7 +339,7 @@ def init_anat_preproc_wf(skull_strip_template, output_spaces, template, debug,
     return workflow
 
 
-def init_anat_template_wf(longitudinal, omp_nthreads, name='anat_template_wf'):
+def init_anat_template_wf(longitudinal, omp_nthreads, num_t1w, name='anat_template_wf'):
     r"""
     This workflow generates a canonically oriented structural template from
     input T1w images.
@@ -399,6 +401,7 @@ def init_anat_template_wf(longitudinal, omp_nthreads, name='anat_template_wf'):
                             no_iteration=not longitudinal,
                             transform_outputs=True,
                             ),
+        mem_gb=2 * num_t1w - 1,
         name='t1_merge')
 
     # Reorient template to RAS, if needed (mri_robust_template may set to LIA)

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -384,7 +384,8 @@ def init_single_subject_wf(subject_id, task_id, name,
                                            freesurfer=freesurfer,
                                            hires=hires,
                                            reportlets_dir=reportlets_dir,
-                                           output_dir=output_dir)
+                                           output_dir=output_dir,
+                                           num_t1w=len(layout['t1w']))
 
     workflow.connect([
         (inputnode, anat_preproc_wf, [('subjects_dir', 'inputnode.subjects_dir')]),

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -385,7 +385,7 @@ def init_single_subject_wf(subject_id, task_id, name,
                                            hires=hires,
                                            reportlets_dir=reportlets_dir,
                                            output_dir=output_dir,
-                                           num_t1w=len(layout['t1w']))
+                                           num_t1w=len(subject_data['t1w']))
 
     workflow.connect([
         (inputnode, anat_preproc_wf, [('subjects_dir', 'inputnode.subjects_dir')]),


### PR DESCRIPTION
Ended up writing my own quick profiler, captured this memory profile, which seems to follow a 2N-1.5 rule, where N is the number of input images.

![t1_merge_memory](https://user-images.githubusercontent.com/83442/33451246-71bc5248-d5dc-11e7-9e4f-2a71fbf6cf9c.png)

This looks like an effect of registering each subsequent image to the first being embarrassingly parallel. If we hit more images than available threads, then I suspect the profile will end up looking a bit different, but I'm not sure it's worth trying to finesse this. If we get to a lot of input images, it will probably justifiably be the only thing running for a bit.