### PR TITLE
 [ENH] Estimate motion parameters before STC

### DIFF
--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -169,3 +169,10 @@ Posters
    :target: _static/OHBM2017-poster.png
 
 .. include:: license.rst
+
+Other relevant references
+-------------------------
+
+  .. [Power2017] Power JD, Plitt M, Kundu P, Bandettini PA, Martin A (2017) Temporal interpolation alters
+      motion in fMRI scans: Magnitudes and consequences for artifact detection. PLOS ONE 12(9): e0182939.
+      doi:`10.1371/journal.pone.0182939 <https://doi.org/10.1371/journal.pone.0182939>`_.

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -86,7 +86,7 @@ Finally, a non-linear registration to the MNI template space is estimated.
 .. figure:: _static/segmentation.svg
     :scale: 100%
 
-    Brain tissue segmentation (FAST).
+    Brain tissue segmentation (``fast``).
 
 .. figure:: _static/T1MNINormalization.svg
     :scale: 100%
@@ -351,18 +351,18 @@ EPI to T1w registration
         use_bbr=True,
         bold2t1w_dof=9)
 
-The reference EPI image of each run is aligned by the ``bbregister`` routine to the
-reconstructed subject using the gray/white matter boundary (FreeSurfer's
-``?h.white`` surfaces).
+The reference :abbr:`EPI (echo-planar imaging)` image of each run is aligned
+by the ``bbregister`` routine to the reconstructed subject using the gray/white
+matter boundary (FreeSurfer's ``?h.white`` surfaces).
 
 .. figure:: _static/EPIT1Normalization.svg
     :scale: 100%
 
-    Animation showing EPI to T1w registration (FreeSurfer bbregister)
+    Animation showing :abbr:`EPI (echo-planar imaging)` to T1w registration (FreeSurfer ``bbregister``)
 
-If FreeSurfer processing is disabled, FLIRT is performed with the BBR cost
-function, using the FAST segmentation to establish the gray/white matter
-boundary.
+If FreeSurfer processing is disabled, FSL ``flirt`` is run with the
+:abbr:`BBR (boundary-based registration)` cost function, using the
+``fast`` segmentation to establish the gray/white matter boundary.
 
 EPI to MNI transformation
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -382,8 +382,8 @@ EPI to MNI transformation
 This sub-workflow concatenates the transforms calculated upstream (see
 `Head-motion estimation`_, `Susceptibility Distortion Correction (SDC)`_ (if
 fieldmaps are available), `EPI to T1w registration`_, and a T1w-to-MNI
-transform from `T1w/T2w preprocessing`_) to map the EPI image to standardized
-MNI space.
+transform from `T1w/T2w preprocessing`_) to map the :abbr:`EPI (echo-planar imaging)`
+image to standard MNI space.
 It also maps the T1w-based mask to MNI space.
 
 Transforms are concatenated and applied all at once, with one interpolation (Lanczos)

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -259,7 +259,7 @@ Head-motion estimation
         mem_gb=1,
         omp_nthreads=1)
 
-Using the previous :ref:`estimated reference scan <bold_ref>`,
+Using the previously :ref:`estimated reference scan <bold_ref>`,
 FSL ``mcflirt`` is used to estimate head-motion.
 As a result, one rigid-body transform w.r.t. the reference image
 is written for each :abbr:`BOLD (blood-oxygen level-dependent)`
@@ -380,8 +380,8 @@ EPI to MNI transformation
         output_grid_ref=None)
 
 This sub-workflow concatenates the transforms calculated upstream (see
-`Head-motion estimation`_, `Susceptibility Distortion Correction (SDC)`_ (if
-fieldmaps are available), `EPI to T1w registration`_, and a T1w-to-MNI
+`Head-motion estimation`_, `Susceptibility Distortion Correction (SDC)`_ --if
+fieldmaps are available--, `EPI to T1w registration`_, and a T1w-to-MNI
 transform from `T1w/T2w preprocessing`_) to map the :abbr:`EPI (echo-planar imaging)`
 image to standard MNI space.
 It also maps the T1w-based mask to MNI space.

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -5,7 +5,8 @@ Processing pipeline details
 ===========================
 
 ``fmriprep`` adapts its pipeline depending on what data and metadata are
-available and are used as the input. For example, slice timing correction will be
+available and are used as the input.
+For example, slice timing correction will be
 performed only if the ``SliceTiming`` metadata field is found for the input
 dataset.
 
@@ -261,9 +262,10 @@ Head-motion estimation
 
 Using the previously :ref:`estimated reference scan <bold_ref>`,
 FSL ``mcflirt`` is used to estimate head-motion.
-As a result, one rigid-body transform w.r.t. the reference image
-is written for each :abbr:`BOLD (blood-oxygen level-dependent)`
-time-step. Additionally, a list of 6-parameters (three rotations,
+As a result, one rigid-body transform with respect to
+the reference image is written for each :abbr:`BOLD (blood-oxygen level-dependent)`
+time-step.
+Additionally, a list of 6-parameters (three rotations,
 three translations) per time-step is written and fed to the
 :ref:`confounds workflow <bold_confounds>`.
 Motion parameters are therefore calculated before any time-domain
@@ -308,7 +310,8 @@ Susceptibility Distortion Correction (SDC)
 
 One of the major problems that affects :abbr:`EPI (echo planar imaging)` data
 is the spatial distortion caused by the inhomogeneity of the field inside
-the scanner. Please refer to :ref:`sdc` for details on the
+the scanner.
+Please refer to :ref:`sdc` for details on the
 available workflows.
 
 
@@ -331,7 +334,8 @@ All volumes in the :abbr:`BOLD (blood-oxygen level-dependent)` series are
 resampled in their native space by concatenating the mappings found in previous
 correction workflows (:abbr:`HMC (head-motion correction)` and
 :abbr:`SDC (susceptibility-derived distortion correction)` if excecuted)
-for a one-shot interpolation process. Interpolation uses a Lanczos kernel.
+for a one-shot interpolation process.
+Interpolation uses a Lanczos kernel.
 
 .. _bold_reg:
 
@@ -464,6 +468,7 @@ A visualization of the AROMA component classification is also included in the HT
     :scale: 100%
 
     Maps created with maximum intensity projection (glass brain) with a black
-    brain outline. Right hand side of each map: time series (top in seconds),
-    frequency spectrum (bottom in Hertz). Components classified as signal in
-    green; noise in red.
+    brain outline.
+    Right hand side of each map: time series (top in seconds),
+    frequency spectrum (bottom in Hertz).
+    Components classified as signal in green; noise in red.

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -268,8 +268,9 @@ time-step.
 Additionally, a list of 6-parameters (three rotations,
 three translations) per time-step is written and fed to the
 :ref:`confounds workflow <bold_confounds>`.
-Motion parameters are therefore calculated before any time-domain
-filtering, as recently suggested by [Power2017]_.
+For a more accurate estimation of head-motion, we calculate its parameters
+before any time-domain filtering (i.e. :ref:`slice-timing correction <bold_stc>`),
+as recommended in [Power2017]_.
 
 .. _bold_stc:
 
@@ -296,7 +297,8 @@ All slices are realigned in time to the middle of each TR.
 Slice time correction can be disabled with the ``--ignore slicetiming``
 command line argument.
 If a :abbr:`BOLD (blood-oxygen level-dependent)` series has fewer than
-5 usable (steady-state) volumes, slice time correction will be disabled.
+5 usable (steady-state) volumes, slice time correction will be disabled
+for that run.
 
 
 Susceptibility Distortion Correction (SDC)

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -320,7 +320,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
 
     # Top-level BOLD splitter
     bold_split = pe.Node(FSLSplit(dimension='t'), name='bold_split',
-                         mem_gb=mem_gb * 3)
+                         mem_gb=mem_gb['filesize'] * 3)
 
     # HMC on the BOLD
     bold_hmc_wf = init_bold_hmc_wf(name='bold_hmc_wf',

--- a/fmriprep/workflows/bold/stc.py
+++ b/fmriprep/workflows/bold/stc.py
@@ -62,7 +62,7 @@ def init_bold_stc_wf(metadata, name='bold_stc_wf'):
     def create_custom_slice_timing_file_func(metadata):
         import os
         slice_timings = metadata["SliceTiming"]
-        slice_timings_ms = [str(t) for t in slice_timings]
+        slice_timings_ms = ["%f" % t for t in slice_timings]
         out_file = "timings.1D"
         with open("timings.1D", "w") as fp:
             fp.write("\t".join(slice_timings_ms))
@@ -83,7 +83,7 @@ def init_bold_stc_wf(metadata, name='bold_stc_wf'):
     copy_xform = pe.Node(CopyXForm(), name='copy_xform', mem_gb=0.1)
 
     def _prefix_at(x):
-        return "@" + x
+        return "@%s" % x
 
     workflow.connect([
         (inputnode, slice_timing_correction, [('bold_file', 'in_file'),

--- a/fmriprep/workflows/bold/stc.py
+++ b/fmriprep/workflows/bold/stc.py
@@ -61,13 +61,11 @@ def init_bold_stc_wf(metadata, name='bold_stc_wf'):
 
     def create_custom_slice_timing_file_func(metadata):
         import os
-        slice_timings = metadata["SliceTiming"]
-        slice_timings_ms = ["%f" % t for t in slice_timings]
-        out_file = "timings.1D"
-        with open("timings.1D", "w") as fp:
-            fp.write("\t".join(slice_timings_ms))
-
-        return os.path.abspath(out_file)
+        slice_timings_sec = ["%f" % t for t in metadata["SliceTiming"]]
+        out_file = os.path.abspath("timings.1D")
+        with open(out_file, "w") as fp:
+            fp.write("\t".join(slice_timings_sec))
+        return out_file
 
     create_custom_slice_timing_file = pe.Node(
         niu.Function(function=create_custom_slice_timing_file_func),

--- a/fmriprep/workflows/fieldmap/base.py
+++ b/fmriprep/workflows/fieldmap/base.py
@@ -21,6 +21,19 @@ be used:
   4. :ref:`sdc_fieldmapless`
 
 
+Table of behavior (fieldmap use-cases):
+
+=============== =========== ============= ===============
+Fieldmaps found ``use_syn`` ``force_syn``     Action
+=============== =========== ============= ===============
+True            *           True          Fieldmaps + SyN
+True            *           False         Fieldmaps
+False           *           True          SyN
+False           True        False         SyN
+False           False       False         HMC only
+=============== =========== ============= ===============
+
+
 """
 
 


### PR DESCRIPTION
This PR focuses on estimating head-motion parameters before temporal filtering of the signal, as suggested in (Power, 2017) - see #849.

If slice-timing correction (STC) is done, then all processing is tailored to STC. Otherwise, the original data are used.