### PR TITLE
[FIX] Robuster EPI mask

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -232,12 +232,14 @@ BOLD reference image estimation
 
 This workflow estimates a reference image for a
 :abbr:`BOLD (blood-oxygen level-dependent)` series.
-If T1-saturation effects ("dummy scans" or non-steady state volumes) are
-detected they are used as reference due to their superior tissue contrast.
-Otherwise a median of motion corrected subset of volumes is used.
-The reference image is used to calculate a brain mask for the
-:abbr:`BOLD (blood-oxygen level-dependent)` signal using
-`Nilearn <http://nilearn.github.io/>`_.
+When T1-saturation effects ("dummy scans" or non-steady state volumes) are
+detected, they are averaged and used as reference due to their
+superior tissue contrast.
+Otherwise, a median of motion corrected subset of volumes is used.
+
+The reference image is then used to calculate a brain mask for the
+:abbr:`BOLD (blood-oxygen level-dependent)` signal using the
+:mod:`fmriprep.workflows.bold.util.init_enhance_and_skullstrip_bold_wf`.
 Further, the reference is fed to the :ref:`head-motion estimation
 workflow <bold_hmc>` and the :ref:`registration workflow to map
 BOLD series into the T1w image of the same subject <bold_reg>`.

--- a/fmriprep/workflows/bold/util.py
+++ b/fmriprep/workflows/bold/util.py
@@ -127,7 +127,7 @@ def init_enhance_and_skullstrip_bold_wf(name='enhance_and_skullstrip_bold_wf',
       2. Run ANTs' ``N4BiasFieldCorrection`` on the input
          :abbr:`BOLD (blood-oxygen level-dependant)` average, using the
          mask generated in 1) instead of the internal Otsu thresholding.
-      3. Calculate a loose mask using BET, with one mathematical morphology
+      3. Calculate a loose mask using FSL's ``bet``, with one mathematical morphology
          dilation of one iteration and a sphere of 6mm as structuring element.
       4. Mask the :abbr:`INU (intensity non-uniformity)`-corrected image
          with the latest mask calculated in 3), then use AFNI's ``3dUnifize``


### PR DESCRIPTION
This PR:

- [x] Replaces the default Otsu mask of `N4BiasFieldCorrection` by setting a mask from nilearn
- [x] Runs `N4BiasFieldCorrection` to only one thread, as parallelization is not really necessary here and results are not run-to-run reproducible when multithreaded.

Closes #902, #905, #907. Ref. #895.