### PR TITLE
[FIX] Refine antsBrainExtraction if recon-all is run

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,22 @@
 Next release
 ============
 
+1.0.1 (<TBD>)
+=============
+
+With thanks to @emdupre for contributions.
+
+* [FIX] Refine ``antsBrainExtraction`` if ``recon-all`` is run (#912)
+  With thanks to Arno Klein for his helpful comments here
+  (https://github.com/poldracklab/fmriprep/issues/431#issuecomment-299583391)
+* [ENH] Use thinner contours in reportlets (#910)
+* [FIX] Robuster EPI mask (#911)
+* [DOC] Documentation about FreeSurfer and ``--fs-no-reconall`` (#894)
+* [FIX] Set workflow return value before potential error (#887)
+* [DOC] Fix example in installation ants-nthreads -> omp-nthreads (#885)
+  With thanks to @mvdoc.
+* [ENH] Allow for multiecho data (#875)
+
 
 1.0.0 (6th of December 2017)
 ============================

--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -95,7 +95,7 @@ we recommend to include in your paper.
      tool of ANTs v2.1.0 [7], using brain-extracted versions of both T1w volume and template.
      Brain tissue segmentation of cerebrospinal fluid (CSF), white-matter (WM) and
      gray-matter (GM) was performed on the brain-extracted T1w using
-     <code>fast</code> [16]. (FSL v5.0.9).
+     <code>fast</code> [16] (FSL v5.0.9).
    </p>
 
    <p style="font-style: italic;">
@@ -149,7 +149,7 @@ we recommend to include in your paper.
 
    <p>
      <span id="fmriprep_citation">FMRIPREP</span> Available from: <a id="fmriprep_doi_url" href="https://doi.org/10.5281/zenodo.852659">10.5281/zenodo.852659</a>.
-     <img src onerror='fillCitation()'>
+     <img src onerror='fillCitation()' alt="" />
    </p>
    <p>
      2. 	Gorgolewski K, Burns CD, Madison C, Clark D, Halchenko YO, Waskom ML, Ghosh SS. Nipype: a flexible, lightweight and extensible neuroimaging data processing framework in python. Front Neuroinform. 2011 Aug 22;5(August):13. doi:<a href="https://doi.org/10.3389/fninf.2011.00013">10.3389/fninf.2011.00013</a>.

--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -76,89 +76,146 @@ we recommend to include in your paper.
    With slicetime correction: <input id="slicetime" type="checkbox" checked="true" onclick="toggle();"/><br />
    </p>
 
-   <p style="font-style: italic;">Results included in this manuscript come from preprocessing performed using FMRIPREP version <span id="fmriprep_version">latest</span> [1] a Nipype [2,3] based tool. Each T1 weighted volume was corrected for bias field using N4BiasFieldCorrection v2.1.0 [4] and skullstripped using antsBrainExtraction.sh v2.1.0 (using
-   <span class="ss_template_text_OASIS">OASIS</span>
-   <span class="ss_template_text_NKI" style="display: none">NKI</span>
-   template).
-   <span class="freesurfer_text_true">Cortical surface was estimated using FreeSurfer v6.0.0 [5]. </span>
-   The skullstripped T1w volume was coregistered to skullstripped ICBM 152 Nonlinear Asymmetrical template version 2009c [6] using nonlinear transformation implemented in ANTs v2.1.0 [7].</p>
+   <p style="font-style: italic;">
+     Results included in this manuscript come from preprocessing performed using
+     FMRIPREP version <span id="fmriprep_version">latest</span> [1], a Nipype [2,3] based tool.
+     Each T1w (T1-weighted) volume was corrected for INU (intensity non-uniformity) using
+     <code>N4BiasFieldCorrection</code> v2.1.0 [4] and skull-stripped using
+     <code>antsBrainExtraction.sh</code> v2.1.0 (using the
+     <span class="ss_template_text_OASIS">OASIS</span>
+     <span class="ss_template_text_NKI" style="display: none">NKI</span> template).
+     <span class="freesurfer_text_true">Brain surfaces were reconstructed using
+     <code>recon-all</code> from FreeSurfer v6.0.0 [5],
+     and the brain mask estimated previously was refined with a custom variation of
+     <a href="https://doi.org/10.1371/journal.pcbi.1005350.g002">the method to reconcile
+     ANTs-derived and FreeSurfer-derived segmentations of the cortical gray-matter</a>
+     of Mindboggle [20].</span>
+     Spatial normalization to the ICBM 152 Nonlinear Asymmetrical template version 2009c [6]
+     was performed through nonlinear registration with the <code>antsRegistration</code>
+     tool of ANTs v2.1.0 [7], using brain-extracted versions of both T1w volume and template.
+     Brain tissue segmentation of cerebrospinal fluid (CSF), white-matter (WM) and
+     gray-matter (GM) was performed on the brain-extracted T1w using
+     <code>fast</code> [16]. (FSL v5.0.9).
+   </p>
 
-  <p style="font-style: italic;">Functional data was <span class="slicetime_text_true">slice time corrected using AFNI [10] and </span>motion corrected using MCFLIRT v5.0.9 [8].
-  <span class="SDC_text_TOPUP" style="display: none">Distortion correction was performed using an implementation of the TOPUP technique [9] using 3dQwarp v16.2.07 distributed as part of AFNI [10]. </span>
-  <span class="SDC_text_FUGUE" style="display: none">Distortion correction was performed using fieldmaps processed by the FUGUE v5.0.9 [11] tool. </span>
-  <span class="SDC_text_SyN" style="display: none">Distortion correction was performed by estimating ANTs based nonlinear co-registration of the functional image to intensity inverted T1w image [12,13] constrained with an average fieldmap template [14].</span>
-  This was followed by co-registration to the corresponding T1-weighted volume using boundary based registration 9 degrees of freedom - implemented in
-  <span class="freesurfer_text_true">FreeSurfer v6.0.0 [15]</span>
-  <span class="freesurfer_text_false" style="display: none">FSL [15]</span>
-  . Motion correcting transformations,
-  <span class="SDC_text_TOPUP" style="display: none">field distortion correcting warp, </span>
-  <span class="SDC_text_FUGUE" style="display: none">field distortion correcting warp, </span>
-  <span class="SDC_text_SyN" style="display: none">field distortion correcting warp, </span>
-  T1 weighted transformation and MNI template warp were applied in a single step using antsApplyTransformations v2.1.0 with Lanczos interpolation.
-  </p>
-  <p style="font-style: italic;">
-  Three tissue classes were extracted from T1w images using FSL FAST v5.0.9 [16]. Voxels from cerebrospinal fluid and white matter were used to create a mask in turn used to extract physiological noise regressors using aCompCor [17]. Mask was eroded and limited to subcortical regions to limit overlap with gray matter, six principal components were estimated. Frame-wise displacement [18] was calculated for each functional run using Nipype implementation. <span class="AROMA_text_true" style="display: none">ICA-based Automatic Removal Of Motion Artifacts (AROMA) was used to generate aggressive noise regressors as well as creating a variant of data that was non-aggressively denoised [19].</span></p>
-  <p style="font-style: italic;">
-  For more details of the pipeline see <a id="workflow_url" href="http://fmriprep.readthedocs.io/en/latest/workflows.html">http://fmriprep.readthedocs.io/en/latest/workflows.html</a>.
-  </p>
-  <p>
-  <span id="fmriprep_citation">FMRIPREP</span> Available from: <a id="fmriprep_doi_url" href="https://doi.org/10.5281/zenodo.852659">10.5281/zenodo.852659</a>
-  <img src onerror='fillCitation()'>
-  </p>
-  <p>
-  2. 	Gorgolewski K, Burns CD, Madison C, Clark D, Halchenko YO, Waskom ML, Ghosh SS. Nipype: a flexible, lightweight and extensible neuroimaging data processing framework in python. Front Neuroinform [Internet]. 2011 Aug 22;5(August):13. doi:<a href="https://doi.org/10.3389/fninf.2011.00013">10.3389/fninf.2011.00013</a>
-  </p>
-  <p>
-  3. 	Gorgolewski KJ, Esteban O, Ellis DG, Notter MP, Ziegler E, Johnson H, Hamalainen C, Yvernault B, Burns C, Manhães-Savio A, Jarecka D, Markiewicz CJ, Salo T, Clark D, Waskom M, Wong J, Modat M, Dewey BE, Clark MG, Dayan M, Loney F, Madison C, Gramfort A, Keshavan A, Berleant S, Pinsard B, Goncalves M, Clark D, Cipollini B, Varoquaux G, Wassermann D, Rokem A, Halchenko YO, Forbes J, Moloney B, Malone IB, Hanke M, Mordom D, Buchanan C, Pauli WM, Huntenburg JM, Horea C, Schwartz Y, Tungaraza R, Iqbal S, Kleesiek J, Sikka S, Frohlich C, Kent J, Perez-Guevara M, Watanabe A, Welch D, Cumba C, Ginsburg D, Eshaghi A, Kastman E, Bougacha S, Blair R, Acland B, Gillman A, Schaefer A, Nichols BN, Giavasis S, Erickson D, Correa C, Ghayoor A, Küttner R, Haselgrove C, Zhou D, Craddock RC, Haehn D, Lampe L, Millman J, Lai J, Renfro M, Liu S, Stadler J, Glatard T, Kahn AE, Kong X-Z, Triplett W, Park A, McDermottroe C, Hallquist M, Poldrack R, Perkins LN, Noel M, Gerhard S, Salvatore J, Mertz F, Broderick W, Inati S, Hinds O, Brett M, Durnez J, Tambini A, Rothmei S, Andberg SK, Cooper G, Marina A, Mattfeld A, Urchs S, Sharp P, Matsubara K, Geisler D, Cheung B, Floren A, Nickson T, Pannetier N, Weinstein A, Dubois M, Arias J, Tarbert C, Schlamp K, Jordan K, Liem F, Saase V, Harms R, Khanuja R, Podranski K, Flandin G, Papadopoulos Orfanos D, Schwabacher I, McNamee D, Falkiewicz M, Pellman J, Linkersdörfer J, Varada J, Pérez-García F, Davison A, Shachnev D, Ghosh S. Nipype: a flexible, lightweight and extensible neuroimaging data processing framework in Python [Internet]. 2017. doi:<a href="https://doi.org/10.5281/zenodo.581704">10.5281/zenodo.581704</a>
-  </p>
-  <p>
-  4. 	Tustison NJ, Avants BB, Cook PA, Zheng Y, Egan A, Yushkevich PA, Gee JC. N4ITK: improved N3 bias correction. IEEE Trans Med Imaging [Internet]. 2010 Jun;29(6):1310–20. doi:<a href="https://doi.org/10.1109/TMI.2010.2046908">10.1109/TMI.2010.2046908</a>
-  </p>
-  <p>
-  5. 	Dale A, Fischl B, Sereno MI. Cortical Surface-Based Analysis: I. Segmentation and Surface Reconstruction. Neuroimage. 1999;9(2):179–94. doi:<a href="https://doi.org/10.1006/nimg.1998.0395">10.1006/nimg.1998.0395</a>
-  </p>
-  <p>
-  6. 	Fonov VS, Evans AC, McKinstry RC, Almli CR, Collins DL. Unbiased nonlinear average age-appropriate brain templates from birth to adulthood. NeuroImage; Amsterdam [Internet]. 2009 Jul 1;47:S102. doi:<a href="https://doi.org/10.1016/S1053-8119(09)70884-5">10.1016/S1053-8119(09)70884-5</a>
-  </p>
-  <p>
-  7. 	Avants BB, Epstein CL, Grossman M, Gee JC. Symmetric diffeomorphic image registration with cross-correlation: evaluating automated labeling of elderly and neurodegenerative brain. Med Image Anal [Internet]. 2008 Feb;12(1):26–41. doi:<a href="https://doi.org/10.1016/j.media.2007.06.004">10.1016/j.media.2007.06.004</a>
-  </p>
-  <p>
-  8. 	Jenkinson M, Bannister P, Brady M, Smith S. Improved optimization for the robust and accurate linear registration and motion correction of brain images. Neuroimage [Internet]. 2002 Oct;17(2):825–41. doi:<a href="https://doi.org/10.1006/nimg.2002.1132">10.1006/nimg.2002.1132</a>
-  </p>
-  <p>
-  9. 	Andersson JLR, Skare S, Ashburner J. How to correct susceptibility distortions in spin-echo echo-planar images: application to diffusion tensor imaging. Neuroimage [Internet]. 2003 Oct;20(2):870–88. doi:<a href="https://doi.org/10.1016/S1053-8119(03)00336-7">10.1016/S1053-8119(03)00336-7</a>
-  </p>
-  <p>
-  10. 	Cox RW. AFNI: software for analysis and visualization of functional magnetic resonance neuroimages. Comput Biomed Res [Internet]. 1996 Jun;29(3):162–73. doi:<a href="https://doi.org/10.1006/cbmr.1996.0014">10.1006/cbmr.1996.0014</a>
-  </p>
-  <p>
-  11. 	Jenkinson M. Fast, automated, N-dimensional phase-unwrapping algorithm. Magn Reson Med [Internet]. 2003 Jan;49(1):193–7. doi:<a href="https://doi.org/10.1002/mrm.10354">10.1002/mrm.10354</a>
-  </p>
-  <p>
-  12. 	Huntenburg JM. Evaluating nonlinear coregistration of BOLD EPI and T1w images [Internet]. Freie Universität Berlin; 2014. Available from: <a href="http://hdl.handle.net/11858/00-001M-0000-002B-1CB5-A">http://hdl.handle.net/11858/00-001M-0000-002B-1CB5-A</a>
-  </p>
-  <p>
-  13. 	Wang S, Peterson DJ, Gatenby JC, Li W, Grabowski TJ, Madhyastha TM. Evaluation of Field Map and Nonlinear Registration Methods for Correction of Susceptibility Artifacts in Diffusion MRI. Front Neuroinform [Internet]. 2017 [cited 2017 Feb 21];11. doi:<a href="https://doi.org/10.3389/fninf.2017.00017">10.3389/fninf.2017.00017</a>
-  </p>
-  <p>
-  14. 	Treiber JM, White NS, Steed TC, Bartsch H, Holland D, Farid N, McDonald CR, Carter BS, Dale AM, Chen CC. Characterization and Correction of Geometric Distortions in 814 Diffusion Weighted Images. PLoS One [Internet]. 2016 Mar 30;11(3):e0152472. doi:<a href="https://doi.org/10.1371/journal.pone.0152472">10.1371/journal.pone.0152472</a>
-  </p>
-  <p>
-  15. 	Greve DN, Fischl B. Accurate and robust brain image alignment using boundary-based registration. Neuroimage [Internet]. 2009 Oct;48(1):63–72. doi:<a href="https://doi.org/10.1016/j.neuroimage.2009.06.060">10.1016/j.neuroimage.2009.06.060</a>
-  </p>
-  <p>
-  16. 	Zhang Y, Brady M, Smith S. Segmentation of brain MR images through a hidden Markov random field model and the expectation-maximization algorithm. IEEE Trans Med Imaging [Internet]. 2001 Jan;20(1):45–57. doi:<a href="https://doi.org/10.1109/42.906424">10.1109/42.906424</a>
-  </p>
-  <p>
-  17. 	Behzadi Y, Restom K, Liau J, Liu TT. A component based noise correction method (CompCor) for BOLD and perfusion based fMRI. Neuroimage [Internet]. 2007 Aug 1;37(1):90–101. doi:<a href="https://doi.org/10.1109/42.906424">10.1016/j.neuroimage.2007.04.042</a>
-  </p>
-  <p>
-  18. 	Power JD, Mitra A, Laumann TO, Snyder AZ, Schlaggar BL, Petersen SE. Methods to detect, characterize, and remove motion artifact in resting state fMRI. Neuroimage [Internet]. 2013 Aug 29;84:320–41. doi:<a href="https://doi.org/10.1016/j.neuroimage.2013.08.048">10.1016/j.neuroimage.2013.08.048</a>
-  </p>
-  <p>
-  19. 	Pruim RHR, Mennes M, van Rooij D, Llera A, Buitelaar JK, Beckmann CF. ICA-AROMA: A robust ICA-based strategy for removing motion artifacts from fMRI data. Neuroimage [Internet]. 2015 May 15;112:267–77. doi:<a href="https://doi.org/10.1016/j.neuroimage.2015.02.064">10.1016/j.neuroimage.2015.02.064</a>
-  </p>
+   <p style="font-style: italic;">
+     Functional data was <span class="slicetime_text_true">slice time corrected using
+     <code>3dTshift</code> from AFNI v16.2.07 [10]
+     and </span>motion corrected using <code>mcflirt</code> (FSL v5.0.9 [8]).
+     <span class="SDC_text_TOPUP" style="display: none">Distortion correction was performed
+     using an implementation of the TOPUP technique [9] using <code>3dQwarp</code> (AFNI v16.2.07 [10]).</span>
+     <span class="SDC_text_FUGUE" style="display: none">Distortion correction was performed using fieldmaps
+     processed with <code>fugue</code> [11] (FSL v5.0.9).</span>
+     <span class="SDC_text_SyN" style="display: none">
+     "Fieldmap-less" distortion correction was performed by co-registering the functional image to
+     the same-subject T1w image with intensity inverted [12,13] constrained with an average fieldmap
+     template [14], implemented with <code>antsRegistration</code> (ANTs).</span>
+     This was followed by co-registration to the corresponding T1w using boundary-based registration [15]
+     with 9 degrees of freedom, using
+     <span class="freesurfer_text_true"><code>bbregister</code> (FreeSurfer v6.0.0).</span>
+     <span class="freesurfer_text_false" style="display: none"><code>flirt</code> (FSL).</span>
+     Motion correcting transformations,
+     <span class="SDC_text_TOPUP" style="display: none">field distortion correcting warp, </span>
+     <span class="SDC_text_FUGUE" style="display: none">field distortion correcting warp, </span>
+     <span class="SDC_text_SyN" style="display: none">field distortion correcting warp, </span>
+     BOLD-to-T1w transformation and T1w-to-template (MNI) warp were concatenated and applied in
+     a single step using <code>antsApplyTransforms</code> (ANTs v2.1.0) using Lanczos interpolation.
+   </p>
+
+   <p style="font-style: italic;">
+     Physiological noise regressors were extracted applying CompCor [17].
+     Principal components were estimated for the two CompCor variants:
+     temporal (tCompCor) and anatomical (aCompCor).
+     A mask to exclude signal with cortical origin was obtained by eroding
+     the brain mask, ensuring it only contained subcortical structures.
+     Six tCompCor components were then calculated including only the top 5% variable
+     voxels within that subcortical mask.
+     For aCompCor, six components were calculated within the intersection of the
+     subcortical mask and the union of CSF and WM masks calculated in T1w space,
+     after their projection to the native space of each functional run.
+     Frame-wise displacement [18] was calculated for each functional run using the implementation
+     of Nipype.
+     <span class="AROMA_text_true" style="display: none">ICA-based Automatic Removal Of Motion
+     Artifacts (AROMA) was used to generate aggressive noise regressors as well as to create a
+     variant of data that is non-aggressively denoised [19].</span>
+   </p>
+
+   <p style="font-style: italic;">
+     Many internal operations of FMRIPREP use Nilearn [21], principally within the BOLD-processing
+     workflow.
+     For more details of the pipeline see
+     <a id="workflow_url" href="http://fmriprep.readthedocs.io/en/latest/workflows.html">http://fmriprep.readthedocs.io/en/latest/workflows.html</a>.
+   </p>
+
+   <p>
+     <span id="fmriprep_citation">FMRIPREP</span> Available from: <a id="fmriprep_doi_url" href="https://doi.org/10.5281/zenodo.852659">10.5281/zenodo.852659</a>.
+     <img src onerror='fillCitation()'>
+   </p>
+   <p>
+     2. 	Gorgolewski K, Burns CD, Madison C, Clark D, Halchenko YO, Waskom ML, Ghosh SS. Nipype: a flexible, lightweight and extensible neuroimaging data processing framework in python. Front Neuroinform. 2011 Aug 22;5(August):13. doi:<a href="https://doi.org/10.3389/fninf.2011.00013">10.3389/fninf.2011.00013</a>.
+   </p>
+   <p>
+     3. 	Gorgolewski KJ, Esteban O, Ellis DG, Notter MP, Ziegler E, Johnson H, Hamalainen C, Yvernault B, Burns C, Manhães-Savio A, Jarecka D, Markiewicz CJ, Salo T, Clark D, Waskom M, Wong J, Modat M, Dewey BE, Clark MG, Dayan M, Loney F, Madison C, Gramfort A, Keshavan A, Berleant S, Pinsard B, Goncalves M, Clark D, Cipollini B, Varoquaux G, Wassermann D, Rokem A, Halchenko YO, Forbes J, Moloney B, Malone IB, Hanke M, Mordom D, Buchanan C, Pauli WM, Huntenburg JM, Horea C, Schwartz Y, Tungaraza R, Iqbal S, Kleesiek J, Sikka S, Frohlich C, Kent J, Perez-Guevara M, Watanabe A, Welch D, Cumba C, Ginsburg D, Eshaghi A, Kastman E, Bougacha S, Blair R, Acland B, Gillman A, Schaefer A, Nichols BN, Giavasis S, Erickson D, Correa C, Ghayoor A, Küttner R, Haselgrove C, Zhou D, Craddock RC, Haehn D, Lampe L, Millman J, Lai J, Renfro M, Liu S, Stadler J, Glatard T, Kahn AE, Kong X-Z, Triplett W, Park A, McDermottroe C, Hallquist M, Poldrack R, Perkins LN, Noel M, Gerhard S, Salvatore J, Mertz F, Broderick W, Inati S, Hinds O, Brett M, Durnez J, Tambini A, Rothmei S, Andberg SK, Cooper G, Marina A, Mattfeld A, Urchs S, Sharp P, Matsubara K, Geisler D, Cheung B, Floren A, Nickson T, Pannetier N, Weinstein A, Dubois M, Arias J, Tarbert C, Schlamp K, Jordan K, Liem F, Saase V, Harms R, Khanuja R, Podranski K, Flandin G, Papadopoulos Orfanos D, Schwabacher I, McNamee D, Falkiewicz M, Pellman J, Linkersdörfer J, Varada J, Pérez-García F, Davison A, Shachnev D, Ghosh S. Nipype: a flexible, lightweight and extensible neuroimaging data processing framework in Python. 2017. doi:<a href="https://doi.org/10.5281/zenodo.581704">10.5281/zenodo.581704</a>.
+   </p>
+   <p>
+     4. 	Tustison NJ, Avants BB, Cook PA, Zheng Y, Egan A, Yushkevich PA, Gee JC. N4ITK: improved N3 bias correction. IEEE Trans Med Imaging. 2010 Jun;29(6):1310–20. doi:<a href="https://doi.org/10.1109/TMI.2010.2046908">10.1109/TMI.2010.2046908</a>.
+   </p>
+   <p>
+     5. 	Dale A, Fischl B, Sereno MI. Cortical Surface-Based Analysis: I. Segmentation and Surface Reconstruction. Neuroimage. 1999;9(2):179–94. doi:<a href="https://doi.org/10.1006/nimg.1998.0395">10.1006/nimg.1998.0395</a>.
+   </p>
+   <p>
+     6. 	Fonov VS, Evans AC, McKinstry RC, Almli CR, Collins DL. Unbiased nonlinear average age-appropriate brain templates from birth to adulthood. NeuroImage; Amsterdam. 2009 Jul 1;47:S102. doi:<a href="https://doi.org/10.1016/S1053-8119(09)70884-5">10.1016/S1053-8119(09)70884-5</a>.
+   </p>
+   <p>
+     7. 	Avants BB, Epstein CL, Grossman M, Gee JC. Symmetric diffeomorphic image registration with cross-correlation: evaluating automated labeling of elderly and neurodegenerative brain. Med Image Anal. 2008 Feb;12(1):26–41. doi:<a href="https://doi.org/10.1016/j.media.2007.06.004">10.1016/j.media.2007.06.004</a>.
+   </p>
+   <p>
+     8. 	Jenkinson M, Bannister P, Brady M, Smith S. Improved optimization for the robust and accurate linear registration and motion correction of brain images. Neuroimage. 2002 Oct;17(2):825–41. doi:<a href="https://doi.org/10.1006/nimg.2002.1132">10.1006/nimg.2002.1132</a>.
+   </p>
+   <p>
+     9. 	Andersson JLR, Skare S, Ashburner J. How to correct susceptibility distortions in spin-echo echo-planar images: application to diffusion tensor imaging. Neuroimage. 2003 Oct;20(2):870–88. doi:<a href="https://doi.org/10.1016/S1053-8119(03)00336-7">10.1016/S1053-8119(03)00336-7</a>.
+   </p>
+   <p>
+     10. 	Cox RW. AFNI: software for analysis and visualization of functional magnetic resonance neuroimages. Comput Biomed Res. 1996 Jun;29(3):162–73. doi:<a href="https://doi.org/10.1006/cbmr.1996.0014">10.1006/cbmr.1996.0014</a>.
+    </p>
+    <p>
+     11. 	Jenkinson M. Fast, automated, N-dimensional phase-unwrapping algorithm. Magn Reson Med. 2003 Jan;49(1):193–7. doi:<a href="https://doi.org/10.1002/mrm.10354">10.1002/mrm.10354</a>.
+   </p>
+   <p>
+     12. 	Huntenburg JM. Evaluating nonlinear coregistration of BOLD EPI and T1w images. Freie Universität Berlin; 2014. Available from: <a href="http://hdl.handle.net/11858/00-001M-0000-002B-1CB5-A">http://hdl.handle.net/11858/00-001M-0000-002B-1CB5-A</a>.
+   </p>
+   <p>
+     13. 	Wang S, Peterson DJ, Gatenby JC, Li W, Grabowski TJ, Madhyastha TM. Evaluation of Field Map and Nonlinear Registration Methods for Correction of Susceptibility Artifacts in Diffusion MRI. Front Neuroinform. 2017 [cited 2017 Feb 21];11. doi:<a href="https://doi.org/10.3389/fninf.2017.00017">10.3389/fninf.2017.00017</a>.
+   </p>
+   <p>
+     14. 	Treiber JM, White NS, Steed TC, Bartsch H, Holland D, Farid N, McDonald CR, Carter BS, Dale AM, Chen CC. Characterization and Correction of Geometric Distortions in 814 Diffusion Weighted Images. PLoS One. 2016 Mar 30;11(3):e0152472. doi:<a href="https://doi.org/10.1371/journal.pone.0152472">10.1371/journal.pone.0152472</a>.
+   </p>
+   <p>
+     15. 	Greve DN, Fischl B. Accurate and robust brain image alignment using boundary-based registration. Neuroimage. 2009 Oct;48(1):63–72. doi:<a href="https://doi.org/10.1016/j.neuroimage.2009.06.060">10.1016/j.neuroimage.2009.06.060</a>.
+   </p>
+   <p>
+     16. 	Zhang Y, Brady M, Smith S. Segmentation of brain MR images through a hidden Markov random field model and the expectation-maximization algorithm. IEEE Trans Med Imaging. 2001 Jan;20(1):45–57. doi:<a href="https://doi.org/10.1109/42.906424">10.1109/42.906424</a>.
+   </p>
+   <p>
+     17. 	Behzadi Y, Restom K, Liau J, Liu TT. A component based noise correction method (CompCor) for BOLD and perfusion based fMRI. Neuroimage. 2007 Aug 1;37(1):90–101. doi:<a href="https://doi.org/10.1109/42.906424">10.1016/j.neuroimage.2007.04.042</a>.
+   </p>
+   <p>
+     18. 	Power JD, Mitra A, Laumann TO, Snyder AZ, Schlaggar BL, Petersen SE. Methods to detect, characterize, and remove motion artifact in resting state fMRI. Neuroimage. 2013 Aug 29;84:320–41. doi:<a href="https://doi.org/10.1016/j.neuroimage.2013.08.048">10.1016/j.neuroimage.2013.08.048</a>.
+   </p>
+   <p>
+     19. 	Pruim RHR, Mennes M, van Rooij D, Llera A, Buitelaar JK, Beckmann CF. ICA-AROMA: A robust ICA-based strategy for removing motion artifacts from fMRI data. Neuroimage. 2015 May 15;112:267–77. doi:<a href="https://doi.org/10.1016/j.neuroimage.2015.02.064">10.1016/j.neuroimage.2015.02.064</a>.
+   </p>
+   <p>
+     20.   Klein A, Ghosh SS, Bao FS, Giard J, Häme Y, Stavsky E, et al. Mindboggling morphometry of human brains.
+     PLoS Comput Biol 13(2): e1005350. 2017.
+     doi:<a href="https://doi.org/10.1371/journal.pcbi.1005350">10.1371/journal.pcbi.1005350</a>.
+   </p>
+   <p>
+     21.   Abraham A, Pedregosa F, Eickenberg M, Gervais P, Mueller A, Kossaifi J, Gramfort A,
+     Thirion B, Varoquaux G. Machine learning for neuroimaging with scikit-learn. Front in Neuroinf 8:14.
+     2014. doi:<a href="https://doi.org/10.3389/fninf.2014.00014">10.3389/fninf.2014.00014</a>.
+   </p>
+
 
 Posters
 -------

--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -173,6 +173,10 @@ Posters
 Other relevant references
 -------------------------
 
+  .. [Fonov2011] Fonov VS, Evans AC, Botteron K, Almli CR, McKinstry RC, Collins DL and BDCG,
+      Unbiased average age-appropriate atlases for pediatric studies, NeuroImage 54(1), 2011
+      doi:`10.1016/j.neuroimage.2010.07.033 <https://doi.org/10.1016/j.neuroimage.2010.07.033>`_.
+
   .. [Power2017] Power JD, Plitt M, Kundu P, Bandettini PA, Martin A (2017) Temporal interpolation alters
       motion in fMRI scans: Magnitudes and consequences for artifact detection. PLOS ONE 12(9): e0182939.
       doi:`10.1371/journal.pone.0182939 <https://doi.org/10.1371/journal.pone.0182939>`_.

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -132,6 +132,8 @@ flag, which forces the estimation of an unbiased template.
     ``T1w`` space, and not to the input images.
 
 
+.. _workflows_surface:
+
 Surface preprocessing
 ~~~~~~~~~~~~~~~~~~~~~
 :mod:`fmriprep.workflows.anatomical.init_surface_recon_wf`
@@ -205,9 +207,9 @@ Typically, the original brain mask calculated with ``antsBrainExtraction.sh``
 will contain some innaccuracies including small amounts of MR signal from
 outside the brain.
 Based on the tissue segmentation of FreeSurfer (located in ``mri/aseg.mgz``)
-and only when the `Surface Processing`_ step has been executed,
-FMRIPREP replaces the brain mask with a refined one that derives from the
-``aseg.mgz`` file as described in
+and only when the :ref:`Surface Processing <workflows_surface>` step has been
+executed, FMRIPREP replaces the brain mask with a refined one that derives
+from the ``aseg.mgz`` file as described in
 :mod:`fmriprep.workflows.anatomical.init_refine_brainmask_wf`.
 
 

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -72,28 +72,42 @@ T1w/T2w preprocessing
                               hires=True,
                               num_t1w=1)
 
-The anatomical sub-workflow begins by constructing a template image by
-:ref:`conforming <conformation>` any T1-weighted images to RAS orientation and
-a common voxel size, and, in the case of multiple images, merges them into a
-single template (see `Longitudinal processing`_).
-This template is then skull-stripped, and the white matter/gray
-matter/cerebrospinal fluid segments are found.
-Finally, a non-linear registration to the MNI template space is estimated.
+The anatomical sub-workflow begins by constructing an average image by
+:ref:`conforming <conformation>` all found T1w images to RAS orientation and
+a common voxel size, and, in the case of multiple images, averages them into a
+single reference template (see `Longitudinal processing`_).
+
+.. _t1preproc_steps:
+
+Brain extraction, brain tissue segmentation and spatial normalization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Then, the T1w image/average is skull-stripped using ANTs' ``antsBrainExtraction.sh``,
+which is an atlas-based brain extraction workflow.
 
 .. figure:: _static/brainextraction_t1.svg
     :scale: 100%
 
-    Brain extraction (ANTs).
+    Brain extraction
+
+
+Once the brain mask is computed, FSL ``fast`` is utilized for brain tissue segmentation.
 
 .. figure:: _static/segmentation.svg
     :scale: 100%
 
-    Brain tissue segmentation (``fast``).
+    Brain tissue segmentation.
+
+
+Finally, spatial normalization to MNI-space is performed using ANTs' ``antsRegistration``
+in a multiscale, mutual-information based, nonlinear registration scheme.
+In particular, spatial normalization is done using the `ICBM 2009c Nonlinear
+Asymmetric template (1×1×1mm) <http://nist.mni.mcgill.ca/?p=904>`_ [Fonov2011]_.
 
 .. figure:: _static/T1MNINormalization.svg
     :scale: 100%
 
-    Animation showing T1w to MNI normalization (ANTs)
+    Animation showing T1w to MNI normalization
 
 
 Longitudinal processing
@@ -142,6 +156,8 @@ Surface reconstruction is performed in three phases.
 The first phase initializes the subject with T1w and T2w (if available)
 structural images and performs basic reconstruction (``autorecon1``) with the
 exception of skull-stripping.
+Skull-stripping is skipped since the brain mask :ref:`calculated previously
+<t1preproc_steps>` is injected into the appropriate location for FreeSurfer.
 For example, a subject with only one session with T1w and T2w images
 would be processed by the following command::
 
@@ -180,6 +196,19 @@ boundary and the pial surface.
 The ``smoothwm``, ``midthickness``, ``pial`` and ``inflated`` surfaces are also
 converted to GIFTI_ format and adjusted to be compatible with multiple software
 packages, including FreeSurfer and the `Connectome Workbench`_.
+
+
+Refinement of the brain mask
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Typically, the original brain mask calculated with ``antsBrainExtraction.sh``
+will contain some innaccuracies including small amounts of MR signal from
+outside the brain.
+Based on the tissue segmentation of FreeSurfer (located in ``mri/aseg.mgz``)
+and only when the `Surface Processing`_ step has been executed,
+FMRIPREP replaces the brain mask with a refined one that derives from the
+``aseg.mgz`` file as described in
+:mod:`fmriprep.workflows.anatomical.init_refine_brainmask_wf`.
 
 
 BOLD preprocessing

--- a/fmriprep/info.py
+++ b/fmriprep/info.py
@@ -72,6 +72,7 @@ REQUIRES = [
     'nipype',
     'seaborn',
     'indexed_gzip>=0.7.0',
+    'scikit-image',
 ]
 
 LINKS_REQUIRES = [

--- a/fmriprep/interfaces/__init__.py
+++ b/fmriprep/interfaces/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:

--- a/fmriprep/interfaces/__init__.py
+++ b/fmriprep/interfaces/__init__.py
@@ -9,7 +9,8 @@ from .images import (
     IntraModalMerge, InvertT1w, ValidateImage, TemplateDimensions, Conform, Reorient
 )
 from .freesurfer import (
-    StructuralReference, MakeMidthickness, FSInjectBrainExtracted, FSDetectInputs
+    StructuralReference, MakeMidthickness, FSInjectBrainExtracted,
+    FSDetectInputs, RefineBrainMask,
 )
 from .surf import NormalizeSurf, GiftiNameSource, GiftiSetAnatomicalStructure
 from .reports import SubjectSummary, FunctionalSummary, AboutSummary

--- a/fmriprep/interfaces/freesurfer.py
+++ b/fmriprep/interfaces/freesurfer.py
@@ -337,7 +337,7 @@ def grow_mask(anat, aseg, ants_segs, ww=7, zval=2.0, bw=4):
     indices = np.argwhere(newrefmask > 0)
     for pixel in indices:
         # When ATROPOS identified the pixel as GM, set and carry on
-        if ants_segs[tuple(pixel)] == 3:
+        if ants_segs[tuple(pixel)] == 2:
             refined[tuple(pixel)] = 1
             continue
 

--- a/fmriprep/interfaces/freesurfer.py
+++ b/fmriprep/interfaces/freesurfer.py
@@ -228,6 +228,12 @@ class RefineBrainMaskOutputSpec(TraitedSpec):
 
 
 class RefineBrainMask(SimpleInterface):
+    """
+    Refine the brain mask implicit in the ``aseg.mgz``
+    file to include possibly missing gray-matter voxels
+    and deep, wide sulci.
+    """
+
     input_spec = RefineBrainMaskInputSpec
     output_spec = RefineBrainMaskOutputSpec
 

--- a/fmriprep/interfaces/freesurfer.py
+++ b/fmriprep/interfaces/freesurfer.py
@@ -317,7 +317,7 @@ def refine_aseg(aseg, ball_size=4):
     return newmask.astype(np.uint8)
 
 
-def grow_mask(anat, aseg, ants_segs, ww=7, zval=2.0, bw=4):
+def grow_mask(anat, aseg, ants_segs=None, ww=7, zval=2.0, bw=4):
     """
     Grow mask including pixels that have a high likelihood.
     GM tissue parameters are sampled in image patches of ``ww`` size.
@@ -327,6 +327,9 @@ def grow_mask(anat, aseg, ants_segs, ww=7, zval=2.0, bw=4):
 
     """
     selem = sim.ball(bw)
+
+    if ants_segs is None:
+        ants_segs = np.zeros_like(aseg, dtype=np.uint8)
 
     aseg[aseg == 42] = 3  # Collapse both hemispheres
     gm = anat.copy()

--- a/fmriprep/interfaces/freesurfer.py
+++ b/fmriprep/interfaces/freesurfer.py
@@ -240,8 +240,7 @@ class RefineBrainMask(SimpleInterface):
         msknii = nb.Nifti1Image(
             grow_mask(anatnii.get_data(),
                       nb.load(self.inputs.in_aseg).get_data(),
-                      nb.load(self.inputs.in_ants).get_data(),
-            ),
+                      nb.load(self.inputs.in_ants).get_data()),
             anatnii.affine,
             anatnii.header
         )

--- a/fmriprep/interfaces/freesurfer.py
+++ b/fmriprep/interfaces/freesurfer.py
@@ -313,17 +313,14 @@ def refine_aseg(aseg, ball_size=4):
     return newmask.astype(np.uint8)
 
 
-def grow_mask(anat_file, aseg_file, ww=7, zval=2.0, bw=4):
+def grow_mask(anat, aseg, ww=7, zval=2.0, bw=4):
     """
     Grow mask including pixels that have a high likelihood.
     GM tissue parameters are sampled in image patches of ``ww`` size.
     """
     selem = sim.ball(bw)
 
-    aseg = nb.load(aseg_file).get_data().astype(np.uint8)
     aseg[aseg == 42] = 3  # Collapse both hemispheres
-
-    anat = nb.load(anat_file).get_data()
     gm = anat.copy()
     gm[aseg != 3] = 0
 

--- a/fmriprep/interfaces/freesurfer.py
+++ b/fmriprep/interfaces/freesurfer.py
@@ -194,7 +194,7 @@ class PatchedConcatenateLTA(ConcatenateLTA):
     """
 
     def _list_outputs(self):
-        outputs = super(ConcatenateLTA, self)._list_outputs()
+        outputs = super(PatchedConcatenateLTA, self)._list_outputs()
 
         with open(outputs['out_file'], 'r') as f:
             lines = f.readlines()

--- a/fmriprep/interfaces/surf.py
+++ b/fmriprep/interfaces/surf.py
@@ -55,8 +55,13 @@ class NormalizeSurf(SimpleInterface):
     In principle, this should apply safely to any other surface, although it is
     less relevant to surfaces that don't describe an anatomical structure.
 
-    .. _AlgorithmSurfaceApplyAffine: https://github.com/Washington-University/workbench/blob/1b79e56/src/Algorithms/AlgorithmSurfaceApplyAffine.cxx#L73-L91
-    .. _FreeSurfer2CaretConvertAndRegisterNonlinear: https://github.com/Washington-University/Pipelines/blob/ae69b9a/PostFreeSurfer/scripts/FreeSurfer2CaretConvertAndRegisterNonlinear.sh#L147-154
+    .. _AlgorithmSurfaceApplyAffine: https://github.com/Washington-University/workbench\
+/blob/1b79e56/src/Algorithms/AlgorithmSurfaceApplyAffine.cxx#L73-L91
+
+    .. _FreeSurfer2CaretConvertAndRegisterNonlinear: https://github.com/Washington-University/\
+Pipelines/blob/ae69b9a/PostFreeSurfer/scripts/FreeSurfer2CaretConvertAndRegisterNonlinear.sh\
+#L147-154
+
     """
     input_spec = NormalizeSurfInputSpec
     output_spec = NormalizeSurfOutputSpec

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
@@ -8,6 +7,7 @@ Anatomical reference preprocessing workflows
 
 .. autofunction:: init_anat_preproc_wf
 .. autofunction:: init_skullstrip_ants_wf
+.. autofunction:: init_refine_brainmask_wf
 
 Surface preprocessing
 +++++++++++++++++++++
@@ -967,8 +967,8 @@ def init_refine_brainmask_wf(name='refine_brainmask'):
                                ('subject_id', 'subject_id')]),
         (inputnode, tonii, [('in_file', 'reslice_like')]),
         (get_aseg, tonative, [('aseg', 'seg_file'),
-                           ('rawavg', 'template_file'),
-                           ('aseg', 'reg_header')]),
+                              ('rawavg', 'template_file'),
+                              ('aseg', 'reg_header')]),
         (tonative, tonii, [('vol_label_file', 'in_file')]),
         (tonii, refine, [('out_file', 'in_aseg')]),
         (refine, outputnode, [('out_file', 'out_file')]),

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -704,7 +704,7 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
             ('out_reg_file', 'inputnode.t1_2_fsnative_reverse_transform')]),
         (fsnative_2_t1_xfm, t1_2_fsnative_xfm, [('out_reg_file', 'in_lta')]),
         # Refine ANTs mask, deriving new mask from FS' aseg
-        (inputnode, refine_brainmask_wf, [('corrected_t1', 'in_brain')]),
+        (inputnode, refine_brainmask_wf, [('corrected_t1', 'inputnode.in_file')]),
         (autorecon_resume_wf, refine_brainmask_wf, [
             ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
             ('outputnode.subject_id', 'inputnode.subject_id')]),
@@ -715,7 +715,7 @@ def init_surface_recon_wf(omp_nthreads, hires, name='surface_recon_wf'):
         (gifti_surface_wf, outputnode, [('outputnode.surfaces', 'surfaces')]),
         (t1_2_fsnative_xfm, outputnode, [('out_lta', 't1_2_fsnative_forward_transform')]),
         (fsnative_2_t1_xfm, outputnode, [('out_reg_file', 't1_2_fsnative_reverse_transform')]),
-        (refine_brainmask_wf, outputnode, ['outputnode.out_file', 'out_brainmask'])
+        (refine_brainmask_wf, outputnode, [('outputnode.out_file', 'out_brainmask')]),
     ])
 
     return workflow
@@ -967,7 +967,7 @@ def init_refine_brainmask_wf(name='refine_brainmask'):
         (get_aseg, tonii, [('aseg', 'seg_file'),
                            ('rawavg', 'template_file'),
                            ('aseg', 'reg_header')]),
-        (tonii, refine, ['vol_label_file', 'in_aseg']),
+        (tonii, refine, [('vol_label_file', 'in_aseg')]),
         (refine, outputnode, [('out_file', 'out_file')]),
     ])
 

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -292,6 +292,8 @@ def init_anat_preproc_wf(skull_strip_template, output_spaces, template, debug,
                 ('outputnode.surfaces', 'surfaces')]),
         ])
 
+        # Refine brain mask
+
     seg2msks = pe.Node(niu.Function(function=_seg2msks), name='seg2msks')
     seg_rpt = pe.Node(ROIsPlot(colors=['r', 'magenta', 'b', 'g']), name='seg_rpt')
     anat_reports_wf = init_anat_reports_wf(


### PR DESCRIPTION
Use the `aseg.mgz` output of FreeSurfer to derive a refined mask to replace the (generally less conservative) mask calculated with `antsBrainExtraction.sh`.

Closes #431