### PR TITLE
Patch to group bold scans by task AND run

### DIFF
--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -172,7 +172,7 @@ def collect_data(dataset, participant_label, task=None):
                  for modality, query in queries.items()}
 
     def _run_num(x):
-        return re.search("run-\\d*", x).group(0)
+        return re.search("task-\\w*_run-\\d*", x).group(0)
 
     if subj_data["bold"] is not []:
         all_runs = subj_data["bold"]


### PR DESCRIPTION
As discussed in #914, bold runs should not be grouped only by run, as this could yield multiple tasks in the same run sub-list. Instead, both task and run should be used as grouping factors. Tested on `ds000210/sub-02` and `ds000205/sub-07`.