### PR TITLE
[FIX] Revert run grouping (fixes #914)

### DIFF
--- a/fmriprep/utils/bids.py
+++ b/fmriprep/utils/bids.py
@@ -171,16 +171,21 @@ def collect_data(dataset, participant_label, task=None):
     subj_data = {modality: [x.filename for x in layout.get(**query)]
                  for modality, query in queries.items()}
 
-    def _run_num(x):
-        return re.search("task-\\w*_run-\\d*", x).group(0)
+    # OE: temporary disabled (#914)
+    # This bit of code should:
+    # 1. identify multi-echo scans (must contain echo-<index> identifier)
+    # 2. group echoes belonging to the same run, same task or 
+    #    same run and task, always: within same session
+    # def _run_num(x):
+    #     return re.search("task-\\w*_run-\\d*", x).group(0)
 
-    if subj_data["bold"] is not []:
-        all_runs = subj_data["bold"]
-        try:
-            runs = [list(run) for _, run in groupby(all_runs, key=_run_num)]
-            runs = list(map(lambda x: x[0] if len(x) == 1 else x, runs))
-            subj_data.update({"bold": runs})
-        except AttributeError:
-            pass
+    # if subj_data["bold"] is not []:
+    #     all_runs = subj_data["bold"]
+    #     try:
+    #         runs = [list(run) for _, run in groupby(all_runs, key=_run_num)]
+    #         runs = list(map(lambda x: x[0] if len(x) == 1 else x, runs))
+    #         subj_data.update({"bold": runs})
+    #     except AttributeError:
+    #         pass
 
     return subj_data, layout


### PR DESCRIPTION
I'm going to revert this change until we have a fully tested solution. @emdupre, I'll help you set up new tests on both ds000210 and ds000216 (they are multi-echo but have different combinations of tasks and runs).

Alternatively (probably best), we could submit a PR to the BIDS examples with three different multi-echo patterns:

1. With tasks and runs (I think ds000210 is like this)
2. With only tasks (I think ds216)
3. With sessions.

And use this as test data. WDYT @emdupre, @chrisfilo ?