### PR TITLE
Import nibabel in get_ees

### DIFF
--- a/fmriprep/interfaces/fmap.py
+++ b/fmriprep/interfaces/fmap.py
@@ -314,6 +314,8 @@ def get_ees(in_meta, in_file=None):
 
     """
 
+    import nibabel as nb
+
     # Use case 1: EES is defined
     ees = in_meta.get('EffectiveEchoSpacing', None)
     if ees is not None:


### PR DESCRIPTION
When running with a field map without defining `EffectiveEchoSpacing` in the json, getting
```
File "<string>", line 59, in get_ees
NameError: name 'nb' is not defined
```
