### PR TITLE
CI: Do not deploy on branches, only tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,5 +495,7 @@ workflows:
             - ds005
             - ds054
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -438,7 +438,7 @@ workflows:
       - get_data:
           filters:
             branches:
-              ignore: /docs+\/.*/
+              ignore: /docs?\/.*/
             tags:
               only: /.*/
 
@@ -454,7 +454,7 @@ workflows:
             - build
           filters:
             branches:
-              ignore: /docs+\/.*/
+              ignore: /docs?\/.*/
             tags:
               only: /.*/
 
@@ -463,7 +463,7 @@ workflows:
             - build
           filters:
             branches:
-              ignore: /docs+\/.*/
+              ignore: /docs?\/.*/
             tags:
               only: /.*/
 
@@ -473,7 +473,7 @@ workflows:
             - build
           filters:
             branches:
-              ignore: /docs+\/.*/
+              ignore: /docs?\/.*/
             tags:
               only: /.*/
 
@@ -483,7 +483,7 @@ workflows:
             - build
           filters:
             branches:
-              ignore: /docs+\/.*/
+              ignore: /docs?\/.*/
             tags:
               only: /.*/
 


### PR DESCRIPTION
This should keep it from trying to push a new image with every commit to master.