### PR TITLE
[FIX] ROIs Plot and output brain masks consistency

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -487,8 +487,6 @@ Confounds estimation
     from fmriprep.workflows.bold.confounds import init_bold_confs_wf
     wf = init_bold_confs_wf(
         name="discover_wf",
-        use_aroma=False,
-        ignore_aroma_err=False,
         mem_gb=1,
         metadata={"RepetitionTime": 2.0,
                   "SliceTiming": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]})

--- a/fmriprep/interfaces/__init__.py
+++ b/fmriprep/interfaces/__init__.py
@@ -13,7 +13,7 @@ from .freesurfer import (
 )
 from .surf import NormalizeSurf, GiftiNameSource, GiftiSetAnatomicalStructure
 from .reports import SubjectSummary, FunctionalSummary, AboutSummary
-from .utils import TPM2ROI, AddTPMs, AddTSVHeader, ConcatAffines
+from .utils import TPM2ROI, AddTPMs, AddTSVHeader, ConcatAffines, JoinTSVColumns
 from .fmap import FieldEnhance, FieldToRadS, FieldToHz, Phasediff2Fieldmap
 from .confounds import GatherConfounds, ICAConfounds
 from .itk import MCFLIRT2ITK, MultiApplyTransforms

--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -11,6 +11,8 @@ Interfaces to generate reportlets
 
 import os
 import time
+import re
+
 from collections import Counter
 from niworkflows.nipype.interfaces.base import (
     traits, TraitedSpec, BaseInterfaceInputSpec,
@@ -147,7 +149,7 @@ class FunctionalSummaryInputSpec(BaseInterfaceInputSpec):
     registration_dof = traits.Enum(6, 9, 12, desc='Registration degrees of freedom',
                                    mandatory=True)
     output_spaces = traits.List(desc='Target spaces')
-    confounds = traits.List(desc='Confounds collected')
+    confounds_file = File(exists=True, desc='Confounds file')
 
 
 class FunctionalSummary(SummaryInterface):
@@ -174,9 +176,13 @@ class FunctionalSummary(SummaryInterface):
             pedir = 'MISSING - Assuming Anterior-Posterior'
         else:
             pedir = {'i': 'Left-Right', 'j': 'Anterior-Posterior'}[self.inputs.pe_direction[0]]
+
+        if isdefined(self.inputs.confounds_file):
+            with open(self.inputs.confounds_file) as cfh:
+                conflist = cfh.readline().strip('\n').strip()
         return FUNCTIONAL_TEMPLATE.format(pedir=pedir, stc=stc, sdc=sdc, registration=reg,
                                           output_spaces=', '.join(self.inputs.output_spaces),
-                                          confounds=', '.join(self.inputs.confounds))
+                                          confounds=re.sub(' +', ', ', conflist))
 
 
 class AboutSummaryInputSpec(BaseInterfaceInputSpec):

--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -182,7 +182,7 @@ class FunctionalSummary(SummaryInterface):
                 conflist = cfh.readline().strip('\n').strip()
         return FUNCTIONAL_TEMPLATE.format(pedir=pedir, stc=stc, sdc=sdc, registration=reg,
                                           output_spaces=', '.join(self.inputs.output_spaces),
-                                          confounds=re.sub(' +', ', ', conflist))
+                                          confounds=re.sub(r'[\t ]+', ', ', conflist))
 
 
 class AboutSummaryInputSpec(BaseInterfaceInputSpec):

--- a/fmriprep/interfaces/utils.py
+++ b/fmriprep/interfaces/utils.py
@@ -197,6 +197,126 @@ class AddTSVHeader(SimpleInterface):
         return runtime
 
 
+class JoinTSVColumnsInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc='input file')
+    join_file = File(exists=True, mandatory=True, desc='file to be adjoined')
+    side = traits.Enum('right', 'left', usedefault=True, desc='where to join')
+    columns = traits.List(traits.Str, desc='header for columns')
+
+
+class JoinTSVColumnsOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc='output TSV file')
+
+
+class JoinTSVColumns(SimpleInterface):
+    """Add a header row to a TSV file
+
+    .. testsetup::
+
+    >>> import os
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from tempfile import TemporaryDirectory
+    >>> tmpdir = TemporaryDirectory()
+    >>> os.chdir(tmpdir.name)
+
+    .. doctest::
+
+    An example TSV:
+
+    >>> data = np.arange(30).reshape((6, 5))
+    >>> np.savetxt('data.tsv', data[:, :3], delimiter='\t', fmt='%.1f')
+    >>> np.savetxt('add.tsv', data[:, 3:], delimiter='\t', fmt='%.1f')
+
+    Add headers:
+
+    >>> from fmriprep.interfaces import JoinTSVColumns
+    >>> join = JoinTSVColumns()
+    >>> join.inputs.in_file = 'data.tsv'
+    >>> join.inputs.join_file = 'add.tsv'
+    >>> join.inputs.columns = ['a', 'b', 'c', 'd', 'e']
+    >>> res = join.run()
+    >>> res.outputs.out_file  # doctest: +ELLIPSIS
+    '...data_joined.tsv'
+    >>> pd.read_csv(res.outputs.out_file, sep='\s+', index_col=None,
+    ...             engine='python')  # doctest: +NORMALIZE_WHITESPACE
+          a     b     c     d     e
+    0   0.0   1.0   2.0   3.0   4.0
+    1   5.0   6.0   7.0   8.0   9.0
+    2  10.0  11.0  12.0  13.0  14.0
+    3  15.0  16.0  17.0  18.0  19.0
+    4  20.0  21.0  22.0  23.0  24.0
+    5  25.0  26.0  27.0  28.0  29.0
+
+    >>> join = JoinTSVColumns()
+    >>> join.inputs.in_file = 'data.tsv'
+    >>> join.inputs.join_file = 'add.tsv'
+    >>> res = join.run()
+    >>> pd.read_csv(res.outputs.out_file, sep='\s+', index_col=None,
+    ...             engine='python')  # doctest: +NORMALIZE_WHITESPACE
+        0.0   1.0   2.0   3.0   4.0
+    0   5.0   6.0   7.0   8.0   9.0
+    1  10.0  11.0  12.0  13.0  14.0
+    2  15.0  16.0  17.0  18.0  19.0
+    3  20.0  21.0  22.0  23.0  24.0
+    4  25.0  26.0  27.0  28.0  29.0
+
+    >>> join = JoinTSVColumns()
+    >>> join.inputs.in_file = 'data.tsv'
+    >>> join.inputs.join_file = 'add.tsv'
+    >>> join.inputs.side = 'left'
+    >>> join.inputs.columns = ['a', 'b', 'c', 'd', 'e']
+    >>> res = join.run()
+    >>> pd.read_csv(res.outputs.out_file, sep='\s+', index_col=None,
+    ...             engine='python')  # doctest: +NORMALIZE_WHITESPACE
+          a     b     c    d     e
+    0   3.0   4.0  0.0   1.0   2.0
+    1   8.0   9.0  5.0   6.0   7.0
+    2  13.0  14.0 10.0  11.0  12.0
+    3  18.0  19.0 15.0  16.0  17.0
+    4  23.0  24.0 20.0  21.0  22.0
+    5  28.0  29.0 25.0  26.0  27.0
+
+    .. testcleanup::
+
+    >>> tmpdir.cleanup()
+
+    """
+    input_spec = JoinTSVColumnsInputSpec
+    output_spec = JoinTSVColumnsOutputSpec
+
+    def _run_interface(self, runtime):
+        out_file = fname_presuffix(
+            self.inputs.in_file, suffix='_joined.tsv', newpath=runtime.cwd,
+            use_ext=False)
+
+        header = ''
+        if isdefined(self.inputs.columns) and self.inputs.columns:
+            header = '\t'.join(self.inputs.columns)
+
+        with open(self.inputs.in_file) as ifh:
+            data = ifh.read().splitlines(keepends=False)
+
+        with open(self.inputs.join_file) as ifh:
+            join = ifh.read().splitlines(keepends=False)
+
+        assert len(data) == len(join)
+
+        merged = []
+        for d, j in zip(data, join):
+            line = '%s\t%s' % ((j, d) if self.inputs.side == 'left' else (d, j))
+            merged.append(line)
+
+        if header:
+            merged.insert(0, header)
+
+        with open(out_file, 'w') as ofh:
+            ofh.write('\n'.join(merged))
+
+        self._results['out_file'] = out_file
+        return runtime
+
+
 class ConcatAffinesInputSpec(DynamicTraitedSpec, BaseInterfaceInputSpec):
     invert = traits.Bool(False, usedefault=True, desc='Invert output transform')
 

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -386,7 +386,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
             (bold_reference_wf, bold_stc_wf, [('outputnode.bold_file', 'inputnode.bold_file'),
                                               ('outputnode.skip_vols', 'inputnode.skip_vols')]),
         ])
-    else:  # bypass STD from original BOLD to the splitter through boldbuffer
+    else:  # bypass STC from original BOLD to the splitter through boldbuffer
         workflow.connect([
             (bold_reference_wf, boldbuffer, [
                 ('outputnode.bold_file', 'bold_file')]),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -608,8 +608,8 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
             (bold_bold_trans_wf, boldmask_to_t1w, [
                 ('outputnode.bold_mask', 'input_image')]),
             (bold_reg_wf, boldmask_to_t1w, [
-                ('outputnode.bold_t1', 'reference_image'),
-                ('outputnode.bold_mask_t1', 'transforms')]),
+                ('outputnode.bold_mask_t1', 'reference_image'),
+                ('outputnode.itk_bold_to_t1', 'transforms')]),
             (boldmask_to_t1w, outputnode, [
                 ('output_image', 'bold_mask_t1')]),
         ])

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -204,6 +204,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
         * :py:func:`~fmriprep.workflows.bold.t2s.init_bold_t2s_wf`
         * :py:func:`~fmriprep.workflows.bold.registration.init_bold_reg_wf`
         * :py:func:`~fmriprep.workflows.bold.confounds.init_bold_confounds_wf`
+        * :py:func:`~fmriprep.workflows.bold.confounds.init_ica_aroma_wf`
         * :py:func:`~fmriprep.workflows.bold.resampling.init_bold_mni_trans_wf`
         * :py:func:`~fmriprep.workflows.bold.resampling.init_bold_preproc_trans_wf`
         * :py:func:`~fmriprep.workflows.bold.resampling.init_bold_surf_wf`
@@ -289,6 +290,10 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
                 't2s_map', 'aroma_noise_ics', 'melodic_mix', 'nonaggr_denoised_file']),
         name='outputnode')
 
+    # BOLD buffer: an identity used as a pointer to either the original BOLD
+    # or the STC'ed one for further use.
+    boldbuffer = pe.Node(niu.IdentityInterface(fields=['bold_file']), name='boldbuffer')
+
     summary = pe.Node(
         FunctionalSummary(output_spaces=output_spaces,
                           slice_timing=run_stc,
@@ -330,11 +335,6 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
     bold_reference_wf = init_bold_reference_wf(
         omp_nthreads=omp_nthreads, enhance_t2=True)
 
-    # STC on the BOLD
-    # bool('TooShort') == True, so check True explicitly
-    if run_stc is True:
-        bold_stc_wf = init_bold_stc_wf(name='bold_stc_wf', metadata=metadata)
-
     # Top-level BOLD splitter
     bold_split = pe.Node(FSLSplit(dimension='t'), name='bold_split',
                          mem_gb=mem_gb['filesize'] * 3)
@@ -364,8 +364,6 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
     # get confounds
     bold_confounds_wf = init_bold_confs_wf(
         mem_gb=mem_gb['largemem'],
-        use_aroma=use_aroma,
-        ignore_aroma_err=ignore_aroma_err,
         metadata=metadata,
         name='bold_confounds_wf')
     bold_confounds_wf.get_node('inputnode').inputs.t1_transform_flags = [False]
@@ -380,11 +378,32 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
         name='bold_bold_trans_wf'
     )
 
+    # SLICE-TIME CORRECTION (or bypass) #############################################
+    if run_stc is True:  # bool('TooShort') == True, so check True explicitly
+        bold_stc_wf = init_bold_stc_wf(name='bold_stc_wf', metadata=metadata)
+        workflow.connect([
+            (bold_stc_wf, boldbuffer, [('outputnode.stc_file', 'bold_file')]),
+            (bold_reference_wf, bold_stc_wf, [('outputnode.bold_file', 'inputnode.bold_file'),
+                                              ('outputnode.skip_vols', 'inputnode.skip_vols')]),
+        ])
+    else:  # bypass STD from original BOLD to the splitter through boldbuffer
+        workflow.connect([
+            (bold_reference_wf, boldbuffer, [
+                ('outputnode.bold_file', 'bold_file')]),
+        ])
+
+    # MAIN WORKFLOW STRUCTURE #######################################################
     workflow.connect([
+        # BOLD buffer has slice-time corrected if it was run, original otherwise
+        (boldbuffer, bold_split, [('bold_file', 'in_file')]),
+        # Generate early reference
         (inputnode, bold_reference_wf, [('bold_file', 'inputnode.bold_file')]),
         (bold_reference_wf, bold_hmc_wf, [
             ('outputnode.raw_ref_image', 'inputnode.raw_ref_image'),
             ('outputnode.bold_file', 'inputnode.bold_file')]),
+        (bold_reference_wf, func_reports_wf, [
+            ('outputnode.validation_report', 'inputnode.validation_report')]),
+        # EPI-T1 registration workflow
         (inputnode, bold_reg_wf, [
             ('bold_file', 'inputnode.name_source'),
             ('t1_preproc', 'inputnode.t1_preproc'),
@@ -397,58 +416,46 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
             ('subjects_dir', 'inputnode.subjects_dir'),
             ('subject_id', 'inputnode.subject_id'),
             ('t1_2_fsnative_reverse_transform', 'inputnode.t1_2_fsnative_reverse_transform')]),
-        (inputnode, bold_confounds_wf, [('t1_tpms', 'inputnode.t1_tpms'),
-                                        ('t1_mask', 'inputnode.t1_mask')]),
         (bold_split, bold_reg_wf, [('out_files', 'inputnode.bold_split')]),
         (bold_hmc_wf, bold_reg_wf, [('outputnode.xforms', 'inputnode.hmc_xforms')]),
-        (bold_hmc_wf, bold_confounds_wf, [('outputnode.movpar_file', 'inputnode.movpar_file')]),
-        (bold_reference_wf, func_reports_wf, [
-            ('outputnode.validation_report', 'inputnode.validation_report')]),
         (bold_reg_wf, func_reports_wf, [
             ('outputnode.out_report', 'inputnode.bold_reg_report'),
             ('outputnode.fallback', 'inputnode.bold_reg_fallback'),
-        ]),
-        (bold_confounds_wf, outputnode, [
-            ('outputnode.confounds_file', 'confounds'),
-            ('outputnode.aroma_noise_ics', 'aroma_noise_ics'),
-            ('outputnode.melodic_mix', 'melodic_mix'),
-            ('outputnode.nonaggr_denoised_file', 'nonaggr_denoised_file'),
         ]),
         (bold_reg_wf, outputnode, [('outputnode.bold_t1', 'bold_t1'),
                                    ('outputnode.bold_mask_t1', 'bold_mask_t1'),
                                    ('outputnode.bold_aseg_t1', 'bold_aseg_t1'),
                                    ('outputnode.bold_aparc_t1', 'bold_aparc_t1')]),
-        (bold_confounds_wf, func_reports_wf, [
-            ('outputnode.rois_report', 'inputnode.bold_rois_report'),
-            ('outputnode.ica_aroma_report', 'inputnode.ica_aroma_report')]),
-        (bold_confounds_wf, summary, [('outputnode.confounds_list', 'confounds')]),
         (bold_reg_wf, summary, [('outputnode.fallback', 'fallback')]),
-        (summary, func_reports_wf, [('out_report', 'inputnode.summary_report')]),
+        # Connect bold_confounds_wf
+        (inputnode, bold_confounds_wf, [('t1_tpms', 'inputnode.t1_tpms'),
+                                        ('t1_mask', 'inputnode.t1_mask')]),
+        (bold_hmc_wf, bold_confounds_wf, [
+            ('outputnode.movpar_file', 'inputnode.movpar_file')]),
+        (bold_reg_wf, bold_confounds_wf, [
+            ('outputnode.itk_t1_to_bold', 'inputnode.t1_bold_xform')]),
+        (bold_confounds_wf, func_reports_wf, [
+            ('outputnode.rois_report', 'inputnode.bold_rois_report')]),
+        (bold_confounds_wf, outputnode, [
+            ('outputnode.confounds_file', 'confounds'),
+        ]),
+        # Connect bold_bold_trans_wf
+        (inputnode, bold_bold_trans_wf, [
+            ('bold_file', 'inputnode.name_source')]),
         (bold_split, bold_bold_trans_wf, [
             ('out_files', 'inputnode.bold_split')]),
+        (bold_hmc_wf, bold_bold_trans_wf, [
+            ('outputnode.xforms', 'inputnode.hmc_xforms')]),
+        (bold_bold_trans_wf, bold_confounds_wf, [
+            ('outputnode.bold', 'inputnode.bold'),
+            ('outputnode.bold_mask', 'inputnode.bold_mask')]),
+        # Summary
+        (outputnode, summary, [('confounds', 'confounds_file')]),
+        (summary, func_reports_wf, [('out_report', 'inputnode.summary_report')]),
     ])
 
-    # bool('TooShort') == True, so check True explicitly
-    if run_stc is True:
-        workflow.connect([
-            (bold_reference_wf, bold_stc_wf, [('outputnode.bold_file', 'inputnode.bold_file'),
-                                              ('outputnode.skip_vols', 'inputnode.skip_vols')]),
-            (bold_stc_wf, bold_split, [('outputnode.stc_file', 'in_file')]),
-        ])
-    else:
-        workflow.connect([
-            (bold_reference_wf, bold_split, [
-                ('outputnode.bold_file', 'in_file')]),
-        ])
-
-    # Cases:
-    # fmaps | use_syn | force_syn  |  ACTION
-    # ----------------------------------------------
-    #   T   |    *    |     T      | Fieldmaps + SyN
-    #   T   |    *    |     F      | Fieldmaps
-    #   F   |    *    |     T      | SyN
-    #   F   |    T    |     F      | SyN
-    #   F   |    F    |     F      | HMC only
+    # FIELDMAPS ################################################################
+    # Table of behavior is now found under workflows/fieldmap/base.py
 
     # Predefine to pacify the lintian checks about
     # "could be used before defined" - logic was tested to be sound
@@ -569,6 +576,25 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
                     ('outputnode.out_mask', 'inputnode.ref_bold_mask')]),
             ])
 
+    # BOLD in native BOLD space
+    if fmaps:
+        workflow.connect([
+            (sdc_unwarp_wf, bold_bold_trans_wf, [
+                ('outputnode.out_warp', 'inputnode.fieldwarp'),
+                ('outputnode.out_mask', 'inputnode.bold_mask')]),
+        ])
+    elif use_syn:
+        workflow.connect([
+            (nonlinear_sdc_wf, bold_bold_trans_wf, [
+                ('outputnode.out_warp', 'inputnode.fieldwarp'),
+                ('outputnode.out_mask', 'inputnode.bold_mask')]),
+        ])
+    else:
+        workflow.connect([
+            (bold_reference_wf, bold_bold_trans_wf, [
+                ('outputnode.bold_mask', 'inputnode.bold_mask')]),
+        ])
+
     if 'template' in output_spaces:
         # Apply transforms in 1 shot
         # Only use uncompressed output if AROMA is to be run
@@ -592,72 +618,64 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
                 ('outputnode.xforms', 'inputnode.hmc_xforms')]),
             (bold_reg_wf, bold_mni_trans_wf, [
                 ('outputnode.itk_bold_to_t1', 'inputnode.itk_bold_to_t1')]),
+            (bold_bold_trans_wf, bold_mni_trans_wf, [
+                ('outputnode.bold_mask', 'inputnode.bold_mask')]),
             (bold_mni_trans_wf, outputnode, [('outputnode.bold_mni', 'bold_mni'),
                                              ('outputnode.bold_mask_mni', 'bold_mask_mni')]),
-            (bold_mni_trans_wf, bold_confounds_wf, [
-                ('outputnode.bold_mask_mni', 'inputnode.bold_mask_mni'),
-                ('outputnode.bold_mni', 'inputnode.bold_mni')])
         ])
 
         if fmaps:
             workflow.connect([
                 (sdc_unwarp_wf, bold_mni_trans_wf, [
-                    ('outputnode.out_warp', 'inputnode.fieldwarp'),
-                    ('outputnode.out_mask', 'inputnode.bold_mask')]),
+                    ('outputnode.out_warp', 'inputnode.fieldwarp')]),
             ])
         elif use_syn:
             workflow.connect([
                 (nonlinear_sdc_wf, bold_mni_trans_wf, [
-                    ('outputnode.out_warp', 'inputnode.fieldwarp'),
-                    ('outputnode.out_mask', 'inputnode.bold_mask')]),
+                    ('outputnode.out_warp', 'inputnode.fieldwarp')]),
             ])
-        else:
+
+        if use_aroma:  # ICA-AROMA workflow
+            """
+            ica_aroma_report
+                Reportlet visualizing MELODIC ICs, with ICA-AROMA signal/noise labels
+            aroma_noise_ics
+                CSV of noise components identified by ICA-AROMA
+            melodic_mix
+                FSL MELODIC mixing matrix
+            nonaggr_denoised_file
+                BOLD series with non-aggressive ICA-AROMA denoising applied
+
+            """
+            from .confounds import init_ica_aroma_wf
+            from ...interfaces import JoinTSVColumns
+            ica_aroma_wf = init_ica_aroma_wf(name='ica_aroma_wf',
+                                             ignore_aroma_err=ignore_aroma_err)
+            join = pe.Node(JoinTSVColumns(), name='aroma_confounds')
+
+            workflow.disconnect([
+                (bold_confounds_wf, outputnode, [
+                    ('outputnode.confounds_file', 'confounds'),
+                ]),
+            ])
             workflow.connect([
-                (bold_reference_wf, bold_mni_trans_wf, [
-                    ('outputnode.bold_mask', 'inputnode.bold_mask')]),
+                (bold_hmc_wf, ica_aroma_wf, [
+                    ('outputnode.movpar_file', 'inputnode.movpar_file')]),
+                (bold_mni_trans_wf, ica_aroma_wf, [
+                    ('outputnode.bold_mask_mni', 'inputnode.bold_mask_mni'),
+                    ('outputnode.bold_mni', 'inputnode.bold_mni')]),
+                (bold_confounds_wf, join, [
+                    ('outputnode.confounds_file', 'in_file')]),
+                (ica_aroma_wf, join,
+                    [('outputnode.aroma_confounds', 'join_file')]),
+                (ica_aroma_wf, outputnode,
+                    [('outputnode.aroma_noise_ics', 'aroma_noise_ics'),
+                     ('outputnode.melodic_mix', 'melodic_mix'),
+                     ('outputnode.nonaggr_denoised_file', 'nonaggr_denoised_file')]),
+                (join, outputnode, [('out_file', 'confounds')]),
+                (ica_aroma_wf, func_reports_wf, [
+                    ('outputnode.out_report', 'inputnode.ica_aroma_report')]),
             ])
-
-    # REPORTING ############################################################
-
-    bold_bold_report_wf = init_bold_preproc_report_wf(
-        mem_gb=mem_gb['resampled'],
-        reportlets_dir=reportlets_dir
-    )
-
-    workflow.connect([
-        (inputnode, bold_bold_trans_wf, [
-            ('bold_file', 'inputnode.name_source')]),
-        (bold_hmc_wf, bold_bold_trans_wf, [
-            ('outputnode.xforms', 'inputnode.hmc_xforms')]),
-        (bold_reg_wf, bold_confounds_wf, [
-            ('outputnode.itk_t1_to_bold', 'inputnode.t1_bold_xform')]),
-        (bold_bold_trans_wf, bold_confounds_wf, [
-            ('outputnode.bold', 'inputnode.bold'),
-            ('outputnode.bold_mask', 'inputnode.bold_mask')]),
-        (inputnode, bold_bold_report_wf, [
-            ('bold_file', 'inputnode.name_source'),
-            ('bold_file', 'inputnode.in_pre')]),  # This should be after STC
-        (bold_bold_trans_wf, bold_bold_report_wf, [
-            ('outputnode.bold', 'inputnode.in_post')]),
-    ])
-
-    if fmaps:
-        workflow.connect([
-            (sdc_unwarp_wf, bold_bold_trans_wf, [
-                ('outputnode.out_warp', 'inputnode.fieldwarp'),
-                ('outputnode.out_mask', 'inputnode.bold_mask')]),
-        ])
-    elif use_syn:
-        workflow.connect([
-            (nonlinear_sdc_wf, bold_bold_trans_wf, [
-                ('outputnode.out_warp', 'inputnode.fieldwarp'),
-                ('outputnode.out_mask', 'inputnode.bold_mask')]),
-        ])
-    else:
-        workflow.connect([
-            (bold_reference_wf, bold_bold_trans_wf, [
-                ('outputnode.bold_mask', 'inputnode.bold_mask')]),
-        ])
 
     # SURFACES ##################################################################################
     if freesurfer and any(space.startswith('fs') for space in output_spaces):
@@ -675,6 +693,20 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
             (bold_reg_wf, bold_surf_wf, [('outputnode.bold_t1', 'inputnode.source_file')]),
             (bold_surf_wf, outputnode, [('outputnode.surfaces', 'surfaces')]),
         ])
+
+    # REPORTING ############################################################
+    bold_bold_report_wf = init_bold_preproc_report_wf(
+        mem_gb=mem_gb['resampled'],
+        reportlets_dir=reportlets_dir
+    )
+
+    workflow.connect([
+        (inputnode, bold_bold_report_wf, [
+            ('bold_file', 'inputnode.name_source'),
+            ('bold_file', 'inputnode.in_pre')]),  # This should be after STC
+        (bold_bold_trans_wf, bold_bold_report_wf, [
+            ('outputnode.bold', 'inputnode.in_post')]),
+    ])
 
     return workflow
 

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -606,7 +606,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
         )
         workflow.connect([
             (bold_bold_trans_wf, boldmask_to_t1w, [
-                ('outputnode.bold_mask', 'inputnode.bold_mask')]),
+                ('outputnode.bold_mask', 'input_image')]),
             (bold_reg_wf, boldmask_to_t1w, [
                 ('outputnode.bold_t1', 'reference_image'),
                 ('outputnode.bold_mask_t1', 'transforms')]),

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -94,8 +94,6 @@ def init_bold_confs_wf(mem_gb, metadata, name="bold_confs_wf"):
 
         confounds_file
             TSV of all aggregated confounds
-        confounds_list
-            List of calculated confounds for reporting
         rois_report
             Reportlet visualizing white-matter/CSF mask used for aCompCor,
             the ROI for tCompCor and the BOLD brain mask.
@@ -107,7 +105,7 @@ def init_bold_confs_wf(mem_gb, metadata, name="bold_confs_wf"):
                 't1_bold_xform']),
         name='inputnode')
     outputnode = pe.Node(niu.IdentityInterface(
-        fields=['confounds_file', 'confounds_list', 'rois_report']),
+        fields=['confounds_file', 'rois_report']),
         name='outputnode')
 
     # Get masks ready in T1w space
@@ -249,8 +247,7 @@ def init_bold_confs_wf(mem_gb, metadata, name="bold_confs_wf"):
         (add_header, concat, [('out_file', 'motion')]),
 
         # Set outputs
-        (concat, outputnode, [('confounds_file', 'confounds_file'),
-                              ('confounds_list', 'confounds_list')]),
+        (concat, outputnode, [('confounds_file', 'confounds_file')]),
         (inputnode, rois_plot, [('bold', 'in_file'),
                                 ('bold_mask', 'in_mask')]),
         (tcompcor, mrg_compcor, [('high_variance_masks', 'in1')]),

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -27,8 +27,7 @@ from ...interfaces.patches import (
 )
 
 
-def init_bold_confs_wf(mem_gb, use_aroma, ignore_aroma_err, metadata,
-                       name="bold_confs_wf"):
+def init_bold_confs_wf(mem_gb, metadata, name="bold_confs_wf"):
     """
     This workflow calculates confounds for a BOLD series, and aggregates them
     into a :abbr:`TSV (tab-separated value)` file, for use as nuisance
@@ -48,8 +47,7 @@ def init_bold_confs_wf(mem_gb, use_aroma, ignore_aroma_err, metadata,
     #. Non-steady-state volumes (``NonSteadyStateXX``)
     #. Estimated head-motion parameters, in mm and rad
        (``X``, ``Y``, ``Z``, ``RotX``, ``RotY``, ``RotZ``)
-    #. ICA-AROMA-identified noise components, if enabled
-       (``AROMAAggrCompXX``)
+
 
     Prior to estimating aCompCor and tCompCor, non-steady-state volumes are
     censored and high-pass filtered using a :abbr:`DCT (discrete cosine
@@ -64,8 +62,6 @@ def init_bold_confs_wf(mem_gb, use_aroma, ignore_aroma_err, metadata,
         from fmriprep.workflows.bold.confounds import init_bold_confs_wf
         wf = init_bold_confs_wf(
             mem_gb=1,
-            use_aroma=True,
-            ignore_aroma_err=True,
             metadata={})
 
     **Parameters**
@@ -74,10 +70,6 @@ def init_bold_confs_wf(mem_gb, use_aroma, ignore_aroma_err, metadata,
             Size of BOLD file in GB - please note that this size
             should be calculated after resamplings that may extend
             the FoV
-        use_aroma : bool
-            Perform ICA-AROMA on MNI-resampled functional series
-        ignore_aroma_err : bool
-            Do not fail on ICA-AROMA errors
         metadata : dict
             BIDS metadata for BOLD file
 
@@ -97,11 +89,6 @@ def init_bold_confs_wf(mem_gb, use_aroma, ignore_aroma_err, metadata,
         t1_bold_xform
             Affine matrix that maps the T1w space into alignment with
             the native BOLD space
-        bold_mni
-            BOLD image resampled in MNI space (only if ``use_aroma`` enabled)
-        bold_mask_mni
-            Brain mask corresponding to the BOLD image resampled in MNI space
-            (only if ``use_aroma`` enabled)
 
     **Outputs**
 
@@ -109,32 +96,18 @@ def init_bold_confs_wf(mem_gb, use_aroma, ignore_aroma_err, metadata,
             TSV of all aggregated confounds
         confounds_list
             List of calculated confounds for reporting
-        acompcor_report
-            Reportlet visualizing white-matter/CSF mask used for aCompCor
-        tcompcor_report
-            Reportlet visualizing ROI identified in tCompCor
-        ica_aroma_report
-            Reportlet visualizing MELODIC ICs, with ICA-AROMA signal/noise labels
-        aroma_noise_ics
-            CSV of noise components identified by ICA-AROMA
-        melodic_mix
-            FSL MELODIC mixing matrix
-        nonaggr_denoised_file
-            BOLD series with non-aggressive ICA-AROMA denoising applied
-
-    **Subworkflows**
-
-        * :py:func:`~fmriprep.workflows.bold.confounds.init_ica_aroma_wf`
+        rois_report
+            Reportlet visualizing white-matter/CSF mask used for aCompCor,
+            the ROI for tCompCor and the BOLD brain mask.
 
     """
 
     inputnode = pe.Node(niu.IdentityInterface(
         fields=['bold', 'bold_mask', 'movpar_file', 't1_mask', 't1_tpms',
-                't1_bold_xform', 'bold_mni', 'bold_mask_mni']),
+                't1_bold_xform']),
         name='inputnode')
     outputnode = pe.Node(niu.IdentityInterface(
-        fields=['confounds_file', 'confounds_list', 'rois_report', 'ica_aroma_report',
-                'aroma_noise_ics', 'melodic_mix', 'nonaggr_denoised_file']),
+        fields=['confounds_file', 'confounds_list', 'rois_report']),
         name='outputnode')
 
     # Get masks ready in T1w space
@@ -286,22 +259,6 @@ def init_bold_confs_wf(mem_gb, use_aroma, ignore_aroma_err, metadata,
         (rois_plot, outputnode, [('out_report', 'rois_report')]),
     ])
 
-    if use_aroma:
-        # ICA-AROMA
-        ica_aroma_wf = init_ica_aroma_wf(name='ica_aroma_wf',
-                                         ignore_aroma_err=ignore_aroma_err)
-        workflow.connect([
-            (inputnode, ica_aroma_wf, [('bold_mni', 'inputnode.bold_mni'),
-                                       ('bold_mask_mni', 'inputnode.bold_mask_mni'),
-                                       ('movpar_file', 'inputnode.movpar_file')]),
-            (ica_aroma_wf, concat,
-                [('outputnode.aroma_confounds', 'aroma')]),
-            (ica_aroma_wf, outputnode,
-                [('outputnode.out_report', 'ica_aroma_report'),
-                 ('outputnode.aroma_noise_ics', 'aroma_noise_ics'),
-                 ('outputnode.melodic_mix', 'melodic_mix'),
-                 ('outputnode.nonaggr_denoised_file', 'nonaggr_denoised_file')])
-        ])
     return workflow
 
 
@@ -318,6 +275,8 @@ def init_ica_aroma_wf(name='ica_aroma_wf', ignore_aroma_err=False):
     #. Aggregate identified motion components (aggressive) to TSV
     #. Return classified_motion_ICs and melodic_mix for user to complete
         non-aggressive denoising in T1w space
+    #. Calculate ICA-AROMA-identified noise components
+        (columns named ``AROMAAggrCompXX``)
 
     Additionally, non-aggressive denoising is performed on the BOLD series
     resampled into MNI space.

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -266,7 +266,7 @@ def init_bold_mni_trans_wf(template, mem_gb, omp_nthreads,
         workflow.connect([(inputnode, merge_xforms, [('fieldwarp', 'in3')])])
 
     workflow.connect([
-        (inputnode, gen_ref, [('bold_mask', 'moving_image')]),
+        (inputnode, gen_ref, [(('bold_split', _first), 'moving_image')]),
         (inputnode, mask_merge_tfms, [('t1_2_mni_forward_transform', 'in1'),
                                       (('itk_bold_to_t1', _aslist), 'in2')]),
         (mask_merge_tfms, mask_mni_tfm, [('out', 'transforms')]),

--- a/fmriprep/workflows/tests/test_confounds.py
+++ b/fmriprep/workflows/tests/test_confounds.py
@@ -12,7 +12,7 @@ class TestConfounds(TestWorkflow):
     def test_confounds_wf(self):
         # run
         workflow = init_bold_confs_wf(
-            mem_gb=1, use_aroma=False, ignore_aroma_err=False,
+            mem_gb=1,
             metadata={"RepetitionTime": 2.0,
                       "SliceTiming": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]})
         workflow.write_hierarchical_dotfile()


### PR DESCRIPTION
Now, the brain mask written out to the derivatives folder is the mask presented in the ROIs plot, but in MNI space.

Fixes (the MNI part of) #963.

Changes:

  - [x] A lot of refactoring is going on here, as I had to take the AROMA workflow out of the confounds workflow (otherwise, directly connecting masks would create cycles in the graph).
  - [x] Also added some comments along the workflow building process to make the file more readable.
  - [x] Added a new ``JoinTSVColumns`` interface to enable adding confounds columns to an existing file (in practice: this is used to add the AROMA confounds to the base file).
  - [x] Summary node now takes the confounds file as input, instead of the confounds_list