### PR TITLE
[FIX] Use metadata to select shortest echo as ref_file

### DIFF
--- a/fmriprep/interfaces/multiecho.py
+++ b/fmriprep/interfaces/multiecho.py
@@ -36,6 +36,7 @@ class FirstEchoInputSpec(BaseInterfaceInputSpec):
     ref_imgs = InputMultiPath(File(exists=True), mandatory=True, minlen=2,
                               desc='generated reference image for each '
                               'multi-echo BOLD EPI')
+    te_list = traits.List(traits.Float, mandatory=True, desc='echo times')
 
 
 class FirstEchoOutputSpec(TraitedSpec):
@@ -60,6 +61,7 @@ class FirstEcho(SimpleInterface):
     >>> first_echo.inputs.ref_imgs = ['sub-01_run-01_echo-1_bold.nii.gz', \
                                       'sub-01_run-01_echo-2_bold.nii.gz', \
                                       'sub-01_run-01_echo-3_bold.nii.gz']
+    >>> first_echo.inputs.te_list = [0.013, 0.027, 0.043]
     >>> res = first_echo.run()
     >>> res.outputs.first_image
     'sub-01_run-01_echo-1_bold.nii.gz'
@@ -70,8 +72,8 @@ class FirstEcho(SimpleInterface):
     output_spec = FirstEchoOutputSpec
 
     def _run_interface(self, runtime):
-        self._results['first_image'] = sorted(self.inputs.in_files)[0]
-        self._results['first_ref_image'] = sorted(self.inputs.ref_imgs)[0]
+        self._results['first_image'] = self.inputs.in_files[np.argmin(self.inputs.te_list)]
+        self._results['first_ref_image'] = self.inputs.ref_imgs[np.argmin(self.inputs.te_list)]
 
         return runtime
 

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -450,9 +450,8 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
     if multiecho:
         inputnode.iterables = ('bold_file', bold_file)
 
-        me_first_echo = pe.JoinNode(interface=FirstEcho(),
-                                    joinfield=['in_files',
-                                               'ref_imgs'],
+        me_first_echo = pe.JoinNode(interface=FirstEcho(te_list=tes),
+                                    joinfield=['in_files', 'ref_imgs'],
                                     joinsource='inputnode',
                                     name='me_first_echo')
         workflow.connect([

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -216,17 +216,16 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
 
     """
 
-    if bold_file == '/completely/made/up/path/sub-01_task-nback_bold.nii.gz':
-        mem_gb = {'filesize': 1, 'resampled': 1, 'largemem': 1}
-        bold_tlen = 10
-        ref_file = bold_file
-    else:
-        multiecho = isinstance(bold_file, list)
-        if multiecho:
-            tes = [layout.get_metadata(echo)['EchoTime'] for echo in bold_file]
-            ref_file = dict(zip(tes, bold_file))[min(tes)]
-        else:
-            ref_file = bold_file
+    ref_file = bold_file
+    mem_gb = {'filesize': 1, 'resampled': 1, 'largemem': 1}
+    bold_tlen = 10
+    multiecho = isinstance(bold_file, list)
+
+    if multiecho:
+        tes = [layout.get_metadata(echo)['EchoTime'] for echo in bold_file]
+        ref_file = dict(zip(tes, bold_file))[min(tes)]
+
+    if os.path.isfile(ref_file):
         bold_tlen, mem_gb = _create_mem_gb(ref_file)
 
     wf_name = _get_wf_name(ref_file)

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -222,7 +222,11 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
         ref_file = bold_file
     else:
         multiecho = isinstance(bold_file, list)
-        ref_file = sorted(bold_file)[0] if multiecho else bold_file
+        if multiecho:
+            tes = [layout.get_metadata(echo)['EchoTime'] for echo in bold_file]
+            ref_file = dict(zip(tes, bold_file))[min(tes)]
+        else:
+            ref_file = bold_file
         bold_tlen, mem_gb = _create_mem_gb(ref_file)
 
     wf_name = _get_wf_name(ref_file)
@@ -246,9 +250,6 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
         multiecho = False
         bold_pe = 'j'
     else:
-        if multiecho:  # For multiecho data, grab TEs
-            tes = [layout.get_metadata(echo)['EchoTime'] for echo in bold_file]
-        # Since all other metadata is constant
         metadata = layout.get_metadata(ref_file)
 
         # Find fieldmaps. Options: (phase1|phase2|phasediff|epi|fieldmap)


### PR DESCRIPTION
As discussed in #1009, the BIDS spec does not currently enforce that `*_echo-1*` is the shortest TE of all collected echos. This should patch the current sorting procedure to grab the shortest echo and treat as the `ref_file`. 