### PR TITLE
[ENH] Revise resampling grid for template outputs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,6 +417,7 @@ jobs:
                 /tmp/data/ds054 /tmp/ds054/derivatives participant \
                 --fs-no-reconall --debug --force-syn \
                 --output-space T1w template \
+                --template-resampling-grid native \
                 --mem_mb 4096 --nthreads 2 -vv
       - run:
           name: Checking outputs of fMRIPrep
@@ -520,6 +521,7 @@ jobs:
                 --config $PWD/nipype.cfg -w /tmp/ds000210/work \
                 /tmp/data/ds000210 /tmp/ds000210/derivatives participant \
                 --fs-no-reconall --t2s-coreg --use-syn-sdc \
+                --template-resampling-grid native \
                 --debug --write-graph --mem_mb 4096 --nthreads 2 -vv 
       - run:
           name: Checking outputs of fMRIPrep

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ jobs:
                 --debug --write-graph --use-syn-sdc --use-aroma \
                 --ignore-aroma-denoising-errors --mem_mb 4096 \
                 --output-space T1w template fsaverage5 \
-                --template-resampling-grid 2mm \
+                --template-resampling-grid native \
                 --nthreads 2 -vv
             sudo find /tmp/ds005/work -not -name "*.svg" -not -name "*.html" -not -name "*.rst" \
                 -not -name "*.mat" -not -name "*.lta" -type f -delete
@@ -417,7 +417,7 @@ jobs:
                 /tmp/data/ds054 /tmp/ds054/derivatives participant \
                 --fs-no-reconall --debug --force-syn \
                 --output-space T1w template \
-                --template-resampling-grid native \
+                --template-resampling-grid 2mm \
                 --mem_mb 4096 --nthreads 2 -vv
       - run:
           name: Checking outputs of fMRIPrep

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ jobs:
                 --debug --write-graph --use-syn-sdc --use-aroma \
                 --ignore-aroma-denoising-errors --mem_mb 4096 \
                 --output-space T1w template fsaverage5 \
-                --template-resampling-grid native \
+                --template-resampling-grid 2mm \
                 --nthreads 2 -vv
             sudo find /tmp/ds005/work -not -name "*.svg" -not -name "*.html" -not -name "*.rst" \
                 -not -name "*.mat" -not -name "*.lta" -type f -delete

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,6 +330,7 @@ jobs:
                 --debug --write-graph --use-syn-sdc --use-aroma \
                 --ignore-aroma-denoising-errors --mem_mb 4096 \
                 --output-space T1w template fsaverage5 \
+                --template-resampling-grid native \
                 --nthreads 2 -vv
             sudo find /tmp/ds005/work -not -name "*.svg" -not -name "*.html" -not -name "*.rst" \
                 -not -name "*.mat" -not -name "*.lta" -type f -delete

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -45,7 +45,7 @@ is presented below:
                                 fmap_demean=True,
                                 use_syn=True,
                                 force_syn=True,
-                                output_grid_ref='native',
+                                template_out_grid='native',
                                 use_aroma=False,
                                 ignore_aroma_err=False)
 
@@ -241,7 +241,7 @@ BOLD preprocessing
                               fmap_demean=True,
                               use_syn=True,
                               force_syn=True,
-                              output_grid_ref='native',
+                              template_out_grid='native',
                               use_aroma=False,
                               ignore_aroma_err=False)
 
@@ -449,7 +449,7 @@ EPI to MNI transformation
         template='MNI152NLin2009cAsym',
         mem_gb=1,
         omp_nthreads=1,
-        output_grid_ref='native')
+        template_out_grid='native')
 
 This sub-workflow concatenates the transforms calculated upstream (see
 `Head-motion estimation`_, `Susceptibility Distortion Correction (SDC)`_ --if
@@ -461,7 +461,7 @@ It also maps the T1w-based mask to MNI space.
 Transforms are concatenated and applied all at once, with one interpolation (Lanczos)
 step, so as little information is lost as possible.
 
-The output space grid can be specified using the ``output_grid_ref`` argument.
+The output space grid can be specified using the ``template_out_grid`` argument.
 This option accepts the following (``str``) values:
 
   * ``'native'``: the original resolution of the BOLD image will be used.

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -45,7 +45,7 @@ is presented below:
                                 fmap_demean=True,
                                 use_syn=True,
                                 force_syn=True,
-                                output_grid_ref=None,
+                                output_grid_ref='native',
                                 use_aroma=False,
                                 ignore_aroma_err=False)
 
@@ -241,7 +241,7 @@ BOLD preprocessing
                               fmap_demean=True,
                               use_syn=True,
                               force_syn=True,
-                              output_grid_ref=None,
+                              output_grid_ref='native',
                               use_aroma=False,
                               ignore_aroma_err=False)
 
@@ -449,7 +449,7 @@ EPI to MNI transformation
         template='MNI152NLin2009cAsym',
         mem_gb=1,
         omp_nthreads=1,
-        output_grid_ref=None)
+        output_grid_ref='native')
 
 This sub-workflow concatenates the transforms calculated upstream (see
 `Head-motion estimation`_, `Susceptibility Distortion Correction (SDC)`_ --if
@@ -460,6 +460,16 @@ It also maps the T1w-based mask to MNI space.
 
 Transforms are concatenated and applied all at once, with one interpolation (Lanczos)
 step, so as little information is lost as possible.
+
+The output space grid can be specified using the ``output_grid_ref`` argument.
+This option accepts the following (``str``) values:
+
+  * ``'native'``: the original resolution of the BOLD image will be used.
+  * ``'1mm'``: uses the 1:math:`\times`1:math:`\times`1 [mm] version of the template.
+  * ``'2mm'``: uses the 2:math:`\times`2:math:`\times`2 [mm] version of the template.
+  * **Path to arbitrary reference file**: the output will be resampled on a grid with
+    same resolution as this reference.
+
 
 EPI sampled to FreeSurfer surfaces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -435,7 +435,7 @@ def build_workflow(opts, retval):
         output_spaces=opts.output_space,
         template=opts.template,
         medial_surface_nan=opts.medial_surface_nan,
-        output_grid_ref=opts.template_resampling_grid,
+        template_out_grid=opts.template_resampling_grid,
         hires=opts.hires,
         use_bbr=opts.use_bbr,
         bold2t1w_dof=opts.bold2t1w_dof,

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -132,7 +132,7 @@ def get_parser():
         choices=['MNI152NLin2009cAsym'], default='MNI152NLin2009cAsym',
         help='volume template space (default: MNI152NLin2009cAsym)')
     g_conf.add_argument(
-        '--output-grid-reference', required=False, action='store', default=None,
+        '--template-resampling-grid', required=False, action='store', default='2mm',
         help='Grid reference image for resampling BOLD files to volume template space. '
              'It determines the field of view and resolution of the output images, '
              'but is not used in normalization.')
@@ -435,7 +435,7 @@ def build_workflow(opts, retval):
         output_spaces=opts.output_space,
         template=opts.template,
         medial_surface_nan=opts.medial_surface_nan,
-        output_grid_ref=opts.output_grid_reference,
+        output_grid_ref=opts.template_resampling_grid,
         hires=opts.hires,
         use_bbr=opts.use_bbr,
         bold2t1w_dof=opts.bold2t1w_dof,

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -133,7 +133,11 @@ def get_parser():
         help='volume template space (default: MNI152NLin2009cAsym)')
     g_conf.add_argument(
         '--template-resampling-grid', required=False, action='store', default='2mm',
-        help='Grid reference image for resampling BOLD files to volume template space. '
+        help='Keyword ("native", "1mm", or "2mm") or path to an existing file. '
+             'Allows to define a reference grid for the resampling of BOLD images in template '
+             'space. Keyword "native" will use the original BOLD grid as reference. '
+             'Keywords "1mm" and "2mm" will use the corresponding isotropic template '
+             'resolutions. If a path is given, the grid of that image will be used. '
              'It determines the field of view and resolution of the output images, '
              'but is not used in normalization.')
     g_conf.add_argument(

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -135,7 +135,7 @@ def get_parser():
         '--output-grid-reference', required=False, action='store',
         help='Deprecated after FMRIPREP 1.0.8. Please use --template-resampling-grid instead.')
     g_conf.add_argument(
-        '--template-resampling-grid', required=False, action='store', default='2mm',
+        '--template-resampling-grid', required=False, action='store', default='native',
         help='Keyword ("native", "1mm", or "2mm") or path to an existing file. '
              'Allows to define a reference grid for the resampling of BOLD images in template '
              'space. Keyword "native" will use the original BOLD grid as reference. '

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -132,6 +132,9 @@ def get_parser():
         choices=['MNI152NLin2009cAsym'], default='MNI152NLin2009cAsym',
         help='volume template space (default: MNI152NLin2009cAsym)')
     g_conf.add_argument(
+        '--output-grid-reference', required=False, action='store',
+        help='Deprecated after FMRIPREP 1.0.8. Please use --template-resampling-grid instead.')
+    g_conf.add_argument(
         '--template-resampling-grid', required=False, action='store', default='2mm',
         help='Keyword ("native", "1mm", or "2mm") or path to an existing file. '
              'Allows to define a reference grid for the resampling of BOLD images in template '
@@ -420,6 +423,13 @@ def build_workflow(opts, retval):
         uuid=run_uuid)
     )
 
+    template_out_grid = opts.template_resampling_grid
+    if opts.output_grid_reference is not None:
+        logger.warning(
+            'Option --output-grid-reference is deprecated, please use '
+            '--template-resampling-grid')
+        template_out_grid = template_out_grid or opts.output_grid_reference
+
     retval['workflow'] = init_fmriprep_wf(
         subject_list=subject_list,
         task_id=opts.task_id,
@@ -439,7 +449,7 @@ def build_workflow(opts, retval):
         output_spaces=opts.output_space,
         template=opts.template,
         medial_surface_nan=opts.medial_surface_nan,
-        template_out_grid=opts.template_resampling_grid,
+        template_out_grid=template_out_grid,
         hires=opts.hires,
         use_bbr=opts.use_bbr,
         bold2t1w_dof=opts.bold2t1w_dof,

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -149,7 +149,8 @@ def init_fmriprep_wf(subject_list, task_id, run_uuid,
         ignore_aroma_err : bool
             Do not fail on ICA-AROMA errors
         template_out_grid : str
-            Path of custom reference image for normalization
+            Keyword ('native', '1mm' or '2mm') or path of custom reference
+            image for normalization
 
     """
     fmriprep_wf = pe.Workflow(name='fmriprep_wf')
@@ -323,7 +324,8 @@ def init_single_subject_wf(subject_id, task_id, name,
         force_syn : bool
             **Temporary**: Always run SyN-based SDC
         template_out_grid : str
-            Path of custom reference image for normalization
+            Keyword ('native', '1mm' or '2mm') or path of custom reference
+            image for normalization
         use_aroma : bool
             Perform ICA-AROMA on MNI-resampled functional series
         ignore_aroma_err : bool

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -35,7 +35,7 @@ def init_fmriprep_wf(subject_list, task_id, run_uuid,
                      omp_nthreads, skull_strip_template, work_dir, output_dir, bids_dir,
                      freesurfer, output_spaces, template, medial_surface_nan, hires,
                      use_bbr, bold2t1w_dof, fmap_bspline, fmap_demean, use_syn, force_syn,
-                     use_aroma, ignore_aroma_err, output_grid_ref):
+                     use_aroma, ignore_aroma_err, template_out_grid):
     """
     This workflow organizes the execution of FMRIPREP, with a sub-workflow for
     each subject.
@@ -78,7 +78,7 @@ def init_fmriprep_wf(subject_list, task_id, run_uuid,
                               force_syn=True,
                               use_aroma=False,
                               ignore_aroma_err=False,
-                              output_grid_ref='native')
+                              template_out_grid='native')
 
 
     Parameters
@@ -148,7 +148,7 @@ def init_fmriprep_wf(subject_list, task_id, run_uuid,
             Perform ICA-AROMA on MNI-resampled functional series
         ignore_aroma_err : bool
             Do not fail on ICA-AROMA errors
-        output_grid_ref : str
+        template_out_grid : str
             Path of custom reference image for normalization
 
     """
@@ -190,7 +190,7 @@ def init_fmriprep_wf(subject_list, task_id, run_uuid,
                                                    fmap_demean=fmap_demean,
                                                    use_syn=use_syn,
                                                    force_syn=force_syn,
-                                                   output_grid_ref=output_grid_ref,
+                                                   template_out_grid=template_out_grid,
                                                    use_aroma=use_aroma,
                                                    ignore_aroma_err=ignore_aroma_err)
 
@@ -213,7 +213,7 @@ def init_single_subject_wf(subject_id, task_id, name,
                            omp_nthreads, skull_strip_template, reportlets_dir, output_dir,
                            bids_dir, freesurfer, output_spaces, template, medial_surface_nan,
                            hires, use_bbr, bold2t1w_dof, fmap_bspline, fmap_demean, use_syn,
-                           force_syn, output_grid_ref, use_aroma, ignore_aroma_err):
+                           force_syn, template_out_grid, use_aroma, ignore_aroma_err):
     """
     This workflow organizes the preprocessing pipeline for a single subject.
     It collects and reports information about the subject, and prepares
@@ -255,7 +255,7 @@ def init_single_subject_wf(subject_id, task_id, name,
                                     fmap_demean=True,
                                     use_syn=True,
                                     force_syn=True,
-                                    output_grid_ref='native',
+                                    template_out_grid='native',
                                     use_aroma=False,
                                     ignore_aroma_err=False)
 
@@ -322,7 +322,7 @@ def init_single_subject_wf(subject_id, task_id, name,
             If fieldmaps are present and enabled, this is not run, by default.
         force_syn : bool
             **Temporary**: Always run SyN-based SDC
-        output_grid_ref : str
+        template_out_grid : str
             Path of custom reference image for normalization
         use_aroma : bool
             Perform ICA-AROMA on MNI-resampled functional series
@@ -437,7 +437,7 @@ def init_single_subject_wf(subject_id, task_id, name,
                                                use_syn=use_syn,
                                                force_syn=force_syn,
                                                debug=debug,
-                                               output_grid_ref=output_grid_ref,
+                                               template_out_grid=template_out_grid,
                                                use_aroma=use_aroma,
                                                ignore_aroma_err=ignore_aroma_err)
 

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -78,7 +78,7 @@ def init_fmriprep_wf(subject_list, task_id, run_uuid,
                               force_syn=True,
                               use_aroma=False,
                               ignore_aroma_err=False,
-                              output_grid_ref=None)
+                              output_grid_ref='native')
 
 
     Parameters
@@ -148,7 +148,7 @@ def init_fmriprep_wf(subject_list, task_id, run_uuid,
             Perform ICA-AROMA on MNI-resampled functional series
         ignore_aroma_err : bool
             Do not fail on ICA-AROMA errors
-        output_grid_ref : str or None
+        output_grid_ref : str
             Path of custom reference image for normalization
 
     """
@@ -255,7 +255,7 @@ def init_single_subject_wf(subject_id, task_id, name,
                                     fmap_demean=True,
                                     use_syn=True,
                                     force_syn=True,
-                                    output_grid_ref=None,
+                                    output_grid_ref='native',
                                     use_aroma=False,
                                     ignore_aroma_err=False)
 
@@ -322,7 +322,7 @@ def init_single_subject_wf(subject_id, task_id, name,
             If fieldmaps are present and enabled, this is not run, by default.
         force_syn : bool
             **Temporary**: Always run SyN-based SDC
-        output_grid_ref : str or None
+        output_grid_ref : str
             Path of custom reference image for normalization
         use_aroma : bool
             Perform ICA-AROMA on MNI-resampled functional series

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -51,7 +51,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
                          output_spaces, template, output_dir, omp_nthreads,
                          fmap_bspline, fmap_demean, use_syn, force_syn,
                          use_aroma, ignore_aroma_err, medial_surface_nan,
-                         debug, low_mem, output_grid_ref, layout=None):
+                         debug, low_mem, template_out_grid, layout=None):
     """
     This workflow controls the functional preprocessing stages of FMRIPREP.
 
@@ -78,7 +78,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
                                   use_syn=True,
                                   force_syn=True,
                                   low_mem=False,
-                                  output_grid_ref='native',
+                                  template_out_grid='native',
                                   medial_surface_nan=False,
                                   use_aroma=False,
                                   ignore_aroma_err=False)
@@ -136,7 +136,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
             Enable debugging outputs
         low_mem : bool
             Write uncompressed .nii files in some cases to reduce memory usage
-        output_grid_ref : str or None
+        template_out_grid : str or None
             Path of custom reference image for normalization
         layout : BIDSLayout
             BIDSLayout structure to enable metadata retrieval
@@ -565,7 +565,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
             template=template,
             mem_gb=mem_gb['resampled'],
             omp_nthreads=omp_nthreads,
-            output_grid_ref=output_grid_ref,
+            template_out_grid=template_out_grid,
             use_compression=not (low_mem and use_aroma),
             use_fieldwarp=fmaps is not None,
             name='bold_mni_trans_wf'

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -78,7 +78,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
                                   use_syn=True,
                                   force_syn=True,
                                   low_mem=False,
-                                  output_grid_ref=None,
+                                  output_grid_ref='native',
                                   medial_surface_nan=False,
                                   use_aroma=False,
                                   ignore_aroma_err=False)

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -136,8 +136,9 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
             Enable debugging outputs
         low_mem : bool
             Write uncompressed .nii files in some cases to reduce memory usage
-        template_out_grid : str or None
-            Path of custom reference image for normalization
+        template_out_grid : str
+            Keyword ('native', '1mm' or '2mm') or path of custom reference
+            image for normalization
         layout : BIDSLayout
             BIDSLayout structure to enable metadata retrieval
 

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -161,7 +161,7 @@ def init_bold_surf_wf(mem_gb, output_spaces, medial_surface_nan, name='bold_surf
 
 def init_bold_mni_trans_wf(template, mem_gb, omp_nthreads,
                            name='bold_mni_trans_wf',
-                           output_grid_ref='2mm',
+                           template_out_grid='2mm',
                            use_compression=True,
                            use_fieldwarp=False):
     """
@@ -176,7 +176,7 @@ def init_bold_mni_trans_wf(template, mem_gb, omp_nthreads,
         wf = init_bold_mni_trans_wf(template='MNI152NLin2009cAsym',
                                     mem_gb=3,
                                     omp_nthreads=1,
-                                    output_grid_ref='native')
+                                    template_out_grid='native')
 
     **Parameters**
 
@@ -188,7 +188,7 @@ def init_bold_mni_trans_wf(template, mem_gb, omp_nthreads,
             Maximum number of threads an individual process may use
         name : str
             Name of workflow (default: ``bold_mni_trans_wf``)
-        output_grid_ref : str
+        template_out_grid : str
             Path of custom reference image for normalization.
             Special values of 'native', '1mm', '2mm' are accepted.
         use_compression : bool
@@ -294,19 +294,19 @@ def init_bold_mni_trans_wf(template, mem_gb, omp_nthreads,
         (merge, outputnode, [('out_file', 'bold_mni')]),
     ])
 
-    if output_grid_ref == 'native':
+    if template_out_grid == 'native':
         workflow.connect([
             (gen_ref, mask_mni_tfm, [('out_file', 'reference_image')]),
             (gen_ref, bold_to_mni_transform, [('out_file', 'reference_image')]),
         ])
-    elif output_grid_ref == '1mm' or output_grid_ref == '2mm':
+    elif template_out_grid == '1mm' or template_out_grid == '2mm':
         mask_mni_tfm.inputs.reference_image = op.join(
-            nid.get_dataset(template_str), '%s_brainmask.nii.gz' % output_grid_ref)
+            nid.get_dataset(template_str), '%s_brainmask.nii.gz' % template_out_grid)
         bold_to_mni_transform.inputs.reference_image = op.join(
-            nid.get_dataset(template_str), '%s_T1.nii.gz' % output_grid_ref)
+            nid.get_dataset(template_str), '%s_T1.nii.gz' % template_out_grid)
     else:
-        mask_mni_tfm.inputs.reference_image = output_grid_ref
-        bold_to_mni_transform.inputs.reference_image = output_grid_ref
+        mask_mni_tfm.inputs.reference_image = template_out_grid
+        bold_to_mni_transform.inputs.reference_image = template_out_grid
     return workflow
 
 

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -189,8 +189,8 @@ def init_bold_mni_trans_wf(template, mem_gb, omp_nthreads,
         name : str
             Name of workflow (default: ``bold_mni_trans_wf``)
         template_out_grid : str
-            Path of custom reference image for normalization.
-            Special values of 'native', '1mm', '2mm' are accepted.
+            Keyword ('native', '1mm' or '2mm') or path of custom reference
+            image for normalization.
         use_compression : bool
             Save registered BOLD series as ``.nii.gz``
         use_fieldwarp : bool

--- a/fmriprep/workflows/tests/test_base.py
+++ b/fmriprep/workflows/tests/test_base.py
@@ -38,7 +38,7 @@ class TestBase(TestWorkflow):
                                          ignore_aroma_err=False,
                                          use_syn=True,
                                          force_syn=True,
-                                         output_grid_ref=None)
+                                         output_grid_ref='native')
         wfbasic.write_graph()
         self._assert_mandatory_inputs_set(wfbasic)
 

--- a/fmriprep/workflows/tests/test_base.py
+++ b/fmriprep/workflows/tests/test_base.py
@@ -38,7 +38,7 @@ class TestBase(TestWorkflow):
                                          ignore_aroma_err=False,
                                          use_syn=True,
                                          force_syn=True,
-                                         output_grid_ref='native')
+                                         template_out_grid='native')
         wfbasic.write_graph()
         self._assert_mandatory_inputs_set(wfbasic)
 

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -245,7 +245,7 @@ def get_parser():
     g_wrap.add_argument('-w', '--work-dir', action='store',
                         help='path where intermediate results should be stored')
     g_wrap.add_argument('--template-resampling-grid', required=False, action='store',
-                        type=os.path.abspath,
+                        type=str,
                         help='Grid reference image for resampling BOLD files to volume template '
                              'space.')
     g_wrap.add_argument(
@@ -371,8 +371,11 @@ def main():
                                         '/root/.nipype/nipype.cfg', 'ro'))])
 
     if opts.template_resampling_grid:
-        target = '/imports/' + os.path.basename(opts.template_resampling_grid)
-        command.extend(['-v', ':'.join((opts.template_resampling_grid, target, 'ro'))])
+        target = opts.template_resampling_grid
+        if target not in ['native', '2mm' '1mm']:
+            target = '/imports/' + os.path.basename(target)
+            command.extend(['-v', ':'.join((os.path.abspath(
+                opts.template_resampling_grid), target, 'ro'))])
         unknown_args.extend(['--template-resampling-grid', target])
 
     if opts.shell:

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -21,6 +21,7 @@ import sys
 import os
 import re
 import subprocess
+from warnings import warn
 
 standard_library.install_aliases()
 
@@ -245,6 +246,9 @@ def get_parser():
     g_wrap.add_argument('-w', '--work-dir', action='store',
                         help='path where intermediate results should be stored')
     g_wrap.add_argument(
+        '--output-grid-reference', required=False, action='store', type=os.path.abspath,
+        help='Deprecated after FMRIPREP 1.0.8. Please use --template-resampling-grid instead.')
+    g_wrap.add_argument(
         '--template-resampling-grid', required=False, action='store', type=str,
         help='Keyword ("native", "1mm", or "2mm") or path to an existing file. '
              'Allows to define a reference grid for the resampling of BOLD images in template '
@@ -375,7 +379,11 @@ def main():
         command.extend(['-v', ':'.join((opts.config,
                                         '/root/.nipype/nipype.cfg', 'ro'))])
 
-    if opts.template_resampling_grid:
+    template_target = opts.template_resampling_grid or opts.output_grid_reference
+    if template_target is not None:
+        if opts.output_grid_reference is not None:
+            warn('Option --output-grid-reference is deprecated, please use '
+                 '--template-resampling-grid', DeprecationWarning)
         target = opts.template_resampling_grid
         if target not in ['native', '2mm' '1mm']:
             target = '/imports/' + os.path.basename(target)

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -244,10 +244,15 @@ def get_parser():
         'Standard options that require mapping files into the container')
     g_wrap.add_argument('-w', '--work-dir', action='store',
                         help='path where intermediate results should be stored')
-    g_wrap.add_argument('--template-resampling-grid', required=False, action='store',
-                        type=str,
-                        help='Grid reference image for resampling BOLD files to volume template '
-                             'space.')
+    g_wrap.add_argument(
+        '--template-resampling-grid', required=False, action='store', type=str,
+        help='Keyword ("native", "1mm", or "2mm") or path to an existing file. '
+             'Allows to define a reference grid for the resampling of BOLD images in template '
+             'space. Keyword "native" will use the original BOLD grid as reference. '
+             'Keywords "1mm" and "2mm" will use the corresponding isotropic template '
+             'resolutions. If a path is given, the grid of that image will be used. '
+             'It determines the field of view and resolution of the output images, '
+             'but is not used in normalization.')
     g_wrap.add_argument(
         '--fs-license-file', metavar='PATH', type=os.path.abspath,
         default=os.getenv('FS_LICENSE', None),

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -384,12 +384,11 @@ def main():
         if opts.output_grid_reference is not None:
             warn('Option --output-grid-reference is deprecated, please use '
                  '--template-resampling-grid', DeprecationWarning)
-        target = opts.template_resampling_grid
-        if target not in ['native', '2mm' '1mm']:
-            target = '/imports/' + os.path.basename(target)
+        if template_target not in ['native', '2mm' '1mm']:
+            target = '/imports/' + os.path.basename(template_target)
             command.extend(['-v', ':'.join((os.path.abspath(
-                opts.template_resampling_grid), target, 'ro'))])
-        unknown_args.extend(['--template-resampling-grid', target])
+                template_target), target, 'ro'))])
+        unknown_args.extend(['--template-resampling-grid', template_target])
 
     if opts.shell:
         command.append('--entrypoint=bash')

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -168,7 +168,7 @@ def merge_help(wrapper_help, target_help):
 
     # Make sure we're not clobbering options we don't mean to
     overlap = set(w_flags).intersection(t_flags)
-    expected_overlap = set(['h', 'version', 'w', 'output-grid-reference',
+    expected_overlap = set(['h', 'version', 'w', 'template-resampling-grid',
                             'fs-license-file'])
     assert overlap == expected_overlap, "Clobbering options: {}".format(
         ', '.join(overlap - expected_overlap))
@@ -244,7 +244,7 @@ def get_parser():
         'Standard options that require mapping files into the container')
     g_wrap.add_argument('-w', '--work-dir', action='store',
                         help='path where intermediate results should be stored')
-    g_wrap.add_argument('--output-grid-reference', required=False, action='store',
+    g_wrap.add_argument('--template-resampling-grid', required=False, action='store',
                         type=os.path.abspath,
                         help='Grid reference image for resampling BOLD files to volume template '
                              'space.')
@@ -370,10 +370,10 @@ def main():
         command.extend(['-v', ':'.join((opts.config,
                                         '/root/.nipype/nipype.cfg', 'ro'))])
 
-    if opts.output_grid_reference:
-        target = '/imports/' + os.path.basename(opts.output_grid_reference)
-        command.extend(['-v', ':'.join((opts.output_grid_reference, target, 'ro'))])
-        unknown_args.extend(['--output-grid-reference', target])
+    if opts.template_resampling_grid:
+        target = '/imports/' + os.path.basename(opts.template_resampling_grid)
+        command.extend(['-v', ':'.join((opts.template_resampling_grid, target, 'ro'))])
+        unknown_args.extend(['--template-resampling-grid', target])
 
     if opts.shell:
         command.append('--entrypoint=bash')

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -170,7 +170,7 @@ def merge_help(wrapper_help, target_help):
     # Make sure we're not clobbering options we don't mean to
     overlap = set(w_flags).intersection(t_flags)
     expected_overlap = set(['h', 'version', 'w', 'template-resampling-grid',
-                            'fs-license-file'])
+                            'output-grid-reference', 'fs-license-file'])
     assert overlap == expected_overlap, "Clobbering options: {}".format(
         ', '.join(overlap - expected_overlap))
 


### PR DESCRIPTION
This PR resurrects the dicussion about native or other output resolutions. ~~In particular, this PR CHANGES the current default (the "native" space of the input BOLD file) and sets the template-2mm version~~.

Implications:

  * As off this PR, any new template added to FMRIPREP will require having a 1mm and a 2mm resolution versions. This was probably necessary already, but from this PR on it will be mandatory for sure.
  * The default behavior until v1.0.8 can be obtained using ``--output-grid-reference native``.
  * The option has been renamed: from ``--output-grid-reference`` to ``--template-resampling-grid``, as it is more descriptive.

Justification:

  * Comparison studies need not only a standard (physical) space, but also a standard voxel size (digital space) for the good of analysis.
  * Cluster analyses on images with very large voxels may be very hard to interpret.

Since it's been a long overdue request, I thought it was time to change this default. Closes #337.

Modified ds005 test on circleci with ``--template-resampling-grid native``, so that we test both options.