### PR TITLE
FIX: Do not detrend CSF/WhiteMatter/GlobalSignal

### DIFF
--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -162,9 +162,8 @@ def init_bold_confs_wf(mem_gb, metadata, name="bold_confs_wf"):
 
     # Global and segment regressors
     mrg_lbl = pe.Node(niu.Merge(3), name='merge_rois', run_without_submitting=True)
-    signals = pe.Node(SignalExtraction(
-        detrend=True, class_labels=["CSF", "WhiteMatter", "GlobalSignal"]),
-        name="signals", mem_gb=mem_gb)
+    signals = pe.Node(SignalExtraction(class_labels=["CSF", "WhiteMatter", "GlobalSignal"]),
+                      name="signals", mem_gb=mem_gb)
 
     # Arrange confounds
     add_header = pe.Node(AddTSVHeader(columns=["X", "Y", "Z", "RotX", "RotY", "RotZ"]),


### PR DESCRIPTION
In confounds.tsv, ROI signals (mean time series within each ROI) were linearly detrended after being calculated. This produced time series that bore no obvious relation to the BOLD series from which they were derived, causing undue confusion. The operation was unnecessary but innocuous, as the use of these signals in a GLM would only affect the betas associated with their corresponding nuisance regressors.

Thus, this PR removes the detrending step. This may also help speed up and reduce the memory footprint of the `signals` step.

Fixes #1015.