### PR TITLE
FIX: Always strip session from T1w for derivative naming

### DIFF
--- a/fmriprep/utils/misc.py
+++ b/fmriprep/utils/misc.py
@@ -18,10 +18,10 @@ def fix_multi_T1w_source_name(in_files):
 
     """
     import os
-    if not isinstance(in_files, list):
-        return in_files
-    subject_label = in_files[0].split(os.sep)[-1].split("_")[0].split("-")[-1]
-    base, _ = os.path.split(in_files[0])
+    from niworkflows.nipype.utils.filemanip import filename_to_list
+    in_files = filename_to_list(in_files)
+    base, in_file = os.path.split(in_files[0])
+    subject_label = in_file.split("_", 1)[0].split("-")[1]
     return os.path.join(base, "sub-%s_T1w.nii.gz" % subject_label)
 
 


### PR DESCRIPTION
Fixes #1068.