### PR TITLE
FIX: Check for invalid sform matrices

### DIFF
--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -409,7 +409,7 @@ class ValidateImage(SimpleInterface):
         else:
             RZS = sform[:3, :3]
             zooms = np.sqrt(np.sum(RZS * RZS, axis=0))
-            valid_sform = np.allclose(zooms, img.get_zooms()[:3])
+            valid_sform = np.allclose(zooms, img.header.get_zooms()[:3])
 
         # Matching affines
         matching_affines = valid_qform and np.allclose(qform, sform)


### PR DESCRIPTION
Nibabel does a bit of validation on qforms already, in that it takes some work to produce an affine from the header. However, sforms are stored more-or-less directly, and nibabel simply shuttles values in and out of the header.

This checks for a non-zero determinant and that the RSS of each column matches the zooms.

Closes #1069.