### PR TITLE
MAINT: Remove cwebp to revert to png

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,11 +82,6 @@ RUN mkdir -p $ANTSPATH && \
     | tar -xzC $ANTSPATH --strip-components 1
 ENV PATH=$ANTSPATH:$PATH
 
-# Installing WEBP tools
-RUN curl -sSLO "http://downloads.webmproject.org/releases/webp/libwebp-0.5.2-linux-x86-64.tar.gz" && \
-  tar -xf libwebp-0.5.2-linux-x86-64.tar.gz && cd libwebp-0.5.2-linux-x86-64/bin && \
-  mv cwebp /usr/local/bin/ && rm -rf libwebp-0.5.2-linux-x86-64
-
 # Installing SVGO
 RUN curl -sL https://deb.nodesource.com/setup_7.x | bash -
 RUN apt-get install -y nodejs

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -172,8 +172,8 @@ def init_bold_confs_wf(mem_gb, metadata, name="bold_confs_wf"):
 
     # Generate reportlet
     mrg_compcor = pe.Node(niu.Merge(2), name='merge_compcor', run_without_submitting=True)
-    rois_plot = pe.Node(ROIsPlot(compress_report=True, colors=['r', 'b', 'magenta'],
-                        generate_report=True), name='rois_plot')
+    rois_plot = pe.Node(ROIsPlot(colors=['r', 'b', 'magenta'], generate_report=True),
+                        name='rois_plot')
 
     ds_report_bold_rois = pe.Node(
         DerivativesDataSink(suffix='rois'),


### PR DESCRIPTION
For the sake of cross-browser compatibility, we should revert to PNG for displays.

Leaving `svgo`.

Closes #945 
Closes #969 
Related: #977