### PR TITLE
fmriprep-docker: Support Python 2/3 without future or other helpers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,9 +206,18 @@ jobs:
               poldracklab/fmriprep:latest . \
               --doctest-modules --ignore=docs --ignore=setup.py
       - run:
-          name: Test fmriprep-wrapper
+          name: Test fmriprep-wrapper (Python 2)
           command: |
-            pip install future numpy
+            conda create -n py2 python=2.7
+            source activate py2
+            pip install --upgrade wrapper/
+            fmriprep-docker -i poldracklab/fmriprep:latest --help
+            fmriprep-docker -i poldracklab/fmriprep:latest --version
+      - run:
+          name: Test fmriprep-wrapper (Python 3)
+          command: |
+            conda create -n py3 python=3.6
+            source activate py3
             pip install --upgrade wrapper/
             fmriprep-docker -i poldracklab/fmriprep:latest --help
             fmriprep-docker -i poldracklab/fmriprep:latest --version

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -14,16 +14,11 @@ Please report any feedback to our GitHub repository
 forget to credit all the authors of software that fMRIPrep
 uses (http://fmriprep.rtfd.io/en/latest/citing.html).
 """
-from __future__ import print_function, unicode_literals, division, absolute_import
-from builtins import int, map, input, zip
-from future import standard_library
 import sys
 import os
 import re
 import subprocess
 from warnings import warn
-
-standard_library.install_aliases()
 
 __version__ = '99.99.99'
 __packagename__ = 'fmriprep-docker'
@@ -94,6 +89,13 @@ if not hasattr(subprocess, 'run'):
 
         return res
     subprocess.run = _run
+
+
+# De-fang Python 2's input - we don't eval user input
+try:
+    input = raw_input
+except NameError:
+    pass
 
 
 def check_docker():
@@ -302,11 +304,10 @@ def main():
             print('fmriprep wrapper {!s}'.format(__version__))
         if opts.help:
             parser.print_help()
-        print("fmriprep: ", end='')
         if check == -1:
-            print("Could not find docker command... Is it installed?")
+            print("fmriprep: Could not find docker command... Is it installed?")
         else:
-            print("Make sure you have permission to run 'docker'")
+            print("fmriprep: Make sure you have permission to run 'docker'")
         return 1
 
     # For --help or --version, ask before downloading an image

--- a/wrapper/setup.py
+++ b/wrapper/setup.py
@@ -26,8 +26,8 @@ def main():
         license=info['__license__'],
         classifiers=info['CLASSIFIERS'],
         # Dependencies handling
-        setup_requires=['future'],
-        install_requires=['future'],
+        setup_requires=[],
+        install_requires=[],
         tests_require=[],
         extras_require={},
         dependency_links=[],


### PR DESCRIPTION
Fixes #1079