### PR TITLE
RF: Resume external nipype dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,10 +296,10 @@ jobs:
           at: /tmp
       - restore_cache:
           keys:
-            - ds005-anat-v6-{{ .Branch }}-{{ epoch }}
-            - ds005-anat-v6-{{ .Branch }}
-            - ds005-anat-v6-master
-            - ds005-anat-v6-
+            - ds005-anat-v7-{{ .Branch }}-{{ epoch }}
+            - ds005-anat-v7-{{ .Branch }}
+            - ds005-anat-v7-master
+            - ds005-anat-v7-
       - run:
           name: Setting up test
           command: |
@@ -333,7 +333,7 @@ jobs:
                 --debug --write-graph --mem_mb 4096 \
                 --nthreads 2 --anat-only -vv
       - save_cache:
-         key: ds005-anat-v6-{{ .Branch }}-{{ epoch }}
+         key: ds005-anat-v7-{{ .Branch }}-{{ epoch }}
          paths:
             - /tmp/ds005/work
             - /tmp/ds005/derivatives/fmriprep
@@ -425,10 +425,10 @@ jobs:
           at: /tmp
       - restore_cache:
           keys:
-            - ds054-anat-v4-{{ .Branch }}-{{ epoch }}
-            - ds054-anat-v4-{{ .Branch }}
-            - ds054-anat-v4-master
-            - ds054-anat-v4-
+            - ds054-anat-v5-{{ .Branch }}-{{ epoch }}
+            - ds054-anat-v5-{{ .Branch }}
+            - ds054-anat-v5-master
+            - ds054-anat-v5-
       - run:
           name: Setting up test
           command: |
@@ -462,7 +462,7 @@ jobs:
                 --fs-no-reconall --debug --write-graph \
                 --mem_mb 4096 --nthreads 2 --anat-only -vv
       - save_cache:
-         key: ds054-anat-v4-{{ .Branch }}-{{ epoch }}
+         key: ds054-anat-v5-{{ .Branch }}-{{ epoch }}
          paths:
             - /tmp/ds054/work
             - /tmp/ds054/derivatives
@@ -543,8 +543,8 @@ jobs:
           at: /tmp
       - restore_cache:
           keys:
-            - ds210-anat-v1-{{ epoch }}
-            - ds210-anat-v1-
+            - ds210-anat-v2-{{ epoch }}
+            - ds210-anat-v2-
       - run:
           name: Setting up test
           command: |
@@ -578,7 +578,7 @@ jobs:
                 --fs-no-reconall --debug --write-graph \
                 --mem_mb 4096 --nthreads 2 --anat-only -vv
       - save_cache:
-         key: ds210-anat-v1-{{ epoch }}
+         key: ds210-anat-v2-{{ epoch }}
          paths:
             - /tmp/ds210/work
             - /tmp/ds210/derivatives

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -28,4 +28,4 @@ dependencies:
     - svgutils
     - nitime
     - nilearn
-    - niworkflows>=0.3.13
+    - git+https://github.com/effigies/niworkflows.git@4e8f18d79a45db156d441cbc41cf28b953fc5bf1#egg=niworkflows

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -28,4 +28,4 @@ dependencies:
     - svgutils
     - nitime
     - nilearn
-    - git+https://github.com/effigies/niworkflows.git@4e8f18d79a45db156d441cbc41cf28b953fc5bf1#egg=niworkflows
+    - niworkflows>=0.4.0

--- a/fmriprep/cli/fmriprep_bold_mask.py
+++ b/fmriprep/cli/fmriprep_bold_mask.py
@@ -3,7 +3,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Run the BOLD reference+mask workflow"""
 import os
-from niworkflows.nipype.utils.filemanip import hash_infile
+from nipype.utils.filemanip import hash_infile
 
 
 def get_parser():

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -228,7 +228,7 @@ def get_parser():
 
 def main():
     """Entry point"""
-    from niworkflows.nipype import logging as nlogging
+    from nipype import logging as nlogging
     from multiprocessing import set_start_method, Process, Manager
     from ..viz.reports import generate_reports
     from ..info import __version__
@@ -335,7 +335,7 @@ def build_workflow(opts, retval):
     a hard-limited memory-scope.
 
     """
-    from niworkflows.nipype import logging, config as ncfg
+    from nipype import logging, config as ncfg
     from ..info import __version__
     from ..workflows.base import init_fmriprep_wf
     from ..utils.bids import collect_participants

--- a/fmriprep/info.py
+++ b/fmriprep/info.py
@@ -71,7 +71,7 @@ REQUIRES = [
     'pybids>=0.5.1',
     'nitime',
     'nipype>=1.0.4',
-    'niworkflows>=0.3.13',
+    'niworkflows>=0.4.0',
     'statsmodels',
     'nipype',
     'seaborn',
@@ -81,8 +81,6 @@ REQUIRES = [
 ]
 
 LINKS_REQUIRES = [
-    "git+https://github.com/effigies/niworkflows.git@"
-    "4e8f18d79a45db156d441cbc41cf28b953fc5bf1#egg=niworkflows",
 ]
 
 TESTS_REQUIRES = [

--- a/fmriprep/info.py
+++ b/fmriprep/info.py
@@ -81,6 +81,8 @@ REQUIRES = [
 ]
 
 LINKS_REQUIRES = [
+    "git+https://github.com/effigies/niworkflows.git@"
+    "4e8f18d79a45db156d441cbc41cf28b953fc5bf1#egg=niworkflows",
 ]
 
 TESTS_REQUIRES = [

--- a/fmriprep/info.py
+++ b/fmriprep/info.py
@@ -70,6 +70,7 @@ REQUIRES = [
     'grabbit',
     'pybids>=0.5.1',
     'nitime',
+    'nipype>=1.0.4',
     'niworkflows>=0.3.13',
     'statsmodels',
     'nipype',

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -14,7 +14,7 @@ Fetch some example data:
 
 Disable warnings:
 
-    >>> import nipype import logging
+    >>> from nipype import logging
     >>> logging.getLogger('interface').setLevel('ERROR')
 
 """

--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -14,8 +14,8 @@ Fetch some example data:
 
 Disable warnings:
 
-    >>> import niworkflows.nipype as nn
-    >>> nn.logging.getLogger('interface').setLevel('ERROR')
+    >>> import nipype import logging
+    >>> logging.getLogger('interface').setLevel('ERROR')
 
 """
 
@@ -26,13 +26,13 @@ import simplejson as json
 import gzip
 from shutil import copytree, rmtree, copyfileobj
 
-from niworkflows.nipype import logging
-from niworkflows.nipype.interfaces.base import (
+from nipype import logging
+from nipype.interfaces.base import (
     traits, isdefined, TraitedSpec, BaseInterfaceInputSpec,
     File, Directory, InputMultiPath, OutputMultiPath, Str,
     SimpleInterface
 )
-from niworkflows.nipype.utils.filemanip import copyfile
+from nipype.utils.filemanip import copyfile
 
 LOGGER = logging.getLogger('interface')
 BIDS_NAME = re.compile(

--- a/fmriprep/interfaces/cifti.py
+++ b/fmriprep/interfaces/cifti.py
@@ -17,12 +17,12 @@ from nibabel import cifti2 as ci
 import numpy as np
 from nilearn.image import resample_to_img
 
-from niworkflows.nipype.interfaces.base import (
+from nipype.interfaces.base import (
     BaseInterfaceInputSpec, TraitedSpec, File, traits,
     SimpleInterface, Directory
 )
 from niworkflows.data import getters
-from niworkflows.nipype.utils.filemanip import split_filename
+from nipype.utils.filemanip import split_filename
 
 # CITFI structures with corresponding FS labels
 CIFTI_STRUCT_WITH_LABELS = {

--- a/fmriprep/interfaces/confounds.py
+++ b/fmriprep/interfaces/confounds.py
@@ -13,9 +13,9 @@ import os
 import shutil
 import numpy as np
 import pandas as pd
-from niworkflows.nipype import logging
-from niworkflows.nipype.utils.filemanip import fname_presuffix
-from niworkflows.nipype.interfaces.base import (
+from nipype import logging
+from nipype.utils.filemanip import fname_presuffix
+from nipype.interfaces.base import (
     traits, TraitedSpec, BaseInterfaceInputSpec, File, Directory, isdefined,
     SimpleInterface
 )

--- a/fmriprep/interfaces/fmap.py
+++ b/fmriprep/interfaces/fmap.py
@@ -17,9 +17,9 @@ Interfaces to deal with the various types of fieldmap sources
 
 import numpy as np
 import nibabel as nb
-from niworkflows.nipype import logging
-from niworkflows.nipype.utils.filemanip import fname_presuffix
-from niworkflows.nipype.interfaces.base import (
+from nipype import logging
+from nipype.utils.filemanip import fname_presuffix
+from nipype.interfaces.base import (
     BaseInterfaceInputSpec, TraitedSpec, File, isdefined, traits,
     SimpleInterface)
 
@@ -241,7 +241,7 @@ def _despike2d(data, thres, neigh=None):
 
 def _unwrap(fmap_data, mag_file, mask=None):
     from math import pi
-    from niworkflows.nipype.interfaces.fsl import PRELUDE
+    from nipype.interfaces.fsl import PRELUDE
     magnii = nb.load(mag_file)
 
     if mask is None:
@@ -433,7 +433,7 @@ def _torads(in_file, fmap_range=None, newpath=None):
     """
     from math import pi
     import nibabel as nb
-    from niworkflows.nipype.utils.filemanip import fname_presuffix
+    from nipype.utils.filemanip import fname_presuffix
 
     out_file = fname_presuffix(in_file, suffix='_rad', newpath=newpath)
     fmapnii = nb.load(in_file)
@@ -452,7 +452,7 @@ def _tohz(in_file, range_hz, newpath=None):
     """Convert a field map to Hz units"""
     from math import pi
     import nibabel as nb
-    from niworkflows.nipype.utils.filemanip import fname_presuffix
+    from nipype.utils.filemanip import fname_presuffix
 
     out_file = fname_presuffix(in_file, suffix='_hz', newpath=newpath)
     fmapnii = nb.load(in_file)
@@ -485,7 +485,7 @@ def phdiff2fmap(in_file, delta_te, newpath=None):
     import math
     import numpy as np
     import nibabel as nb
-    from niworkflows.nipype.utils.filemanip import fname_presuffix
+    from nipype.utils.filemanip import fname_presuffix
     #  GYROMAG_RATIO_H_PROTON_MHZ = 42.576
 
     out_file = fname_presuffix(in_file, suffix='_fmap', newpath=newpath)

--- a/fmriprep/interfaces/freesurfer.py
+++ b/fmriprep/interfaces/freesurfer.py
@@ -15,8 +15,8 @@ Fetch some example data:
 
 Disable warnings:
 
-    >>> import niworkflows.nipype as nn
-    >>> nn.logging.getLogger('interface').setLevel('ERROR')
+    >>> from nipype import logging
+    >>> logging.getLogger('interface').setLevel('ERROR')
 
 """
 
@@ -28,13 +28,13 @@ from skimage import morphology as sim
 from scipy.ndimage.morphology import binary_fill_holes
 from nilearn.image import resample_to_img, new_img_like
 
-from niworkflows.nipype.utils.filemanip import copyfile, filename_to_list, fname_presuffix
-from niworkflows.nipype.interfaces.base import (
+from nipype.utils.filemanip import copyfile, filename_to_list, fname_presuffix
+from nipype.interfaces.base import (
     isdefined, InputMultiPath, BaseInterfaceInputSpec, TraitedSpec, File, traits, Directory
 )
-from niworkflows.nipype.interfaces import freesurfer as fs
-from niworkflows.nipype.interfaces.base import SimpleInterface
-from niworkflows.nipype.interfaces.freesurfer.preprocess import ConcatenateLTA
+from nipype.interfaces import freesurfer as fs
+from nipype.interfaces.base import SimpleInterface
+from nipype.interfaces.freesurfer.preprocess import ConcatenateLTA
 
 
 class StructuralReference(fs.RobustTemplate):

--- a/fmriprep/interfaces/images.py
+++ b/fmriprep/interfaces/images.py
@@ -15,12 +15,12 @@ import nibabel as nb
 import nilearn.image as nli
 from textwrap import indent
 
-from niworkflows.nipype import logging
-from niworkflows.nipype.utils.filemanip import fname_presuffix
-from niworkflows.nipype.interfaces.base import (
+from nipype import logging
+from nipype.utils.filemanip import fname_presuffix
+from nipype.interfaces.base import (
     traits, TraitedSpec, BaseInterfaceInputSpec, SimpleInterface,
     File, InputMultiPath, OutputMultiPath)
-from niworkflows.nipype.interfaces import fsl
+from nipype.interfaces import fsl
 
 LOGGER = logging.getLogger('interface')
 
@@ -570,7 +570,7 @@ def reorient(in_file, newpath=None):
 def extract_wm(in_seg, wm_label=3, newpath=None):
     import nibabel as nb
     import numpy as np
-    from niworkflows.nipype.utils.filemanip import fname_presuffix
+    from nipype.utils.filemanip import fname_presuffix
 
     nii = nb.load(in_seg)
     data = np.zeros(nii.shape, dtype=np.uint8)
@@ -622,7 +622,7 @@ def demean(in_file, in_mask, only_mask=False, newpath=None):
     import os
     import numpy as np
     import nibabel as nb
-    from niworkflows.nipype.utils.filemanip import fname_presuffix
+    from nipype.utils.filemanip import fname_presuffix
 
     out_file = fname_presuffix(in_file, suffix='_demeaned',
                                newpath=os.getcwd())

--- a/fmriprep/interfaces/itk.py
+++ b/fmriprep/interfaces/itk.py
@@ -14,12 +14,12 @@ from tempfile import TemporaryDirectory
 import numpy as np
 import nibabel as nb
 
-from niworkflows.nipype import logging
-from niworkflows.nipype.utils.filemanip import fname_presuffix
-from niworkflows.nipype.interfaces.base import (
+from nipype import logging
+from nipype.utils.filemanip import fname_presuffix
+from nipype.interfaces.base import (
     traits, TraitedSpec, BaseInterfaceInputSpec, File, InputMultiPath, OutputMultiPath,
     SimpleInterface)
-from niworkflows.nipype.interfaces.ants.resampling import ApplyTransformsInputSpec
+from nipype.interfaces.ants.resampling import ApplyTransformsInputSpec
 
 LOGGER = logging.getLogger('interface')
 
@@ -222,8 +222,8 @@ class FUGUEvsm2ANTSwarp(SimpleInterface):
 
 
 def _mat2itk(args):
-    from niworkflows.nipype.interfaces.c3 import C3dAffineTool
-    from niworkflows.nipype.utils.filemanip import fname_presuffix
+    from nipype.interfaces.c3 import C3dAffineTool
+    from nipype.utils.filemanip import fname_presuffix
 
     in_file, in_ref, in_src, index, newpath = args
     # Generate a temporal file name
@@ -247,7 +247,7 @@ def _applytfms(args):
     multiprocessing's map
     """
     import nibabel as nb
-    from niworkflows.nipype.utils.filemanip import fname_presuffix
+    from nipype.utils.filemanip import fname_presuffix
     from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
 
     in_file, in_xform, ifargs, index, newpath = args

--- a/fmriprep/interfaces/multiecho.py
+++ b/fmriprep/interfaces/multiecho.py
@@ -21,9 +21,9 @@ import numpy as np
 import nibabel as nb
 from nilearn.masking import (apply_mask, unmask)
 
-from niworkflows.nipype import logging
-from niworkflows.nipype.utils.filemanip import (split_filename, fname_presuffix)
-from niworkflows.nipype.interfaces.base import (
+from nipype import logging
+from nipype.utils.filemanip import (split_filename, fname_presuffix)
+from nipype.interfaces.base import (
     traits, TraitedSpec, File, InputMultiPath, SimpleInterface,
     BaseInterfaceInputSpec)
 

--- a/fmriprep/interfaces/nilearn.py
+++ b/fmriprep/interfaces/nilearn.py
@@ -16,9 +16,9 @@ from scipy.ndimage.morphology import binary_fill_holes
 from nilearn.masking import compute_epi_mask
 from nilearn.image import concat_imgs
 
-from niworkflows.nipype import logging
-from niworkflows.nipype.utils.filemanip import fname_presuffix
-from niworkflows.nipype.interfaces.base import (
+from nipype import logging
+from nipype.utils.filemanip import fname_presuffix
+from nipype.interfaces.base import (
     traits, isdefined, TraitedSpec, BaseInterfaceInputSpec,
     File, InputMultiPath, SimpleInterface
 )

--- a/fmriprep/interfaces/patches.py
+++ b/fmriprep/interfaces/patches.py
@@ -11,7 +11,7 @@ from random import randint
 from time import sleep
 
 from numpy.linalg.linalg import LinAlgError
-from niworkflows.nipype.algorithms import confounds as nac
+from nipype.algorithms import confounds as nac
 
 
 class RobustACompCor(nac.ACompCor):

--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -14,11 +14,11 @@ import time
 import re
 
 from collections import Counter
-from niworkflows.nipype.interfaces.base import (
+from nipype.interfaces.base import (
     traits, TraitedSpec, BaseInterfaceInputSpec,
     File, Directory, InputMultiPath, Str, isdefined,
     SimpleInterface)
-from niworkflows.nipype.interfaces import freesurfer as fs
+from nipype.interfaces import freesurfer as fs
 
 from .bids import BIDS_NAME
 

--- a/fmriprep/interfaces/surf.py
+++ b/fmriprep/interfaces/surf.py
@@ -13,7 +13,7 @@ import re
 import numpy as np
 import nibabel as nb
 
-from niworkflows.nipype.interfaces.base import (
+from nipype.interfaces.base import (
     BaseInterfaceInputSpec, TraitedSpec, File, traits, isdefined,
     SimpleInterface
 )

--- a/fmriprep/interfaces/utils.py
+++ b/fmriprep/interfaces/utils.py
@@ -13,13 +13,13 @@ import numpy as np
 import nibabel as nb
 import scipy.ndimage as nd
 
-from niworkflows.nipype import logging
-from niworkflows.nipype.utils.filemanip import fname_presuffix
-from niworkflows.nipype.interfaces.base import (
+from nipype import logging
+from nipype.utils.filemanip import fname_presuffix
+from nipype.interfaces.base import (
     traits, isdefined, File, InputMultiPath,
     TraitedSpec, DynamicTraitedSpec, BaseInterfaceInputSpec, SimpleInterface
 )
-from niworkflows.nipype.interfaces.io import add_traits
+from nipype.interfaces.io import add_traits
 
 IFLOGGER = logging.getLogger('interfaces')
 

--- a/fmriprep/utils/bspline.py
+++ b/fmriprep/utils/bspline.py
@@ -9,7 +9,7 @@ import nibabel as nb
 from scipy.interpolate import interpn
 from datetime import datetime as dt
 
-from niworkflows.nipype import logging
+from nipype import logging
 LOGGER = logging.getLogger('interfaces')
 
 

--- a/fmriprep/utils/misc.py
+++ b/fmriprep/utils/misc.py
@@ -18,7 +18,7 @@ def fix_multi_T1w_source_name(in_files):
 
     """
     import os
-    from niworkflows.nipype.utils.filemanip import filename_to_list
+    from nipype.utils.filemanip import filename_to_list
     base, in_file = os.path.split(filename_to_list(in_files)[0])
     subject_label = in_file.split("_", 1)[0].split("-")[1]
     return os.path.join(base, "sub-%s_T1w.nii.gz" % subject_label)
@@ -35,7 +35,7 @@ def add_suffix(in_files, suffix):
 
     """
     import os.path as op
-    from niworkflows.nipype.utils.filemanip import fname_presuffix, filename_to_list
+    from nipype.utils.filemanip import fname_presuffix, filename_to_list
     return op.basename(fname_presuffix(filename_to_list(in_files)[0],
                                        suffix=suffix))
 

--- a/fmriprep/utils/testing.py
+++ b/fmriprep/utils/testing.py
@@ -12,9 +12,9 @@ import unittest
 import logging
 from networkx.exception import NetworkXUnfeasible
 
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces.base import isdefined
-from niworkflows.nipype.interfaces import utility as niu
+from nipype.pipeline import engine as pe
+from nipype.interfaces.base import isdefined
+from nipype.interfaces import utility as niu
 
 logging.disable(logging.INFO)  # <- do we really want to do this?
 

--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -17,7 +17,7 @@ import re
 import html
 
 import jinja2
-from niworkflows.nipype.utils.filemanip import loadcrash, copyfile
+from nipype.utils.filemanip import loadcrash, copyfile
 from pkg_resources import resource_filename as pkgrf
 
 

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -24,15 +24,15 @@ import os.path as op
 
 from pkg_resources import resource_filename as pkgr
 
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import (
+from nipype.pipeline import engine as pe
+from nipype.interfaces import (
     io as nio,
     utility as niu,
     c3,
     freesurfer as fs,
     fsl
 )
-from niworkflows.nipype.interfaces.ants import BrainExtraction, N4BiasFieldCorrection
+from nipype.interfaces.ants import BrainExtraction, N4BiasFieldCorrection
 
 from niworkflows.interfaces.registration import RobustMNINormalizationRPT
 import niworkflows.data as nid
@@ -1286,7 +1286,7 @@ def _seg2msks(in_file, newpath=None):
     """Converts labels to masks"""
     import nibabel as nb
     import numpy as np
-    from niworkflows.nipype.utils.filemanip import fname_presuffix
+    from nipype.utils.filemanip import fname_presuffix
 
     nii = nb.load(in_file)
     labels = nii.get_data()

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -15,8 +15,8 @@ import sys
 import os
 from copy import deepcopy
 
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import utility as niu
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu
 
 from ..interfaces import (
     BIDSDataGrabber, BIDSFreeSurferDir, BIDSInfo, SubjectSummary, AboutSummary,

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -13,11 +13,11 @@ Orchestrating the BOLD-preprocessing workflow
 import os
 
 import nibabel as nb
-from niworkflows.nipype import logging
+from nipype import logging
 
-from niworkflows.nipype.interfaces.fsl import Split as FSLSplit
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import utility as niu
+from nipype.interfaces.fsl import Split as FSLSplit
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu
 
 from ...interfaces import (
     DerivativesDataSink,
@@ -910,7 +910,7 @@ def _get_wf_name(bold_fname):
     >>> _get_wf_name('/completely/made/up/path/sub-01_task-nback_run-01_echo-1_bold.nii.gz')
     'func_preproc_task_nback_run_01_echo_1_wf'
     """
-    from niworkflows.nipype.utils.filemanip import split_filename
+    from nipype.utils.filemanip import split_filename
     fname = split_filename(bold_fname)[1]
     fname_nosub = '_'.join(fname.split("_")[1:])
     # if 'echo' in fname_nosub:

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -11,10 +11,10 @@ Calculate BOLD confounds
 """
 import os
 from niworkflows.data import get_mni_icbm152_linear, get_mni_icbm152_nlin_asym_09c
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import utility as niu, fsl
-from niworkflows.nipype.interfaces.nilearn import SignalExtraction
-from niworkflows.nipype.algorithms import confounds as nac
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu, fsl
+from nipype.interfaces.nilearn import SignalExtraction
+from nipype.algorithms import confounds as nac
 
 from niworkflows.interfaces.segmentation import ICA_AROMARPT
 from niworkflows.interfaces.masks import ROIsPlot
@@ -554,7 +554,7 @@ def init_ica_aroma_wf(template, metadata, mem_gb, omp_nthreads,
 def _maskroi(in_mask, roi_file):
     import numpy as np
     import nibabel as nb
-    from niworkflows.nipype.utils.filemanip import fname_presuffix
+    from nipype.utils.filemanip import fname_presuffix
 
     roi = nb.load(roi_file)
     roidata = roi.get_data().astype(np.uint8)

--- a/fmriprep/workflows/bold/hmc.py
+++ b/fmriprep/workflows/bold/hmc.py
@@ -9,8 +9,8 @@ Head-Motion Estimation and Correction (HMC) of BOLD images
 
 """
 
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import utility as niu, fsl
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu, fsl
 from niworkflows.interfaces import NormalizeMotionParams
 from ...interfaces import MCFLIRT2ITK
 

--- a/fmriprep/workflows/bold/registration.py
+++ b/fmriprep/workflows/bold/registration.py
@@ -15,8 +15,8 @@ Registration workflows
 import os
 import os.path as op
 
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import utility as niu, fsl, c3, freesurfer as fs
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu, fsl, c3, freesurfer as fs
 from niworkflows.interfaces.registration import FLIRTRPT, BBRegisterRPT, MRICoregRPT
 from niworkflows.interfaces.utils import GenerateSamplingReference
 from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
@@ -640,7 +640,7 @@ def compare_xforms(lta_list, norm_threshold=15):
 
     """
     from fmriprep.interfaces.surf import load_transform
-    from niworkflows.nipype.algorithms.rapidart import _calc_norm_affine
+    from nipype.algorithms.rapidart import _calc_norm_affine
 
     bbr_affine = load_transform(lta_list[0])
     fallback_affine = load_transform(lta_list[1])

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -13,9 +13,9 @@ Resampling workflows
 import os.path as op
 
 
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import utility as niu, freesurfer as fs
-from niworkflows.nipype.interfaces.fsl import Split as FSLSplit
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu, freesurfer as fs
+from nipype.interfaces.fsl import Split as FSLSplit
 
 from niworkflows import data as nid
 from niworkflows.interfaces.utils import GenerateSamplingReference
@@ -484,7 +484,7 @@ def init_bold_preproc_report_wf(mem_gb, reportlets_dir, name='bold_preproc_repor
 
     """
 
-    from niworkflows.nipype.algorithms.confounds import TSNR
+    from nipype.algorithms.confounds import TSNR
     from niworkflows.interfaces import SimpleBeforeAfter
     from ...interfaces import DerivativesDataSink
 

--- a/fmriprep/workflows/bold/stc.py
+++ b/fmriprep/workflows/bold/stc.py
@@ -8,9 +8,9 @@ Slice-Timing Correction (STC) of BOLD images
 .. autofunction:: init_bold_stc_wf
 
 """
-from niworkflows.nipype import logging
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import utility as niu, afni
+from nipype import logging
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu, afni
 from niworkflows.interfaces.utils import CopyXForm
 
 DEFAULT_MEMORY_MIN_GB = 0.01

--- a/fmriprep/workflows/bold/t2s.py
+++ b/fmriprep/workflows/bold/t2s.py
@@ -8,9 +8,9 @@ Generate T2* map from multi-echo BOLD images
 .. autofunction:: init_bold_t2s_wf
 
 """
-from niworkflows.nipype import logging
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import utility as niu
+from nipype import logging
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu
 
 from ...interfaces.multiecho import (T2SMap, MaskT2SMap)
 from .resampling import init_bold_preproc_trans_wf

--- a/fmriprep/workflows/bold/util.py
+++ b/fmriprep/workflows/bold/util.py
@@ -10,8 +10,8 @@ Utility workflows
 .. autofunction:: init_skullstrip_bold_wf
 
 """
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import utility as niu, fsl, afni, ants
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu, fsl, afni, ants
 from niworkflows.interfaces.utils import CopyXForm
 from niworkflows.interfaces.masks import SimpleShowMaskRPT
 from niworkflows.interfaces.registration import EstimateReferenceImage

--- a/fmriprep/workflows/fieldmap/base.py
+++ b/fmriprep/workflows/fieldmap/base.py
@@ -36,9 +36,9 @@ False           False       False         HMC only
 
 """
 
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import utility as niu
-from niworkflows.nipype import logging
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu
+from nipype import logging
 
 # Fieldmap workflows
 from .pepolar import init_pepolar_unwarp_wf

--- a/fmriprep/workflows/fieldmap/fmap.py
+++ b/fmriprep/workflows/fieldmap/fmap.py
@@ -20,10 +20,9 @@ of the BIDS specification.
 
 """
 
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import utility as niu, fsl, ants
-# Note that deman_image imports from nipype
-from niworkflows.nipype.workflows.dmri.fsl.utils import demean_image, cleanup_edge_pipeline
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu, fsl, ants
+from nipype.workflows.dmri.fsl.utils import demean_image, cleanup_edge_pipeline
 from niworkflows.interfaces.masks import BETRPT
 
 from ...interfaces import (

--- a/fmriprep/workflows/fieldmap/pepolar.py
+++ b/fmriprep/workflows/fieldmap/pepolar.py
@@ -12,8 +12,8 @@ Phase Encoding POLARity (*PEPOLAR*) techniques
 
 import pkg_resources as pkgr
 
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import afni, ants, fsl, utility as niu
+from nipype.pipeline import engine as pe
+from nipype.interfaces import afni, ants, fsl, utility as niu
 from niworkflows.interfaces import CopyHeader
 from niworkflows.interfaces.registration import ANTSApplyTransformsRPT
 
@@ -233,7 +233,7 @@ def init_prepare_epi_wf(omp_nthreads, name="prepare_epi_wf"):
     workflow = pe.Workflow(name=name)
 
     def _flatten(l):
-        from niworkflows.nipype.utils.filemanip import filename_to_list
+        from nipype.utils.filemanip import filename_to_list
         return [item for sublist in l for item in filename_to_list(sublist)]
 
     workflow.connect([
@@ -251,7 +251,7 @@ def init_prepare_epi_wf(omp_nthreads, name="prepare_epi_wf"):
 
 def _fix_hdr(in_file, newpath=None):
     import nibabel as nb
-    from niworkflows.nipype.utils.filemanip import fname_presuffix
+    from nipype.utils.filemanip import fname_presuffix
 
     nii = nb.load(in_file)
     hdr = nii.header.copy()

--- a/fmriprep/workflows/fieldmap/phdiff.py
+++ b/fmriprep/workflows/fieldmap/phdiff.py
@@ -18,10 +18,9 @@ Fieldmap preprocessing workflow for fieldmap data structure
 
 """
 
-from niworkflows.nipype.interfaces import ants, fsl, utility as niu
-from niworkflows.nipype.pipeline import engine as pe
-# Note that demean_image imports from nipype
-from niworkflows.nipype.workflows.dmri.fsl.utils import siemens2rads, demean_image, \
+from nipype.interfaces import ants, fsl, utility as niu
+from nipype.pipeline import engine as pe
+from nipype.workflows.dmri.fsl.utils import siemens2rads, demean_image, \
     cleanup_edge_pipeline
 from niworkflows.interfaces.masks import BETRPT
 

--- a/fmriprep/workflows/fieldmap/syn.py
+++ b/fmriprep/workflows/fieldmap/syn.py
@@ -25,9 +25,9 @@ Feedback will be enthusiastically received.
 """
 import pkg_resources as pkgr
 
-from niworkflows.nipype import logging
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import fsl, utility as niu
+from nipype import logging
+from nipype.pipeline import engine as pe
+from nipype.interfaces import fsl, utility as niu
 from niworkflows.interfaces.fixes import (FixHeaderApplyTransforms as ApplyTransforms,
                                           FixHeaderRegistration as Registration)
 from ...interfaces import InvertT1w

--- a/fmriprep/workflows/fieldmap/unwarp.py
+++ b/fmriprep/workflows/fieldmap/unwarp.py
@@ -21,8 +21,8 @@ Unwarping
 
 import pkg_resources as pkgr
 
-from niworkflows.nipype.pipeline import engine as pe
-from niworkflows.nipype.interfaces import ants, fsl, utility as niu
+from nipype.pipeline import engine as pe
+from nipype.interfaces import ants, fsl, utility as niu
 from niworkflows.interfaces.registration import ANTSApplyTransformsRPT, ANTSRegistrationRPT
 
 from ...interfaces import itk, DerivativesDataSink
@@ -244,8 +244,8 @@ def init_fmap_unwarp_report_wf(name='fmap_unwarp_report_wf', suffix='variant-hmc
 
     """
 
-    from niworkflows.nipype.pipeline import engine as pe
-    from niworkflows.nipype.interfaces import utility as niu
+    from nipype.pipeline import engine as pe
+    from nipype.interfaces import utility as niu
     from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
 
     from niworkflows.interfaces import SimpleBeforeAfter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-niworkflows>=0.3.13
+git+https://github.com/effigies/niworkflows.git@4e8f18d79a45db156d441cbc41cf28b953fc5bf1#egg=niworkflows
 versioneer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/effigies/niworkflows.git@4e8f18d79a45db156d441cbc41cf28b953fc5bf1#egg=niworkflows
+niworkflows>=0.4.0
 versioneer

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -356,9 +356,6 @@ def main():
     for pkg in ('fmriprep', 'niworkflows', 'nipype'):
         repo_path = getattr(opts, 'patch_' + pkg)
         if repo_path is not None:
-            # nipype is now a submodule of niworkflows
-            if pkg == 'nipype':
-                pkg = 'niworkflows/nipype'
             command.extend(['-v',
                             '{}:{}/{}:ro'.format(repo_path, PKG_PATH, pkg)])
 


### PR DESCRIPTION
Purges `niworkflows.nipype` in favor of `nipype`.

Pins poldracklab/niworkflows#241.

----

#### Original text:

This is just to validate poldracklab/niworkflows#238. Should be a functionally inert refactor, so can wait for the next niworkflows release to actually update the pin.