### PR TITLE
[FIX] Corrects Dockerfile WORKDIR.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -161,7 +161,7 @@ RUN echo "${VERSION}" > /root/src/fmriprep/fmriprep/VERSION && \
 
 RUN ldconfig
 
-WORKDIR /root/src/fmriprep
+WORKDIR /tmp/
 
 ENTRYPOINT ["/usr/local/miniconda/bin/fmriprep"]
 


### PR DESCRIPTION
## Changes proposed in this pull request

It sets the last WORKDIR in the docker image to /tmp, instead of /root/src/fmriprep, so now you can run the docker container as a user different from root.  

As far as I can tell, if no working directory is specified by the `-w` parameter, fmriprep will try to create the folder `work` under `/root/src/fmriprep`, and only root has access to that folder.

This should fix problems people have found when running docker specifying a user (e.g., ref #1060).


**Please review and check the following**:
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->

  - [x] I have read the [guidelines for contributions](https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md).
  - [x] I understand that my contributions will not be merged unless the work is
        finished (i.e. no ``[WIP]`` tag remains in the title of my PR) and tests pass.
  - [x] The proposed code follows the
        [coding style](https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md#fmriprep-coding-style-guide),
        to the extent I understood them (and I will address any comments raised by the PR's reviewers in this regard).
  - [x] \(Optional\) I opt-out from being listed in the `.zenodo.json` file.
