### PR TITLE
[ENH] Enable ``-u`` (docker user/userid) flag in wrapper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
           name: Run fMRIPrep tests
           no_output_timeout: 2h
           command: |
-            docker run -ti --rm=false \
+            docker run -u $USER -ti --rm=false \
               --entrypoint="py.test" poldracklab/fmriprep:latest \
               /root/src/fmriprep/ --doctest-modules --ignore=docs --ignore=setup.py
       - run:
@@ -264,7 +264,7 @@ jobs:
           name: Build fMRIPrep documentation
           no_output_timeout: 2h
           command: |
-            docker run -ti --rm=false -v $PWD:/_build_html \
+            docker run -u $USER -ti --rm=false -v $PWD:/_build_html \
               --entrypoint=sphinx-build poldracklab/fmriprep:latest \
               -T -E -b html -d _build/doctrees-readthedocs -W -D \
               language=en /root/src/fmriprep/docs/ /_build_html 2>&1 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
           name: Run fMRIPrep tests
           no_output_timeout: 2h
           command: |
-            docker run -u $USER -ti --rm=false \
+            docker run -u 1000 -ti --rm=false \
               --entrypoint="py.test" poldracklab/fmriprep:latest \
               /root/src/fmriprep/ --doctest-modules --ignore=docs --ignore=setup.py
       - run:
@@ -264,7 +264,7 @@ jobs:
           name: Build fMRIPrep documentation
           no_output_timeout: 2h
           command: |
-            docker run -u $USER -ti --rm=false -v $PWD:/_build_html \
+            docker run -u 1000 -ti --rm=false -v $PWD:/_build_html \
               --entrypoint=sphinx-build poldracklab/fmriprep:latest \
               -T -E -b html -d _build/doctrees-readthedocs -W -D \
               language=en /root/src/fmriprep/docs/ /_build_html 2>&1 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
           name: Run fMRIPrep tests
           no_output_timeout: 2h
           command: |
-            docker run -u 1000 -ti --rm=false \
+            docker run -ti --rm=false \
               --entrypoint="py.test" poldracklab/fmriprep:latest \
               /root/src/fmriprep/ --doctest-modules --ignore=docs --ignore=setup.py
       - run:
@@ -264,7 +264,7 @@ jobs:
           name: Build fMRIPrep documentation
           no_output_timeout: 2h
           command: |
-            docker run -u 1000 -ti --rm=false -v $PWD:/_build_html \
+            docker run -ti --rm=false -v $PWD:/_build_html \
               --entrypoint=sphinx-build poldracklab/fmriprep:latest \
               -T -E -b html -d _build/doctrees-readthedocs -W -D \
               language=en /root/src/fmriprep/docs/ /_build_html 2>&1 \
@@ -326,7 +326,7 @@ jobs:
             sudo setfacl -d -m group:$(id -gn):rwx /tmp/ds005/work && \
                 sudo setfacl -m group:$(id -gn):rwx /tmp/ds005/work
             fmriprep-docker -i poldracklab/fmriprep:latest \
-                -e FMRIPREP_DEV 1 \
+                -e FMRIPREP_DEV 1 -u $(id -u) \
                 --config $PWD/nipype.cfg -w /tmp/ds005/work \
                 /tmp/data/ds005 /tmp/ds005/derivatives participant \
                 --debug --write-graph --mem_mb 4096 \
@@ -346,7 +346,7 @@ jobs:
             sudo setfacl -d -m group:$(id -gn):rwx /tmp/ds005/work && \
                 sudo setfacl -m group:$(id -gn):rwx /tmp/ds005/work
             fmriprep-docker -i poldracklab/fmriprep:latest \
-                -e FMRIPREP_DEV 1 \
+                -e FMRIPREP_DEV 1 -u $(id -u) \
                 --config $PWD/nipype.cfg -w /tmp/ds005/work \
                 /tmp/data/ds005 /tmp/ds005/derivatives participant \
                 --debug --write-graph --use-syn-sdc --mem_mb 4096 \
@@ -373,7 +373,7 @@ jobs:
           command: |
             rm /tmp/data/ds005/sub-01/func/*_run-02_*
             fmriprep-docker -i poldracklab/fmriprep:latest \
-                -e FMRIPREP_DEV 1 \
+                -e FMRIPREP_DEV 1 -u $(id -u) \
                 --config $PWD/nipype.cfg -w /tmp/ds005/work \
                 /tmp/data/ds005 /tmp/ds005/derivatives_partial participant \
                 --debug --write-graph --use-syn-sdc --mem_mb 4096 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,9 +160,7 @@ RUN echo "${VERSION}" > /root/src/fmriprep/fmriprep/VERSION && \
     rm -rf ~/.cache/pip
 
 RUN ldconfig
-WORKDIR /scratch
-RUN chmod 777 /scratch
-
+WORKDIR /tmp/
 ENTRYPOINT ["/usr/local/miniconda/bin/fmriprep"]
 
 ARG BUILD_DATE

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,7 +160,9 @@ RUN echo "${VERSION}" > /root/src/fmriprep/fmriprep/VERSION && \
     rm -rf ~/.cache/pip
 
 RUN ldconfig
-WORKDIR /tmp/
+WORKDIR /scratch
+RUN chmod 777 /scratch
+
 ENTRYPOINT ["/usr/local/miniconda/bin/fmriprep"]
 
 ARG BUILD_DATE

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -286,6 +286,8 @@ def get_parser():
                        type=os.path.abspath, help='Use custom nipype.cfg file')
     g_dev.add_argument('-e', '--env', action='append', nargs=2, metavar=('ENV_VAR', 'value'),
                        help='Set custom environment variable within container')
+    g_dev.add_argument('-u', '--user', action='store',
+                       help='Run container as a given user/uid')
 
     return parser
 
@@ -362,6 +364,9 @@ def main():
     if opts.env:
         for envvar in opts.env:
             command.extend(['-e', '%s=%s' % tuple(envvar)])
+
+    if opts.user:
+        command.extend(['-e', opts.user])
 
     if opts.fs_license_file:
         command.extend([

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -366,7 +366,7 @@ def main():
             command.extend(['-e', '%s=%s' % tuple(envvar)])
 
     if opts.user:
-        command.extend(['-e', opts.user])
+        command.extend(['-u', opts.user])
 
     if opts.fs_license_file:
         command.extend([


### PR DESCRIPTION
## Changes proposed in this pull request
Enables a ``-u`` flag for the Docker wrapper. Add testing this flag into ds005 tests.

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
Documentation is automated with the usage of `fmriprep-docker`

## Pull-request guidelines:
<!--
Please make sure you have read the PR guidelines below, and checked 
all boxes that apply at the bottom.
-->
1. We invite you to list yourself as a *fMRIPrep* contributor, so if your name 
   is not already mentioned, please modify the 
   [``.zenodo.json``](https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json)
   file with your data right above Russ' entry. Example:
   ```
   {
      "name": "Contributor, New FMRIPrep",
      "affiliation": "Department of fMRI prep'ing, Open Science Made-Up University",
      "orcid": "<your id>"
   },
   {
      "name": "Poldrack, Russell A.",
      "affiliation": "Department of Psychology, Stanford University",
      "orcid": "0000-0001-6755-0259"
   },
   ```
   
2. By submitting this request you acknowledge that your contributions are available under the BSD 3-Clause license.

3. Use a descriptive prefix, between brackets for your PR: ``ENH`` (enhancement), ``FIX``, ``TST``, ``DOC``, ``STY``,
   ``REF`` (refactor), ``CI`` (continous integration), ``MAINT`` (maintenance). Example:
   ```
   [ENH] Support for SB-reference in multi-band datasets
   ```
   For works-in-progress, add the ``WIP`` tag in addition to the descriptive prefix. 
   Pull-requests tagged with ``[WIP]`` will not merged in until the tag is removed.

4. Your PR will be reviewed according to the following
   [template](https://github.com/poldracklab/fmriprep/wiki/Reviewing-a-Pull-Request).

5. Documentation is a fundamental aspect to the *glass-box* philosophy that *fMRIPrep* abides by.
   Please understand that the *fMRIPrep* team may (are likely to) request you to improve the documentation
   provided with this PR, within the PR or in future PRs.
   

**Please review and check the following**:
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->

  - [x] I have read the [guidelines for contributions](https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md).
  - [x] I understand that my contributions will not be merged unless the work is
        finished (i.e. no ``[WIP]`` tag remains in the title of my PR) and tests pass.
  - [x] The proposed code follows the
        [coding style](https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md#fmriprep-coding-style-guide),
        to the extent I understood them (and I will address any comments raised by the PR's reviewers in this regard).
  - [ ] \(Optional\) I opt-out from being listed in the `.zenodo.json` file.
