### PR TITLE
DOC: Update copyright year to 2018

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2017, the CRN developers team.
+Copyright (c) 2015-2018, the CRN developers team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -7,5 +7,5 @@ in the ``fmriprep`` distribution.
 
 All trademarks referenced herein are property of their respective holders.
 
-Copyright (c) 2015-2017, the fmriprep developers and the CRN.
+Copyright (c) 2015-2018, the fMRIPrep developers and the CRN.
 All rights reserved.

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -12,7 +12,7 @@ running ::
 Please report any feedback to our GitHub repository
 (https://github.com/poldracklab/fmriprep) and do not
 forget to credit all the authors of software that fMRIPrep
-uses (http://fmriprep.rtfd.io/en/latest/citing.html).
+uses (https://fmriprep.readthedocs.io/en/latest/citing.html).
 """
 import sys
 import os
@@ -23,7 +23,7 @@ from warnings import warn
 __version__ = '99.99.99'
 __packagename__ = 'fmriprep-docker'
 __author__ = 'The CRN developers'
-__copyright__ = 'Copyright 2017, Center for Reproducible Neuroscience, Stanford University'
+__copyright__ = 'Copyright 2018, Center for Reproducible Neuroscience, Stanford University'
 __credits__ = ['Craig Moodie', 'Ross Blair', 'Oscar Esteban', 'Chris Gorgolewski',
                'Shoshana Berleant', 'Christopher J. Markiewicz', 'Russell A. Poldrack']
 __license__ = '3-clause BSD'


### PR DESCRIPTION
## Changes proposed in this pull request

Updates documentation URL in fmriprep-docker wrapper to use HTTPS link.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->

Updates copyright year to 2018

**Please review and check the following**:
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->

  - [x] I have read the [guidelines for contributions](https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md).
  - [x] I understand that my contributions will not be merged unless the work is
        finished (i.e. no ``[WIP]`` tag remains in the title of my PR) and tests pass.
  - [x] The proposed code follows the
        [coding style](https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md#fmriprep-coding-style-guide),
        to the extent I understood them (and I will address any comments raised by the PR's reviewers in this regard).
  - [ ] \(Optional\) I opt-out from being listed in the `.zenodo.json` file.
