### PR TITLE
FIX: Verify first word of _cmd in dependency check

### DIFF
--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -37,7 +37,7 @@ def check_deps(workflow):
         (node.interface.__class__.__name__, node.interface._cmd)
         for node in workflow._get_all_nodes()
         if (hasattr(node.interface, '_cmd') and
-            which(node.interface._cmd) is None))
+            which(node.interface._cmd.split()[0]) is None))
 
 
 def get_parser():


### PR DESCRIPTION
## Changes proposed in this pull request

In the event that an `interface._cmd` has spaces in it - *i.e.*, pre-set flags in addition to the command name, the `which` check will fail. This PR uses `_cmd.split()[0]` to use only the command up to the first space when checking for the command.

A command of the form `python /some/path/some_script` will merely check the existence of `python`, and not `/some/path/some_script`, but that would not be correctly handled by the existing check. To my knowledge, we do not have any such nodes at this time, so this is theoretical, but we may want to consider a more robust long-term solution, but I don't believe that should hold up this fix.

Fixes #1235.

## Documentation that should be reviewed

None.

## Pull-request guidelines:

  - [x] I have read the [guidelines for contributions](https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md).
  - [x] I understand that my contributions will not be merged unless the work is
        finished (i.e. no ``[WIP]`` tag remains in the title of my PR) and tests pass.
  - [x] The proposed code follows the
        [coding style](https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md#fmriprep-coding-style-guide),
        to the extent I understood them (and I will address any comments raised by the PR's reviewers in this regard).
  - [ ] \(Optional\) I opt-out from being listed in the `.zenodo.json` file.
