### PR TITLE
DOC: De-indent to remove text from code block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.pytest_cache/
 
 # C extensions
 *.so

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -136,7 +136,7 @@ If the data to be preprocessed is also on the HPC, you are ready to run fmriprep
         --omp-nthreads 16
 
 
-    or, unset the ``PYTHONPATH`` variable before running: ::
+   or, unset the ``PYTHONPATH`` variable before running: ::
 
       $ unset PYTHONPATH; singularity run ~/poldracklab_fmriprep_latest-2016-12-04-5b74ad9a4c4d.img \
         /work/04168/asdf/lonestar/ $WORK/lonestar/output \


### PR DESCRIPTION
## Changes proposed in this pull request

De-indent to remove text from code block. Noticed this when verifying that #1237 was hitting ReadTheDocs.

## Documentation that should be reviewed

First note in [Running a Singularity Image](https://fmriprep.readthedocs.io/en/latest/installation.html#running-a-singularity-image).

## Pull-request guidelines:

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->

  - [x] I have read the [guidelines for contributions](https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md).
  - [x] I understand that my contributions will not be merged unless the work is
        finished (i.e. no ``[WIP]`` tag remains in the title of my PR) and tests pass.
  - [x] The proposed code follows the
        [coding style](https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md#fmriprep-coding-style-guide),
        to the extent I understood them (and I will address any comments raised by the PR's reviewers in this regard).
  - [ ] \(Optional\) I opt-out from being listed in the `.zenodo.json` file.
