### PR TITLE
ENH: Use single-band reference images when available

### DIFF
--- a/docker/scripts/get_templates.sh
+++ b/docker/scripts/get_templates.sh
@@ -2,8 +2,8 @@
 
 MNI_TEMPLATE="https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/580705eb594d9001ed622649"
 MNI_SHA256="608b1d609255424d51300e189feacd5ec74b04e244628303e802a6c0b0f9d9db"
-ASYM_09C_TEMPLATE="https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/5b0dbce20f461a000db8fa3d"
-ASYM_09C_SHA256="2851302474359c2c48995155aadb48b861e5dcf87aefda71af8010f671e8ed66"
+ASYM_09C_TEMPLATE="https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/580705089ad5a101f17944a9"
+ASYM_09C_SHA256="a24699ba0d13f72d0f8934cc211cb80bfd9c9a077b481d9b64295cf5275235a9"
 OASIS_TEMPLATE="https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/584123a29ad5a1020913609d"
 OASIS_SHA256="d87300e91346c16f55baf6f54f5f990bc020b61e8d5df9bcc3abb0cc4b943113"
 NKI_TEMPLATE="https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/59cd90f46c613b02b3d79782"

--- a/docker/scripts/get_templates.sh
+++ b/docker/scripts/get_templates.sh
@@ -2,8 +2,8 @@
 
 MNI_TEMPLATE="https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/580705eb594d9001ed622649"
 MNI_SHA256="608b1d609255424d51300e189feacd5ec74b04e244628303e802a6c0b0f9d9db"
-ASYM_09C_TEMPLATE="https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/580705089ad5a101f17944a9"
-ASYM_09C_SHA256="a24699ba0d13f72d0f8934cc211cb80bfd9c9a077b481d9b64295cf5275235a9"
+ASYM_09C_TEMPLATE="https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/5b0dbce20f461a000db8fa3d"
+ASYM_09C_SHA256="2851302474359c2c48995155aadb48b861e5dcf87aefda71af8010f671e8ed66"
 OASIS_TEMPLATE="https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/584123a29ad5a1020913609d"
 OASIS_SHA256="d87300e91346c16f55baf6f54f5f990bc020b61e8d5df9bcc3abb0cc4b943113"
 NKI_TEMPLATE="https://files.osf.io/v1/resources/fvuh8/providers/osfstorage/59cd90f46c613b02b3d79782"

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -294,6 +294,9 @@ BOLD reference image estimation
 
 This workflow estimates a reference image for a
 :abbr:`BOLD (blood-oxygen level-dependent)` series.
+If a single-band reference ("sbref") image associated with the BOLD series is
+available, then it is used directly.
+If not, a reference image is estimated from the BOLD series as follows:
 When T1-saturation effects ("dummy scans" or non-steady state volumes) are
 detected, they are averaged and used as reference due to their
 superior tissue contrast.

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -107,7 +107,7 @@ def get_parser():
     g_conf = parser.add_argument_group('Workflow configuration')
     g_conf.add_argument(
         '--ignore', required=False, action='store', nargs="+", default=[],
-        choices=['fieldmaps', 'slicetiming'],
+        choices=['fieldmaps', 'slicetiming', 'sbref'],
         help='ignore selected aspects of the input dataset to disable corresponding '
              'parts of the workflow (a space delimited list)')
     g_conf.add_argument(

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -242,6 +242,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
                     'Memory resampled/largemem=%.2f/%.2f GB.'),
                ref_file, mem_gb['filesize'], bold_tlen, mem_gb['resampled'], mem_gb['largemem'])
 
+    sbref_file = None
     # For doc building purposes
     if layout is None or bold_file == 'bold_preprocesing':
         LOGGER.log(25, 'No valid layout: building empty workflow.')
@@ -257,7 +258,6 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
             'magnitude2': 'sub-03/ses-2/fmap/sub-03_ses-2_run-1_magnitude2.nii.gz',
         }]
         run_stc = True
-        sbref_file = None
         multiecho = False
     else:
         # Find associated sbref, if possible

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -265,7 +265,10 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
         entities['type'] = 'sbref'
         files = layout.get(**entities)
         refbase = os.path.basename(ref_file)
-        if files:
+        if files and multiecho:
+            LOGGER.warning("Single-band reference found, but not supported in "
+                           "multi-echo workflows at this time. Ignoring.")
+        elif files:
             sbref_file = files[0].filename
             sbbase = os.path.basename(sbref_file)
             if len(files) > 1:

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -257,8 +257,26 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
             'magnitude2': 'sub-03/ses-2/fmap/sub-03_ses-2_run-1_magnitude2.nii.gz',
         }]
         run_stc = True
+        sbref_file = None
         multiecho = False
     else:
+        # Find associated sbref, if possible
+        entities = layout.parse_file_entities(ref_file)
+        entities['type'] = 'sbref'
+        files = layout.get(**entities)
+        refbase = os.path.basename(ref_file)
+        if files:
+            sbref_file = files[0].filename
+            sbbase = os.path.basename(sbref_file)
+            if len(files) > 1:
+                LOGGER.warning(
+                    "Multiple single-band reference files found for {}; using "
+                    "{}".format(refbase, sbbase))
+            else:
+                LOGGER.log(25, "Using single-band reference file {}".format(sbbase)
+        else:
+            LOGGER.log(25, "No single-band-reference found for {}".format(refbase))
+
         metadata = layout.get_metadata(ref_file)
 
         # Find fieldmaps. Options: (phase1|phase2|phasediff|epi|fieldmap|syn)
@@ -312,13 +330,15 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
 """
 
     inputnode = pe.Node(niu.IdentityInterface(
-        fields=['bold_file', 'subjects_dir', 'subject_id',
+        fields=['bold_file', 'sbref_file', 'subjects_dir', 'subject_id',
                 't1_preproc', 't1_brain', 't1_mask', 't1_seg', 't1_tpms',
                 't1_aseg', 't1_aparc',
                 't1_2_mni_forward_transform', 't1_2_mni_reverse_transform',
                 't1_2_fsnative_forward_transform', 't1_2_fsnative_reverse_transform']),
         name='inputnode')
     inputnode.inputs.bold_file = bold_file
+    if sbref_file is not None:
+        inputnode.inputs.sbref_file = sbref_file
 
     outputnode = pe.Node(niu.IdentityInterface(
         fields=['bold_t1', 'bold_mask_t1', 'bold_aseg_t1', 'bold_aparc_t1', 'cifti_variant',
@@ -441,7 +461,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     # MAIN WORKFLOW STRUCTURE #######################################################
     workflow.connect([
         # Generate early reference
-        (inputnode, bold_reference_wf, [('bold_file', 'inputnode.bold_file')]),
+        (inputnode, bold_reference_wf, [('bold_file', 'inputnode.bold_file'),
+                                        ('sbref_file', 'inputnode.sbref_file')]),
         # BOLD buffer has slice-time corrected if it was run, original otherwise
         (boldbuffer, bold_split, [('bold_file', 'in_file')]),
         # HMC

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -573,7 +573,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         # Replace reference with the echo selected with FirstEcho
         workflow.disconnect([
             (inputnode, bold_reference_wf, [
-                ('bold_file', 'inputnode.bold_file')]),
+                ('bold_file', 'inputnode.bold_file'),
+                ('sbref_file', 'inputnode.sbref_file')]),
             (bold_reference_wf, boldbuffer, [
                 ('outputnode.bold_file', 'bold_file')]),
         ])

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -273,7 +273,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
                     "Multiple single-band reference files found for {}; using "
                     "{}".format(refbase, sbbase))
             else:
-                LOGGER.log(25, "Using single-band reference file {}".format(sbbase)
+                LOGGER.log(25, "Using single-band reference file {}".format(sbbase))
         else:
             LOGGER.log(25, "No single-band-reference found for {}".format(refbase))
 

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -265,7 +265,9 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
         entities['type'] = 'sbref'
         files = layout.get(**entities)
         refbase = os.path.basename(ref_file)
-        if files and multiecho:
+        if 'sbref' in ignore:
+            LOGGER.info("Single-band reference files ignored.")
+        elif files and multiecho:
             LOGGER.warning("Single-band reference found, but not supported in "
                            "multi-echo workflows at this time. Ignoring.")
         elif files:

--- a/fmriprep/workflows/bold/util.py
+++ b/fmriprep/workflows/bold/util.py
@@ -116,7 +116,7 @@ using a custom methodology of *fMRIPrep*.
         (validate, outputnode, [('out_file', 'bold_file'),
                                 ('out_report', 'validation_report')]),
         (gen_ref, outputnode, [('n_volumes_to_discard', 'skip_vols')]),
-        (validate_ref, outputnode, [('ref_image', 'raw_ref_image')]),
+        (validate_ref, outputnode, [('out_file', 'raw_ref_image')]),
         (enhance_and_skullstrip_bold_wf, outputnode, [
             ('outputnode.bias_corrected_file', 'ref_image'),
             ('outputnode.mask_file', 'bold_mask'),

--- a/fmriprep/workflows/bold/util.py
+++ b/fmriprep/workflows/bold/util.py
@@ -87,7 +87,7 @@ def init_bold_reference_wf(omp_nthreads, bold_file=None, name='bold_reference_wf
 First, a reference volume and its skull-stripped version were generated
 using a custom methodology of *fMRIPrep*.
 """
-    inputnode = pe.Node(niu.IdentityInterface(fields=['bold_file']), name='inputnode')
+    inputnode = pe.Node(niu.IdentityInterface(fields=['bold_file', 'sbref_file']), name='inputnode')
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['bold_file', 'raw_ref_image', 'skip_vols', 'ref_image',
                                       'ref_image_brain', 'bold_mask', 'validation_report',
@@ -102,16 +102,20 @@ using a custom methodology of *fMRIPrep*.
 
     gen_ref = pe.Node(EstimateReferenceImage(), name="gen_ref",
                       mem_gb=1)  # OE: 128x128x128x50 * 64 / 8 ~ 900MB.
+    # Re-run validation; no effect if no sbref; otherwise apply same validation to sbref as bold
+    validate_ref = pe.Node(ValidateImage(), name='validate_ref', mem_gb=DEFAULT_MEMORY_MIN_GB)
     enhance_and_skullstrip_bold_wf = init_enhance_and_skullstrip_bold_wf(omp_nthreads=omp_nthreads)
 
     workflow.connect([
         (inputnode, validate, [('bold_file', 'in_file')]),
+        (inputnode, gen_ref, [('sbref_file', 'sbref_file')]),
         (validate, gen_ref, [('out_file', 'in_file')]),
-        (gen_ref, enhance_and_skullstrip_bold_wf, [('ref_image', 'inputnode.in_file')]),
+        (gen_ref, validate_ref, [('ref_image', 'in_file')]),
+        (validate_ref, enhance_and_skullstrip_bold_wf, [('out_file', 'inputnode.in_file')]),
         (validate, outputnode, [('out_file', 'bold_file'),
                                 ('out_report', 'validation_report')]),
-        (gen_ref, outputnode, [('ref_image', 'raw_ref_image'),
-                               ('n_volumes_to_discard', 'skip_vols')]),
+        (gen_ref, outputnode, [('n_volumes_to_discard', 'skip_vols')]),
+        (validate_ref, outputnode, [('ref_image', 'raw_ref_image')]),
         (enhance_and_skullstrip_bold_wf, outputnode, [
             ('outputnode.bias_corrected_file', 'ref_image'),
             ('outputnode.mask_file', 'bold_mask'),

--- a/fmriprep/workflows/bold/util.py
+++ b/fmriprep/workflows/bold/util.py
@@ -87,7 +87,8 @@ def init_bold_reference_wf(omp_nthreads, bold_file=None, name='bold_reference_wf
 First, a reference volume and its skull-stripped version were generated
 using a custom methodology of *fMRIPrep*.
 """
-    inputnode = pe.Node(niu.IdentityInterface(fields=['bold_file', 'sbref_file']), name='inputnode')
+    inputnode = pe.Node(niu.IdentityInterface(fields=['bold_file', 'sbref_file']),
+                        name='inputnode')
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['bold_file', 'raw_ref_image', 'skip_vols', 'ref_image',
                                       'ref_image_brain', 'bold_mask', 'validation_report',


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

For each BOLD file, this approach finds the associated `sbref` file, if available, and passes it to `EstimateReferenceImage`.

One hangup here is that we need to validate both the bold file and sbref if available. To avoid weird conditionals, I put a second, post-reference-estimation validation step. If the image is estimated from the BOLD series, it should have no effect. If the sbref is returned, it will get the same treatment as the BOLD series did prior to estimation.

An alternative approach would be to generate the reference image, and then validate both the BOLD series and the reference image afterwards. I don't think it would make any computational effects (unless the reference process implicitly depends on good affine codes), but it might be a little easier to understand for future maintainers.

Given the possibility of implicit dependence on affine codes, I chose not to take that alternative, but content to be overruled.

Closes #449.
<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->

## To-do

* [x] Add `--ignore sbref` option to CLI to retain current behavior

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->

Added a couple lines to [BOLD reference image estimation](https://fmriprep.readthedocs.io/en/stable/workflows.html#bold-reference-image-estimation).

<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
