### PR TITLE
FIX: Accommodate new template formats

### DIFF
--- a/fmriprep/__about__.py
+++ b/fmriprep/__about__.py
@@ -98,7 +98,7 @@ REQUIRES = [
     'pybids>=0.6.3',
     'nitime',
     'nipype>=1.1.1',
-    'niworkflows>=0.4.2',
+    'niworkflows>=0.4.3',
     'statsmodels',
     'seaborn',
     'indexed_gzip>=0.8.2',

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -50,6 +50,10 @@ from ..interfaces import (
 )
 from ..utils.misc import fix_multi_T1w_source_name, add_suffix
 
+TEMPLATE_MAP = {
+    'MNI152NLin2009cAsym': 'mni_icbm152_nlin_asym_09c',
+    }
+
 
 #  pylint: disable=R0914
 def init_anat_preproc_wf(skull_strip_template, output_spaces, template, debug,
@@ -330,7 +334,7 @@ and used as T1w-reference throughout the workflow.
     )
 
     if 'template' in output_spaces:
-        template_str = nid.TEMPLATE_MAP[template]
+        template_str = TEMPLATE_MAP[template]
         ref_img = op.join(nid.get_dataset(template_str), '1mm_T1.nii.gz')
 
         t1_2_mni.inputs.template = template_str

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -29,6 +29,7 @@ from ...interfaces.freesurfer import (
     # See https://github.com/poldracklab/fmriprep/issues/768
     PatchedConcatenateLTA as ConcatenateLTA
 )
+from ..anatomical import TEMPLATE_MAP
 
 from .util import init_bold_reference_wf
 
@@ -259,7 +260,7 @@ generating a *preprocessed BOLD run in {tpl} space*.
 
     gen_ref = pe.Node(GenerateSamplingReference(), name='gen_ref',
                       mem_gb=0.3)  # 256x256x256 * 64 / 8 ~ 150MB)
-    template_str = nid.TEMPLATE_MAP[template]
+    template_str = TEMPLATE_MAP[template]
     gen_ref.inputs.fixed_image = op.join(nid.get_dataset(template_str), '1mm_T1.nii.gz')
 
     mask_mni_tfm = pe.Node(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-niworkflows>=0.4.2
+niworkflows>=0.4.3
 versioneer


### PR DESCRIPTION
niworkflows 0.4.3 broke downloading, so all builds will fail until this is resolved. Since #1270 may not go in as quickly as needed, I've rebased the template fixes to their own branch.