### PR TITLE
[RF] Split BOLD-T1w registration into calculation/application workflows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ RUN conda install -y mkl=2018.0.3 mkl-service;  sync &&\
                      pandas=0.23.0 \
                      libxml2=2.9.4 \
                      libxslt=1.1.29 \
+                     graphviz=2.40.1 \
                      traits=4.6.0; sync &&  \
     chmod -R a+rX /usr/local/miniconda; sync && \
     chmod +x /usr/local/miniconda/bin/*; sync && \
@@ -127,8 +128,7 @@ RUN python -c "from matplotlib import font_manager" && \
 # Installing Ubuntu packages and cleaning up
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-                    git=1:2.7.4-0ubuntu1 \
-                    graphviz=2.38.0-12ubuntu2 && \
+                    git=1:2.7.4-0ubuntu1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install latest pandoc
@@ -183,4 +183,3 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-url="https://github.com/poldracklab/fmriprep" \
       org.label-schema.version=$VERSION \
       org.label-schema.schema-version="1.0"
-

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -128,7 +128,7 @@ to be run through ``fmriprep``.
 
 Longitudinal processing
 ~~~~~~~~~~~~~~~~~~~~~~~
-In the case of multiple T1w images (across sessions and/or runs), T1w images are 
+In the case of multiple T1w images (across sessions and/or runs), T1w images are
 merged into a single template image using FreeSurfer's `mri_robust_template`_.
 This template may be *unbiased*, or equidistant from all source images, or
 aligned to the first image (determined lexicographically by session label).
@@ -431,23 +431,23 @@ Interpolation uses a Lanczos kernel.
 
 EPI to T1w registration
 ~~~~~~~~~~~~~~~~~~~~~~~
-:mod:`fmriprep.workflows.bold.registration.init_bold_reg_wf`
+:mod:`fmriprep.workflows.bold.registration.init_bold_calc_reg_wf`
 
 .. workflow::
     :graph2use: orig
     :simple_form: yes
 
-    from fmriprep.workflows.bold import init_bold_reg_wf
-    wf = init_bold_reg_wf(
+    from fmriprep.workflows.bold import init_bold_calc_reg_wf
+    wf = init_bold_calc_reg_wf(
         freesurfer=True,
         mem_gb=1,
         omp_nthreads=1,
         use_bbr=True,
         bold2t1w_dof=9)
 
-The reference :abbr:`EPI (echo-planar imaging)` image of each run is aligned
-by the ``bbregister`` routine to the reconstructed subject using the gray/white
-matter boundary (FreeSurfer's ``?h.white`` surfaces).
+The alignment between the reference :abbr:`EPI (echo-planar imaging)` image
+of each run and the reconstructed subject using the gray/white matter boundary
+(FreeSurfer's ``?h.white`` surfaces) is calculated by the ``bbregister`` routine.
 
 .. figure:: _static/EPIT1Normalization.svg
     :scale: 100%

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -431,14 +431,14 @@ Interpolation uses a Lanczos kernel.
 
 EPI to T1w registration
 ~~~~~~~~~~~~~~~~~~~~~~~
-:mod:`fmriprep.workflows.bold.registration.init_bold_calc_reg_wf`
+:mod:`fmriprep.workflows.bold.registration.init_bold_reg_wf`
 
 .. workflow::
     :graph2use: orig
     :simple_form: yes
 
-    from fmriprep.workflows.bold import init_bold_calc_reg_wf
-    wf = init_bold_calc_reg_wf(
+    from fmriprep.workflows.bold import init_bold_reg_wf
+    wf = init_bold_reg_wf(
         freesurfer=True,
         mem_gb=1,
         omp_nthreads=1,
@@ -456,7 +456,9 @@ of each run and the reconstructed subject using the gray/white matter boundary
 
 If FreeSurfer processing is disabled, FSL ``flirt`` is run with the
 :abbr:`BBR (boundary-based registration)` cost function, using the
-``fast`` segmentation to establish the gray/white matter boundary. After :abbr:`BBR (boundary-based registration)` is run, the resulting affine transform will be compared to the initial transform found by FLIRT. Excessive deviation will result in rejecting the BBR refinement and accepting the original, affine registration.
+``fast`` segmentation to establish the gray/white matter boundary.
+After :abbr:`BBR (boundary-based registration)` is run, the resulting affine transform will be compared to the initial transform found by FLIRT.
+Excessive deviation will result in rejecting the BBR refinement and accepting the original, affine registration.
 
 EPI to MNI transformation
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/fmriprep/workflows/bold/__init__.py
+++ b/fmriprep/workflows/bold/__init__.py
@@ -24,7 +24,10 @@ from .util import init_bold_reference_wf
 from .hmc import init_bold_hmc_wf
 from .stc import init_bold_stc_wf
 from .t2s import init_bold_t2s_wf
-from .registration import init_bold_reg_wf
+from .registration import (
+    init_bold_apply_reg_wf,
+    init_bold_calc_reg_wf,
+)
 from .resampling import (
     init_bold_mni_trans_wf,
     init_bold_surf_wf,

--- a/fmriprep/workflows/bold/__init__.py
+++ b/fmriprep/workflows/bold/__init__.py
@@ -25,8 +25,8 @@ from .hmc import init_bold_hmc_wf
 from .stc import init_bold_stc_wf
 from .t2s import init_bold_t2s_wf
 from .registration import (
-    init_bold_apply_reg_wf,
-    init_bold_calc_reg_wf,
+    init_bold_t1_trans_wf,
+    init_bold_reg_wf,
 )
 from .resampling import (
     init_bold_mni_trans_wf,

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -465,18 +465,18 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ('subject_id', 'inputnode.subject_id'),
             ('t1_2_fsnative_reverse_transform', 'inputnode.t1_2_fsnative_reverse_transform')]),
         (inputnode, bold_t1_trans_wf, [
+            ('bold_file', 'inputnode.name_source'),
             ('t1_brain', 'inputnode.t1_brain'),
             ('t1_mask', 'inputnode.t1_mask'),
             ('t1_aseg', 'inputnode.t1_aseg'),
             ('t1_aparc', 'inputnode.t1_aparc')]),
-        (inputnode, bold_t1_trans_wf, [('bold_file', 'inputnode.name_source')]),
         (bold_split, bold_t1_trans_wf, [('out_files', 'inputnode.bold_split')]),
         (bold_hmc_wf, bold_t1_trans_wf, [('outputnode.xforms', 'inputnode.hmc_xforms')]),
-        (bold_t1_trans_wf, outputnode, [('outputnode.bold_aseg_t1', 'bold_aseg_t1'),
-                                        ('outputnode.bold_aparc_t1', 'bold_aparc_t1')]),
         (bold_reg_wf, bold_t1_trans_wf, [
             ('outputnode.itk_bold_to_t1', 'inputnode.itk_bold_to_t1')]),
-        (bold_t1_trans_wf, outputnode, [('outputnode.bold_t1', 'bold_t1')]),
+        (bold_t1_trans_wf, outputnode, [('outputnode.bold_t1', 'bold_t1'),
+                                        ('outputnode.bold_aseg_t1', 'bold_aseg_t1'),
+                                        ('outputnode.bold_aparc_t1', 'bold_aparc_t1')]),
         (bold_reg_wf, summary, [('outputnode.fallback', 'fallback')]),
         # SDC (or pass-through workflow)
         (inputnode, bold_sdc_wf, [

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -468,7 +468,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ('subjects_dir', 'inputnode.subjects_dir'),
             ('subject_id', 'inputnode.subject_id'),
             ('t1_2_fsnative_reverse_transform', 'inputnode.t1_2_fsnative_reverse_transform')]),
-        (bold_split, bold_calc_reg_wf, [('out_files', 'inputnode.bold_split')]),
+        (bold_split, bold_apply_reg_wf, [('out_files', 'inputnode.bold_split')]),
         (bold_hmc_wf, bold_apply_reg_wf, [('outputnode.xforms', 'inputnode.hmc_xforms')]),
         (bold_calc_reg_wf, outputnode, [('outputnode.bold_aseg_t1', 'bold_aseg_t1'),
                                         ('outputnode.bold_aparc_t1', 'bold_aparc_t1')]),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -457,7 +457,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ('outputnode.bold_file', 'inputnode.bold_file')]),
         # EPI-T1 registration workflow
         (inputnode, bold_calc_reg_wf, [
-            ('bold_file', 'inputnode.name_source'),
             ('t1_preproc', 'inputnode.t1_preproc'),
             ('t1_brain', 'inputnode.t1_brain'),
             ('t1_mask', 'inputnode.t1_mask'),
@@ -468,6 +467,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ('subjects_dir', 'inputnode.subjects_dir'),
             ('subject_id', 'inputnode.subject_id'),
             ('t1_2_fsnative_reverse_transform', 'inputnode.t1_2_fsnative_reverse_transform')]),
+        (inputnode, bold_apply_reg_wf, [('bold_file', 'inputnode.name_source')]),
         (bold_split, bold_apply_reg_wf, [('out_files', 'inputnode.bold_split')]),
         (bold_hmc_wf, bold_apply_reg_wf, [('outputnode.xforms', 'inputnode.hmc_xforms')]),
         (bold_calc_reg_wf, outputnode, [('outputnode.bold_aseg_t1', 'bold_aseg_t1'),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -34,7 +34,7 @@ from .confounds import init_bold_confs_wf, init_carpetplot_wf
 from .hmc import init_bold_hmc_wf
 from .stc import init_bold_stc_wf
 from .t2s import init_bold_t2s_wf
-from .registration import init_bold_reg_wf
+from .registration import init_bold_apply_reg_wf, init_bold_calc_reg_wf
 from .resampling import (
     init_bold_surf_wf,
     init_bold_mni_trans_wf,
@@ -211,7 +211,8 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
         * :py:func:`~fmriprep.workflows.bold.stc.init_bold_stc_wf`
         * :py:func:`~fmriprep.workflows.bold.hmc.init_bold_hmc_wf`
         * :py:func:`~fmriprep.workflows.bold.t2s.init_bold_t2s_wf`
-        * :py:func:`~fmriprep.workflows.bold.registration.init_bold_reg_wf`
+        * :py:func:`~fmriprep.workflows.bold.registration.init_bold_apply_reg_wf`
+        * :py:func:`~fmriprep.workflows.bold.registration.init_bold_calc_reg_wf`
         * :py:func:`~fmriprep.workflows.bold.confounds.init_bold_confounds_wf`
         * :py:func:`~fmriprep.workflows.bold.confounds.init_ica_aroma_wf`
         * :py:func:`~fmriprep.workflows.bold.resampling.init_bold_mni_trans_wf`
@@ -380,14 +381,20 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                                    omp_nthreads=omp_nthreads)
 
     # mean BOLD registration to T1w
-    bold_reg_wf = init_bold_reg_wf(name='bold_reg_wf',
-                                   freesurfer=freesurfer,
-                                   use_bbr=use_bbr,
-                                   bold2t1w_dof=bold2t1w_dof,
-                                   mem_gb=mem_gb['resampled'],
-                                   omp_nthreads=omp_nthreads,
-                                   use_compression=False,
-                                   use_fieldwarp=(fmaps is not None or use_syn))
+    bold_calc_reg_wf = init_bold_calc_reg_wf(name='bold_calc_reg_wf',
+                                             freesurfer=freesurfer,
+                                             use_bbr=use_bbr,
+                                             bold2t1w_dof=bold2t1w_dof,
+                                             mem_gb=mem_gb['resampled'],
+                                             omp_nthreads=omp_nthreads,
+                                             use_compression=False)
+
+    # mean BOLD registration to T1w
+    bold_apply_reg_wf = init_bold_apply_reg_wf(name='bold_apply_reg_wf',
+                                               mem_gb=mem_gb['resampled'],
+                                               omp_nthreads=omp_nthreads,
+                                               use_compression=False,
+                                               use_fieldwarp=(fmaps is not None or use_syn))
 
     # get confounds
     bold_confounds_wf = init_bold_confs_wf(
@@ -449,7 +456,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ('outputnode.raw_ref_image', 'inputnode.raw_ref_image'),
             ('outputnode.bold_file', 'inputnode.bold_file')]),
         # EPI-T1 registration workflow
-        (inputnode, bold_reg_wf, [
+        (inputnode, bold_calc_reg_wf, [
             ('bold_file', 'inputnode.name_source'),
             ('t1_preproc', 'inputnode.t1_preproc'),
             ('t1_brain', 'inputnode.t1_brain'),
@@ -461,12 +468,15 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ('subjects_dir', 'inputnode.subjects_dir'),
             ('subject_id', 'inputnode.subject_id'),
             ('t1_2_fsnative_reverse_transform', 'inputnode.t1_2_fsnative_reverse_transform')]),
-        (bold_split, bold_reg_wf, [('out_files', 'inputnode.bold_split')]),
-        (bold_hmc_wf, bold_reg_wf, [('outputnode.xforms', 'inputnode.hmc_xforms')]),
-        (bold_reg_wf, outputnode, [('outputnode.bold_t1', 'bold_t1'),
-                                   ('outputnode.bold_aseg_t1', 'bold_aseg_t1'),
-                                   ('outputnode.bold_aparc_t1', 'bold_aparc_t1')]),
-        (bold_reg_wf, summary, [('outputnode.fallback', 'fallback')]),
+        (bold_split, bold_calc_reg_wf, [('out_files', 'inputnode.bold_split')]),
+        (bold_hmc_wf, bold_apply_reg_wf, [('outputnode.xforms', 'inputnode.hmc_xforms')]),
+        (bold_calc_reg_wf, outputnode, [('outputnode.bold_aseg_t1', 'bold_aseg_t1'),
+                                        ('outputnode.bold_aparc_t1', 'bold_aparc_t1')]),
+        (bold_calc_reg_wf, bold_apply_reg_wf, [
+            ('outputnode.reference_image', 'inputnode.reference_grid'),
+            ('outputnode.itk_bold_to_t1', 'inputnode.itk_bold_to_t1')]),
+        (bold_apply_reg_wf, outputnode, [('outputnode.bold_t1', 'bold_t1')]),
+        (bold_calc_reg_wf, summary, [('outputnode.fallback', 'fallback')]),
         # SDC (or pass-through workflow)
         (inputnode, bold_sdc_wf, [
             ('t1_brain', 'inputnode.t1_brain'),
@@ -475,9 +485,10 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ('outputnode.ref_image', 'inputnode.bold_ref'),
             ('outputnode.ref_image_brain', 'inputnode.bold_ref_brain'),
             ('outputnode.bold_mask', 'inputnode.bold_mask')]),
-        (bold_sdc_wf, bold_reg_wf, [
+        (bold_sdc_wf, bold_calc_reg_wf, [
             ('outputnode.bold_ref_brain', 'inputnode.ref_bold_brain'),
-            ('outputnode.bold_mask', 'inputnode.ref_bold_mask'),
+            ('outputnode.bold_mask', 'inputnode.ref_bold_mask')]),
+        (bold_sdc_wf, bold_apply_reg_wf, [
             ('outputnode.out_warp', 'inputnode.fieldwarp')]),
         (bold_sdc_wf, bold_bold_trans_wf, [
             ('outputnode.out_warp', 'inputnode.fieldwarp'),
@@ -488,7 +499,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                                         ('t1_mask', 'inputnode.t1_mask')]),
         (bold_hmc_wf, bold_confounds_wf, [
             ('outputnode.movpar_file', 'inputnode.movpar_file')]),
-        (bold_reg_wf, bold_confounds_wf, [
+        (bold_calc_reg_wf, bold_confounds_wf, [
             ('outputnode.itk_t1_to_bold', 'inputnode.t1_bold_xform')]),
         (bold_confounds_wf, outputnode, [
             ('outputnode.confounds_file', 'confounds'),
@@ -519,7 +530,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 ('t1_seg', 'inputnode.in_seg')]),
             (bold_reference_wf, fmap_unwarp_report_wf, [
                 ('outputnode.ref_image', 'inputnode.in_pre')]),
-            (bold_reg_wf, fmap_unwarp_report_wf, [
+            (bold_calc_reg_wf, fmap_unwarp_report_wf, [
                 ('outputnode.itk_t1_to_bold', 'inputnode.in_xfm')]),
             (bold_sdc_wf, fmap_unwarp_report_wf, [
                 ('outputnode.bold_ref', 'inputnode.in_post')]),
@@ -533,7 +544,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                     ('t1_seg', 'inputnode.in_seg')]),
                 (bold_reference_wf, syn_unwarp_report_wf, [
                     ('outputnode.ref_image', 'inputnode.in_pre')]),
-                (bold_reg_wf, syn_unwarp_report_wf, [
+                (bold_calc_reg_wf, syn_unwarp_report_wf, [
                     ('outputnode.itk_t1_to_bold', 'inputnode.in_xfm')]),
                 (bold_sdc_wf, syn_unwarp_report_wf, [
                     ('outputnode.syn_bold_ref', 'inputnode.in_post')]),
@@ -571,14 +582,14 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
 
             # Replace EPI-to-T1w registration inputs
             workflow.disconnect([
-                (bold_sdc_wf, bold_reg_wf, [
+                (bold_sdc_wf, bold_calc_reg_wf, [
                     ('outputnode.bold_ref_brain', 'inputnode.ref_bold_brain'),
                     ('outputnode.bold_mask', 'inputnode.ref_bold_mask')]),
             ])
             workflow.connect([
                 (bold_hmc_wf, bold_t2s_wf, [
                     ('outputnode.xforms', 'inputnode.hmc_xforms')]),
-                (bold_t2s_wf, bold_reg_wf, [
+                (bold_t2s_wf, bold_calc_reg_wf, [
                     ('outputnode.t2s_map', 'inputnode.ref_bold_brain'),
                     ('outputnode.oc_mask', 'inputnode.ref_bold_mask')]),
             ])
@@ -596,7 +607,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         workflow.connect([
             (bold_bold_trans_wf, boldmask_to_t1w, [
                 ('outputnode.bold_mask', 'input_image')]),
-            (bold_reg_wf, boldmask_to_t1w, [
+            (bold_calc_reg_wf, boldmask_to_t1w, [
                 ('outputnode.bold_mask_t1', 'reference_image'),
                 ('outputnode.itk_bold_to_t1', 'transforms')]),
             (boldmask_to_t1w, outputnode, [
@@ -628,7 +639,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 ('out_files', 'inputnode.bold_split')]),
             (bold_hmc_wf, bold_mni_trans_wf, [
                 ('outputnode.xforms', 'inputnode.hmc_xforms')]),
-            (bold_reg_wf, bold_mni_trans_wf, [
+            (bold_calc_reg_wf, bold_mni_trans_wf, [
                 ('outputnode.itk_bold_to_t1', 'inputnode.itk_bold_to_t1')]),
             (bold_bold_trans_wf, bold_mni_trans_wf, [
                 ('outputnode.bold_mask', 'inputnode.bold_mask')]),
@@ -641,7 +652,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 ('outputnode.bold_mask', 'inputnode.bold_mask')]),
             (inputnode, carpetplot_wf, [
                 ('t1_2_mni_reverse_transform', 'inputnode.t1_2_mni_reverse_transform')]),
-            (bold_reg_wf, carpetplot_wf, [
+            (bold_calc_reg_wf, carpetplot_wf, [
                 ('outputnode.itk_t1_to_bold', 'inputnode.t1_bold_xform')]),
             (bold_confounds_wf, carpetplot_wf, [
                 ('outputnode.confounds_file', 'inputnode.confounds_file')]),
@@ -679,7 +690,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 (bold_hmc_wf, ica_aroma_wf, [
                     ('outputnode.movpar_file', 'inputnode.movpar_file'),
                     ('outputnode.xforms', 'inputnode.hmc_xforms')]),
-                (bold_reg_wf, ica_aroma_wf, [
+                (bold_calc_reg_wf, ica_aroma_wf, [
                     ('outputnode.itk_bold_to_t1', 'inputnode.itk_bold_to_t1')]),
                 (bold_bold_trans_wf, ica_aroma_wf, [
                     ('outputnode.bold_mask', 'inputnode.bold_mask')]),
@@ -709,7 +720,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 ('subjects_dir', 'inputnode.subjects_dir'),
                 ('subject_id', 'inputnode.subject_id'),
                 ('t1_2_fsnative_forward_transform', 'inputnode.t1_2_fsnative_forward_transform')]),
-            (bold_reg_wf, bold_surf_wf, [('outputnode.bold_t1', 'inputnode.source_file')]),
+            (bold_apply_reg_wf, bold_surf_wf, [('outputnode.bold_t1', 'inputnode.source_file')]),
             (bold_surf_wf, outputnode, [('outputnode.surfaces', 'surfaces')]),
         ])
 

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -431,7 +431,7 @@ def init_ica_aroma_wf(template, metadata, mem_gb, omp_nthreads,
         template : str
             Spatial normalization template used as target when that
             registration step was previously calculated with
-            :py:func:`~fmriprep.workflows.bold.registration.init_bold_reg_wf`.
+            :py:func:`~fmriprep.workflows.bold.registration.init_bold_calc_reg_wf`.
             The template must be one of the MNI templates (fMRIPrep uses
             ``MNI152NLin2009cAsym`` by default).
         metadata : dict

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -431,7 +431,7 @@ def init_ica_aroma_wf(template, metadata, mem_gb, omp_nthreads,
         template : str
             Spatial normalization template used as target when that
             registration step was previously calculated with
-            :py:func:`~fmriprep.workflows.bold.registration.init_bold_calc_reg_wf`.
+            :py:func:`~fmriprep.workflows.bold.registration.init_bold_reg_wf`.
             The template must be one of the MNI templates (fMRIPrep uses
             ``MNI152NLin2009cAsym`` by default).
         metadata : dict

--- a/fmriprep/workflows/bold/registration.py
+++ b/fmriprep/workflows/bold/registration.py
@@ -6,7 +6,8 @@
 Registration workflows
 ++++++++++++++++++++++
 
-.. autofunction:: init_bold_reg_wf
+.. autofunction:: init_bold_calc_reg_wf
+.. autofunction:: init_bold_apply_reg_wf
 .. autofunction:: init_bbreg_wf
 .. autofunction:: init_fsl_bbr_wf
 
@@ -37,8 +38,8 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
                           use_compression=True, write_report=True,
                           name='bold_calc_reg_wf', ):
     """
-    This workflow registers the reference BOLD image to T1-space, using a
-    boundary-based registration (BBR) cost function.
+    This workflow calculates the registration of the reference BOLD image to T1-space,
+     using a boundary-based registration (BBR) cost function.
 
     If FreeSurfer-based preprocessing is enabled, the ``bbregister`` utility
     is used to align the BOLD images to the reconstructed subject, and the
@@ -50,12 +51,12 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
         :graph2use: orig
         :simple_form: yes
 
-        from fmriprep.workflows.bold.registration import init_bold_reg_wf
-        wf = init_bold_reg_wf(freesurfer=True,
-                              mem_gb=3,
-                              omp_nthreads=1,
-                              use_bbr=True,
-                              bold2t1w_dof=9)
+        from fmriprep.workflows.bold.registration import init_bold_calc_reg_wf
+        wf = init_bold_calc_reg_wf(freesurfer=True,
+                                   mem_gb=3,
+                                   omp_nthreads=1,
+                                   use_bbr=True,
+                                   bold2t1w_dof=9)
 
     **Parameters**
 
@@ -102,8 +103,6 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
         t1_aparc
             FreeSurfer's ``aparc+aseg.mgz`` atlas projected into the T1w reference
             (only if ``recon-all`` was run).
-        bold_split
-            Individual 3D BOLD volumes, not motion corrected
         subjects_dir
             FreeSurfer SUBJECTS_DIR
         subject_id
@@ -143,7 +142,7 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
         niu.IdentityInterface(
             fields=['name_source', 'ref_bold_brain', 'ref_bold_mask',
                     't1_preproc', 't1_brain', 't1_mask', 't1_seg',
-                    't1_aseg', 't1_aparc', 'bold_split', 'subjects_dir',
+                    't1_aseg', 't1_aparc', 'subjects_dir',
                     'subject_id', 't1_2_fsnative_reverse_transform']),
         name='inputnode'
     )
@@ -248,9 +247,9 @@ def init_bold_apply_reg_wf(mem_gb, omp_nthreads, use_compression=True,
         :graph2use: orig
         :simple_form: yes
 
-        from fmriprep.workflows.bold.registration import init_bold_reg_wf
-        wf = init_bold_reg_wf(mem_gb=3,
-                              omp_nthreads=19)
+        from fmriprep.workflows.bold.registration import init_bold_apply_reg_wf
+        wf = init_bold_apply_reg_wf(mem_gb=3,
+                                    omp_nthreads=19)
 
     **Parameters**
 
@@ -266,6 +265,8 @@ def init_bold_apply_reg_wf(mem_gb, omp_nthreads, use_compression=True,
             Name of workflow (default: ``bold_apply_reg_wf``)
 
     **Inputs**
+        bold_split
+            Individual 3D BOLD volumes, not motion corrected
         reference_grid
             Reference grid for resampling to a different space (e.g. MNI),
             keeping the original resolution
@@ -284,7 +285,8 @@ def init_bold_apply_reg_wf(mem_gb, omp_nthreads, use_compression=True,
     workflow = Workflow(name=name)
     inputnode = pe.Node(
         niu.IdentityInterface(fields=[
-            'reference_grid', 'itk_bold_to_t1', 'hmc_xforms', 'fieldwarp']),
+            'bold_split', 'reference_grid', 'itk_bold_to_t1',
+            'hmc_xforms', 'fieldwarp']),
         name='inputnode'
     )
 

--- a/fmriprep/workflows/bold/registration.py
+++ b/fmriprep/workflows/bold/registration.py
@@ -37,7 +37,7 @@ DEFAULT_MEMORY_MIN_GB = 0.01
 def init_bold_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthreads,
                      use_compression=True, write_report=True, name='bold_reg_wf'):
     """
-    The registration between a reference BOLD image and T1-space is calculated
+    Calculates the registration between a reference BOLD image and T1-space
     using a boundary-based registration (BBR) cost function.
 
     If FreeSurfer-based preprocessing is enabled, the ``bbregister`` utility
@@ -170,12 +170,6 @@ def init_bold_t1_trans_wf(freesurfer, mem_gb, omp_nthreads, use_fieldwarp=False,
     """
     This workflow registers the reference BOLD image to T1-space, using a
     boundary-based registration (BBR) cost function.
-
-    If FreeSurfer-based preprocessing is enabled, the ``bbregister`` utility
-    is used to align the BOLD images to the reconstructed subject, and the
-    resulting transform is adjusted to target the T1 space.
-    If FreeSurfer-based preprocessing is disabled, FSL FLIRT is used with the
-    BBR cost function to directly target the T1 space.
 
     .. workflow::
         :graph2use: orig

--- a/fmriprep/workflows/bold/registration.py
+++ b/fmriprep/workflows/bold/registration.py
@@ -6,8 +6,8 @@
 Registration workflows
 ++++++++++++++++++++++
 
-.. autofunction:: init_bold_calc_reg_wf
-.. autofunction:: init_bold_apply_reg_wf
+.. autofunction:: init_bold_reg_wf
+.. autofunction:: init_bold_t1_trans_wf
 .. autofunction:: init_bbreg_wf
 .. autofunction:: init_fsl_bbr_wf
 
@@ -34,12 +34,11 @@ from ...interfaces.freesurfer import PatchedConcatenateLTA as ConcatenateLTA
 DEFAULT_MEMORY_MIN_GB = 0.01
 
 
-def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthreads,
-                          use_compression=True, write_report=True,
-                          name='bold_calc_reg_wf'):
+def init_bold_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthreads,
+                     use_compression=True, write_report=True, name='bold_reg_wf'):
     """
-    This workflow calculates the registration of the reference BOLD image to T1-space,
-     using a boundary-based registration (BBR) cost function.
+    The registration between a reference BOLD image and T1-space is calculated
+    using a boundary-based registration (BBR) cost function.
 
     If FreeSurfer-based preprocessing is enabled, the ``bbregister`` utility
     is used to align the BOLD images to the reconstructed subject, and the
@@ -51,12 +50,12 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
         :graph2use: orig
         :simple_form: yes
 
-        from fmriprep.workflows.bold.registration import init_bold_calc_reg_wf
-        wf = init_bold_calc_reg_wf(freesurfer=True,
-                                   mem_gb=3,
-                                   omp_nthreads=1,
-                                   use_bbr=True,
-                                   bold2t1w_dof=9)
+        from fmriprep.workflows.bold.registration import init_bold_reg_wf
+        wf = init_bold_reg_wf(freesurfer=True,
+                              mem_gb=3,
+                              omp_nthreads=1,
+                              use_bbr=True,
+                              bold2t1w_dof=9)
 
     **Parameters**
 
@@ -71,35 +70,25 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
             Size of BOLD file in GB
         omp_nthreads : int
             Maximum number of threads an individual process may use
+        name : str
+            Name of workflow (default: ``bold_reg_wf``)
         use_compression : bool
             Save registered BOLD series as ``.nii.gz``
+        use_fieldwarp : bool
+            Include SDC warp in single-shot transform from BOLD to T1
         write_report : bool
             Whether a reportlet should be stored
-        name : str
-            Name of workflow (default: ``bold_calc_reg_wf``)
 
     **Inputs**
 
         ref_bold_brain
             Reference image to which BOLD series is aligned
             If ``fieldwarp == True``, ``ref_bold_brain`` should be unwarped
-        ref_bold_mask
-            Skull-stripping mask of reference image
-        t1_preproc
-            Bias-corrected structural template image
         t1_brain
             Skull-stripped ``t1_preproc``
-        t1_mask
-            Mask of the skull-stripped template image
         t1_seg
             Segmentation of preprocessed structural image, including
             gray-matter (GM), white-matter (WM) and cerebrospinal fluid (CSF)
-        t1_aseg
-            FreeSurfer's ``aseg.mgz`` atlas projected into the T1w reference
-            (only if ``recon-all`` was run).
-        t1_aparc
-            FreeSurfer's ``aparc+aseg.mgz`` atlas projected into the T1w reference
-            (only if ``recon-all`` was run).
         subjects_dir
             FreeSurfer SUBJECTS_DIR
         subject_id
@@ -113,19 +102,8 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
             Affine transform from ``ref_bold_brain`` to T1 space (ITK format)
         itk_t1_to_bold
             Affine transform from T1 space to BOLD space (ITK format)
-        bold_mask_t1
-            BOLD mask in T1 space
-        bold_aseg_t1
-            FreeSurfer's ``aseg.mgz`` atlas, in T1w-space at the BOLD resolution
-            (only if ``recon-all`` was run).
-        bold_aparc_t1
-            FreeSurfer's ``aparc+aseg.mgz`` atlas, in T1w-space at the BOLD resolution
-            (only if ``recon-all`` was run).
         fallback
             Boolean indicating whether BBR was rejected (mri_coreg registration returned)
-        reference_image
-            Reference grid for resampling to a different space (e.g. MNI),
-            keeping the original resolution
 
 
     **Subworkflows**
@@ -137,18 +115,14 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
     workflow = Workflow(name=name)
     inputnode = pe.Node(
         niu.IdentityInterface(
-            fields=['ref_bold_brain', 'ref_bold_mask',
-                    't1_preproc', 't1_brain', 't1_mask', 't1_seg',
-                    't1_aseg', 't1_aparc', 'subjects_dir',
-                    'subject_id', 't1_2_fsnative_reverse_transform']),
+            fields=['ref_bold_brain', 't1_brain', 't1_seg',
+                    'subjects_dir', 'subject_id', 't1_2_fsnative_reverse_transform']),
         name='inputnode'
     )
 
     outputnode = pe.Node(
         niu.IdentityInterface(fields=[
-            'itk_bold_to_t1', 'itk_t1_to_bold', 'fallback',
-            'bold_mask_t1', 'bold_aseg_t1', 'bold_aparc_t1',
-            'reference_image']),
+            'itk_bold_to_t1', 'itk_t1_to_bold', 'fallback']),
         name='outputnode'
     )
 
@@ -171,43 +145,6 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
                               ('outputnode.fallback', 'fallback')]),
     ])
 
-    gen_ref = pe.Node(GenerateSamplingReference(), name='gen_ref',
-                      mem_gb=0.3)  # 256x256x256 * 64 / 8 ~ 150MB
-
-    mask_t1w_tfm = pe.Node(
-        ApplyTransforms(interpolation='MultiLabel', float=True),
-        name='mask_t1w_tfm', mem_gb=0.1
-    )
-
-    workflow.connect([
-        (inputnode, gen_ref, [('ref_bold_brain', 'moving_image'),
-                              ('t1_brain', 'fixed_image'),
-                              ('t1_mask', 'fov_mask')]),
-        (inputnode, mask_t1w_tfm, [('ref_bold_mask', 'input_image')]),
-        (gen_ref, mask_t1w_tfm, [('out_file', 'reference_image')]),
-        (bbr_wf, mask_t1w_tfm, [('outputnode.itk_bold_to_t1', 'transforms')]),
-        (mask_t1w_tfm, outputnode, [('output_image', 'bold_mask_t1')]),
-    ])
-
-    if freesurfer:
-        # Resample aseg and aparc in T1w space (no transforms needed)
-        aseg_t1w_tfm = pe.Node(
-            ApplyTransforms(interpolation='MultiLabel', transforms='identity', float=True),
-            name='aseg_t1w_tfm', mem_gb=0.1)
-        aparc_t1w_tfm = pe.Node(
-            ApplyTransforms(interpolation='MultiLabel', transforms='identity', float=True),
-            name='aparc_t1w_tfm', mem_gb=0.1)
-
-        workflow.connect([
-            (inputnode, aseg_t1w_tfm, [('t1_aseg', 'input_image')]),
-            (inputnode, aparc_t1w_tfm, [('t1_aparc', 'input_image')]),
-            (gen_ref, aseg_t1w_tfm, [('out_file', 'reference_image')]),
-            (gen_ref, aparc_t1w_tfm, [('out_file', 'reference_image')]),
-            (gen_ref, outputnode, [('out_file', 'reference_image')]),
-            (aseg_t1w_tfm, outputnode, [('output_image', 'bold_aseg_t1')]),
-            (aparc_t1w_tfm, outputnode, [('output_image', 'bold_aparc_t1')]),
-        ])
-
     if write_report:
         ds_report_reg = pe.Node(
             DerivativesDataSink(),
@@ -228,8 +165,8 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
     return workflow
 
 
-def init_bold_apply_reg_wf(mem_gb, omp_nthreads, use_compression=True,
-                           use_fieldwarp=False, name='bold_apply_reg_wf'):
+def init_bold_t1_trans_wf(freesurfer, mem_gb, omp_nthreads, use_fieldwarp=False,
+                          use_compression=True, name='bold_t1_trans_wf'):
     """
     This workflow registers the reference BOLD image to T1-space, using a
     boundary-based registration (BBR) cost function.
@@ -244,61 +181,140 @@ def init_bold_apply_reg_wf(mem_gb, omp_nthreads, use_compression=True,
         :graph2use: orig
         :simple_form: yes
 
-        from fmriprep.workflows.bold.registration import init_bold_apply_reg_wf
-        wf = init_bold_apply_reg_wf(mem_gb=3,
-                                    omp_nthreads=19)
+        from fmriprep.workflows.bold.registration import init_bold_t1_trans_wf
+        wf = init_bold_t1_trans_wf(freesurfer=True,
+                                   mem_gb=3,
+                                   omp_nthreads=1)
 
     **Parameters**
 
+        freesurfer : bool
+            Enable FreeSurfer functional registration (bbregister)
+        use_fieldwarp : bool
+            Include SDC warp in single-shot transform from BOLD to T1
         mem_gb : float
             Size of BOLD file in GB
         omp_nthreads : int
             Maximum number of threads an individual process may use
         use_compression : bool
             Save registered BOLD series as ``.nii.gz``
-        use_fieldwarp : bool
-            Include SDC warp in single-shot transform from BOLD to T1
         name : str
-            Name of workflow (default: ``bold_apply_reg_wf``)
+            Name of workflow (default: ``bold_reg_wf``)
 
     **Inputs**
+
         name_source
             BOLD series NIfTI file
             Used to recover original information lost during processing
+        ref_bold_brain
+            Reference image to which BOLD series is aligned
+            If ``fieldwarp == True``, ``ref_bold_brain`` should be unwarped
+        ref_bold_mask
+            Skull-stripping mask of reference image
+        t1_brain
+            Skull-stripped bias-corrected structural template image
+        t1_mask
+            Mask of the skull-stripped template image
+        t1_aseg
+            FreeSurfer's ``aseg.mgz`` atlas projected into the T1w reference
+            (only if ``recon-all`` was run).
+        t1_aparc
+            FreeSurfer's ``aparc+aseg.mgz`` atlas projected into the T1w reference
+            (only if ``recon-all`` was run).
         bold_split
             Individual 3D BOLD volumes, not motion corrected
-        reference_grid
-            Reference grid for resampling to a different space (e.g. MNI),
-            keeping the original resolution
-        itk_bold_to_t1
-            Affine transform from ``ref_bold_brain`` to T1 space (ITK format)
         hmc_xforms
             List of affine transforms aligning each volume to ``ref_image`` in ITK format
+        itk_bold_to_t1
+            Affine transform from ``ref_bold_brain`` to T1 space (ITK format)
         fieldwarp
             a :abbr:`DFM (displacements field map)` in ITK format
 
     **Outputs**
+
         bold_t1
             Motion-corrected BOLD series in T1 space
+        bold_mask_t1
+            BOLD mask in T1 space
+        bold_aseg_t1
+            FreeSurfer's ``aseg.mgz`` atlas, in T1w-space at the BOLD resolution
+            (only if ``recon-all`` was run).
+        bold_aparc_t1
+            FreeSurfer's ``aparc+aseg.mgz`` atlas, in T1w-space at the BOLD resolution
+            (only if ``recon-all`` was run).
+
+
+    **Subworkflows**
+
+        * :py:func:`~fmriprep.workflows.util.init_bbreg_wf`
+        * :py:func:`~fmriprep.workflows.util.init_fsl_bbr_wf`
 
     """
     workflow = Workflow(name=name)
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=[
-            'name_source', 'bold_split', 'reference_grid',
-            'itk_bold_to_t1', 'hmc_xforms', 'fieldwarp']),
+        niu.IdentityInterface(
+            fields=['name_source', 'ref_bold_brain', 'ref_bold_mask',
+                    't1_brain', 't1_mask', 't1_aseg', 't1_aparc',
+                    'bold_split', 'fieldwarp', 'hmc_xforms',
+                    'itk_bold_to_t1']),
         name='inputnode'
     )
 
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=['bold_t1']),
+        niu.IdentityInterface(fields=[
+            'bold_t1', 'bold_mask_t1',
+            'bold_aseg_t1', 'bold_aparc_t1']),
         name='outputnode'
     )
+
+    gen_ref = pe.Node(GenerateSamplingReference(), name='gen_ref',
+                      mem_gb=0.3)  # 256x256x256 * 64 / 8 ~ 150MB
+
+    mask_t1w_tfm = pe.Node(
+        ApplyTransforms(interpolation='MultiLabel', float=True),
+        name='mask_t1w_tfm', mem_gb=0.1
+    )
+
+    workflow.connect([
+        (inputnode, gen_ref, [('ref_bold_brain', 'moving_image'),
+                              ('t1_brain', 'fixed_image'),
+                              ('t1_mask', 'fov_mask')]),
+        (inputnode, mask_t1w_tfm, [('ref_bold_mask', 'input_image')]),
+        (gen_ref, mask_t1w_tfm, [('out_file', 'reference_image')]),
+        (inputnode, mask_t1w_tfm, [('itk_bold_to_t1', 'transforms')]),
+        (mask_t1w_tfm, outputnode, [('output_image', 'bold_mask_t1')]),
+    ])
+
+    if freesurfer:
+        # Resample aseg and aparc in T1w space (no transforms needed)
+        aseg_t1w_tfm = pe.Node(
+            ApplyTransforms(interpolation='MultiLabel', transforms='identity', float=True),
+            name='aseg_t1w_tfm', mem_gb=0.1)
+        aparc_t1w_tfm = pe.Node(
+            ApplyTransforms(interpolation='MultiLabel', transforms='identity', float=True),
+            name='aparc_t1w_tfm', mem_gb=0.1)
+
+        workflow.connect([
+            (inputnode, aseg_t1w_tfm, [('t1_aseg', 'input_image')]),
+            (inputnode, aparc_t1w_tfm, [('t1_aparc', 'input_image')]),
+            (gen_ref, aseg_t1w_tfm, [('out_file', 'reference_image')]),
+            (gen_ref, aparc_t1w_tfm, [('out_file', 'reference_image')]),
+            (aseg_t1w_tfm, outputnode, [('output_image', 'bold_aseg_t1')]),
+            (aparc_t1w_tfm, outputnode, [('output_image', 'bold_aparc_t1')]),
+        ])
 
     # Merge transforms placing the head motion correction last
     nforms = 2 + int(use_fieldwarp)
     merge_xforms = pe.Node(niu.Merge(nforms), name='merge_xforms',
                            run_without_submitting=True, mem_gb=DEFAULT_MEMORY_MIN_GB)
+    workflow.connect([
+        (inputnode, merge_xforms, [('hmc_xforms', 'in%d' % nforms)])
+    ])
+
+    if use_fieldwarp:
+        workflow.connect([
+            (inputnode, merge_xforms, [('fieldwarp', 'in2')])
+        ])
 
     bold_to_t1w_transform = pe.Node(
         MultiApplyTransforms(interpolation="LanczosWindowedSinc", float=True, copy_dtype=True),
@@ -306,19 +322,13 @@ def init_bold_apply_reg_wf(mem_gb, omp_nthreads, use_compression=True,
 
     merge = pe.Node(Merge(compress=use_compression), name='merge', mem_gb=mem_gb)
 
-    if use_fieldwarp:
-        workflow.connect([
-            (inputnode, merge_xforms, [('fieldwarp', 'in2')])
-        ])
-
     workflow.connect([
-        (inputnode, merge_xforms, [('itk_bold_to_t1', 'in1'),
-                                   ('hmc_xforms', 'in%d' % nforms)]),
+        (inputnode, merge_xforms, [('itk_bold_to_t1', 'in1')]),
         (merge_xforms, bold_to_t1w_transform, [('out', 'transforms')]),
-        (inputnode, bold_to_t1w_transform, [('bold_split', 'input_image')]),
-        (inputnode, bold_to_t1w_transform, [('reference_grid', 'reference_image')]),
-        (bold_to_t1w_transform, merge, [('out_files', 'in_files')]),
         (inputnode, merge, [('name_source', 'header_source')]),
+        (inputnode, bold_to_t1w_transform, [('bold_split', 'input_image')]),
+        (gen_ref, bold_to_t1w_transform, [('out_file', 'reference_image')]),
+        (bold_to_t1w_transform, merge, [('out_files', 'in_files')]),
         (merge, outputnode, [('out_file', 'bold_t1')]),
     ])
 

--- a/fmriprep/workflows/bold/registration.py
+++ b/fmriprep/workflows/bold/registration.py
@@ -36,7 +36,7 @@ DEFAULT_MEMORY_MIN_GB = 0.01
 
 def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthreads,
                           use_compression=True, write_report=True,
-                          name='bold_calc_reg_wf', ):
+                          name='bold_calc_reg_wf'):
     """
     This workflow calculates the registration of the reference BOLD image to T1-space,
      using a boundary-based registration (BBR) cost function.
@@ -80,9 +80,6 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
 
     **Inputs**
 
-        name_source
-            BOLD series NIfTI file
-            Used to recover original information lost during processing
         ref_bold_brain
             Reference image to which BOLD series is aligned
             If ``fieldwarp == True``, ``ref_bold_brain`` should be unwarped
@@ -140,7 +137,7 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
     workflow = Workflow(name=name)
     inputnode = pe.Node(
         niu.IdentityInterface(
-            fields=['name_source', 'ref_bold_brain', 'ref_bold_mask',
+            fields=['ref_bold_brain', 'ref_bold_mask',
                     't1_preproc', 't1_brain', 't1_mask', 't1_seg',
                     't1_aseg', 't1_aparc', 'subjects_dir',
                     'subject_id', 't1_2_fsnative_reverse_transform']),
@@ -265,6 +262,9 @@ def init_bold_apply_reg_wf(mem_gb, omp_nthreads, use_compression=True,
             Name of workflow (default: ``bold_apply_reg_wf``)
 
     **Inputs**
+        name_source
+            BOLD series NIfTI file
+            Used to recover original information lost during processing
         bold_split
             Individual 3D BOLD volumes, not motion corrected
         reference_grid
@@ -285,8 +285,8 @@ def init_bold_apply_reg_wf(mem_gb, omp_nthreads, use_compression=True,
     workflow = Workflow(name=name)
     inputnode = pe.Node(
         niu.IdentityInterface(fields=[
-            'bold_split', 'reference_grid', 'itk_bold_to_t1',
-            'hmc_xforms', 'fieldwarp']),
+            'name_source', 'bold_split', 'reference_grid',
+            'itk_bold_to_t1', 'hmc_xforms', 'fieldwarp']),
         name='inputnode'
     )
 

--- a/fmriprep/workflows/bold/registration.py
+++ b/fmriprep/workflows/bold/registration.py
@@ -127,6 +127,9 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
             (only if ``recon-all`` was run).
         fallback
             Boolean indicating whether BBR was rejected (mri_coreg registration returned)
+        reference_image
+            Reference grid for resampling to a different space (e.g. MNI),
+            keeping the original resolution
 
 
     **Subworkflows**
@@ -148,7 +151,8 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
     outputnode = pe.Node(
         niu.IdentityInterface(fields=[
             'itk_bold_to_t1', 'itk_t1_to_bold', 'fallback',
-            'bold_mask_t1', 'bold_aseg_t1', 'bold_aparc_t1']),
+            'bold_mask_t1', 'bold_aseg_t1', 'bold_aparc_t1',
+            'reference_image']),
         name='outputnode'
     )
 
@@ -203,6 +207,7 @@ def init_bold_calc_reg_wf(freesurfer, use_bbr, bold2t1w_dof, mem_gb, omp_nthread
             (inputnode, aparc_t1w_tfm, [('t1_aparc', 'input_image')]),
             (gen_ref, aseg_t1w_tfm, [('out_file', 'reference_image')]),
             (gen_ref, aparc_t1w_tfm, [('out_file', 'reference_image')]),
+            (gen_ref, outputnode, [('out_file', 'reference_image')]),
             (aseg_t1w_tfm, outputnode, [('output_image', 'bold_aseg_t1')]),
             (aparc_t1w_tfm, outputnode, [('output_image', 'bold_aparc_t1')]),
         ])


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

As discussed with @effigies, splits the existing `bold_reg_wf` into two separate, smaller workflows, one of which calculates the registrations and the other of which applies the result in a single-shot. This will make integration of ME-EPI workflow changes possible.  

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
Updated docstrings for both of the new functions.


<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
