### PR TITLE
DOC: Note GIFTI surface alignment

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -219,6 +219,12 @@ The ``smoothwm``, ``midthickness``, ``pial`` and ``inflated`` surfaces are also
 converted to GIFTI_ format and adjusted to be compatible with multiple software
 packages, including FreeSurfer and the `Connectome Workbench`_.
 
+.. note::
+    GIFTI surface outputs are aligned to the FreeSurfer T1.mgz image, which
+    may differ from the T1w space in some cases, to maintain compatibility
+    with the FreeSurfer directory.
+    Any measures sampled to the surface take into account any difference in
+    these images.
 
 Refinement of the brain mask
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Following discussion in [this NeuroStars thread](https://neurostars.org/t/fmriprep-correction-of-surface-extracted-from-freesurfer-anat-only/2428/13), a clarifying note seems necessary.

## Changes proposed in this pull request

Updated documentation.
<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->

* Add a note with the following text:

```RST
GIFTI surface outputs are aligned to the FreeSurfer T1.mgz image, which
may differ from the T1w space in some cases, to maintain compatibility
with the FreeSurfer directory.
Any measures sampled to the surface take into account any difference in
these images.
```

<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
