### PR TITLE
FIX: QwarpPlusMinus renamed source_file to in_file

### DIFF
--- a/fmriprep/workflows/fieldmap/pepolar.py
+++ b/fmriprep/workflows/fieldmap/pepolar.py
@@ -139,10 +139,10 @@ directions, using `3dQwarp` @afni (AFNI {afni_ver}).
 
         workflow.connect([
             (inputnode, prepare_epi_matching_wf, [('in_reference_brain', 'inputnode.ref_brain')]),
-            (prepare_epi_matching_wf, qwarp, [('outputnode.out_file', 'source_file')]),
+            (prepare_epi_matching_wf, qwarp, [('outputnode.out_file', 'in_file')]),
         ])
     else:
-        workflow.connect([(inputnode, qwarp, [('in_reference_brain', 'source_file')])])
+        workflow.connect([(inputnode, qwarp, [('in_reference_brain', 'in_file')])])
 
     to_ants = pe.Node(niu.Function(function=_fix_hdr), name='to_ants',
                       mem_gb=0.01)


### PR DESCRIPTION
In a cleanup in nipy/nipype#2674, `QwarpPlusMinusInputSpec.source_file` got renamed to `in_file`, to be consistent with the `Qwarp` interface. Apparently the deprecation machinery doesn't set the values in the new location, causing #1287.

## Changes proposed in this pull request

* Change source_file to in_file

Fixes #1287.

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->

None


<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
