### PR TITLE
DOC: Switch to orig graph for init_bold_t2s_wf

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -382,7 +382,7 @@ T2* Driven Coregistration
 :mod:`fmriprep.workflows.bold.t2s.init_bold_t2s_wf`
 
 .. workflow::
-    :graph2use: colored
+    :graph2use: orig
     :simple_form: yes
 
     from fmriprep.workflows.bold import init_bold_t2s_wf


### PR DESCRIPTION
The graph for `init_bold_t2s_wf` in `workflows.rst` violates our convention of keeping hierarchical workflows collapsed.

## Changes proposed in this pull request

* Switch from colored graph to orig

## Documentation that should be reviewed

* https://fmriprep.readthedocs.io/en/1.1.7/workflows.html#t2-driven-coregistration
* `<insert equivalent link from artifacts once docs are built>`