### PR TITLE
[FIX] Enhance T2 contrast ``enhance_t2`` in reference estimate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,10 +252,12 @@ jobs:
           name: Run fMRIPrep tests
           no_output_timeout: 2h
           command: |
+            mkdir /tmp/data/reports && \
             docker run -ti --rm=false \
               -v /tmp/data:/tmp/data \
               -e FMRIPREP_REGRESSION_SOURCE=/tmp/data/fmriprep_bold_truncated \
               -e FMRIPREP_REGRESSION_TARGETS=/tmp/data/fmriprep_bold_mask \
+              -e FMRIPREP_REGRESSION_REPORTS=/tmp/data/reports \
               --entrypoint="py.test" poldracklab/fmriprep:latest \
               /root/src/fmriprep/ \
               --doctest-modules --ignore=/root/src/fmriprep/docs --ignore=setup.py
@@ -284,7 +286,7 @@ jobs:
             fmriprep-docker -i poldracklab/fmriprep:latest --help
             fmriprep-docker -i poldracklab/fmriprep:latest --version
       - store_artifacts:
-          path: /home/circleci/out/tests
+          path: /tmp/data/reports
 
 
   build_docs:

--- a/fmriprep/workflows/bold/util.py
+++ b/fmriprep/workflows/bold/util.py
@@ -105,7 +105,8 @@ using a custom methodology of *fMRIPrep*.
                       mem_gb=1)  # OE: 128x128x128x50 * 64 / 8 ~ 900MB.
     # Re-run validation; no effect if no sbref; otherwise apply same validation to sbref as bold
     validate_ref = pe.Node(ValidateImage(), name='validate_ref', mem_gb=DEFAULT_MEMORY_MIN_GB)
-    enhance_and_skullstrip_bold_wf = init_enhance_and_skullstrip_bold_wf(omp_nthreads=omp_nthreads)
+    enhance_and_skullstrip_bold_wf = init_enhance_and_skullstrip_bold_wf(omp_nthreads=omp_nthreads,
+                                                                         enhance_t2=enhance_t2)
 
     workflow.connect([
         (inputnode, validate, [('bold_file', 'in_file')]),


### PR DESCRIPTION
## Changes proposed in this pull request

Pass `enhance_t2` flag from `init_bold_reference_wf` to `init_enhance_and_skullstrip_wf`.

This parameter currently does nothing. It appears to have been an oversight in #966.

## Documentation that should be reviewed

None.