### PR TITLE
[FIX] Create template from one usable T1w image

### DIFF
--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -524,13 +524,13 @@ A T1w-reference map was computed after registration of
     # StructuralReference is fs.RobustTemplate if > 1 volume, copying otherwise
     t1_merge = pe.Node(
         StructuralReference(auto_detect_sensitivity=True,
-                           initial_timepoint=1,      # For deterministic behavior
-                           intensity_scaling=True,   # 7-DOF (rigid + intensity)
-                           subsample_threshold=200,
-                           fixed_timepoint=not longitudinal,
-                           no_iteration=not longitudinal,
-                           transform_outputs=True,
-                           ),
+                            initial_timepoint=1,      # For deterministic behavior
+                            intensity_scaling=True,   # 7-DOF (rigid + intensity)
+                            subsample_threshold=200,
+                            fixed_timepoint=not longitudinal,
+                            no_iteration=not longitudinal,
+                            transform_outputs=True,
+                            ),
         mem_gb=2 * num_t1w - 1,
         name='t1_merge')
 

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -44,7 +44,7 @@ from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransf
 
 from ..engine import Workflow
 from ..interfaces import (
-    DerivativesDataSink, MakeMidthickness, FSInjectBrainExtracted,
+    DerivativesDataSink, StructuralReference, MakeMidthickness, FSInjectBrainExtracted,
     FSDetectInputs, NormalizeSurf, GiftiNameSource, TemplateDimensions, Conform,
     ConcatAffines, RefineBrainMask,
 )
@@ -521,15 +521,16 @@ A T1w-reference map was computed after registration of
         N4BiasFieldCorrection(dimension=3, copy_header=True),
         iterfield='input_image', name='n4_correct',
         n_procs=1)  # n_procs=1 for reproducibility
+    # StructuralReference is fs.RobustTemplate if > 1 volume, copying otherwise
     t1_merge = pe.Node(
-        fs.RobustTemplate(auto_detect_sensitivity=True,
-                          initial_timepoint=1,      # For deterministic behavior
-                          intensity_scaling=True,   # 7-DOF (rigid + intensity)
-                          subsample_threshold=200,
-                          fixed_timepoint=not longitudinal,
-                          no_iteration=not longitudinal,
-                          transform_outputs=True,
-                          ),
+        StructuralReference(auto_detect_sensitivity=True,
+                           initial_timepoint=1,      # For deterministic behavior
+                           intensity_scaling=True,   # 7-DOF (rigid + intensity)
+                           subsample_threshold=200,
+                           fixed_timepoint=not longitudinal,
+                           no_iteration=not longitudinal,
+                           transform_outputs=True,
+                           ),
         mem_gb=2 * num_t1w - 1,
         name='t1_merge')
 


### PR DESCRIPTION
#925 switched from `StructuralReference` to `fs.RobustTemplate`, under the reasoning that a single T1w image could be caught at workflow construction time. However, the conformation process can remove images that would need to be upsampled too much, leaving only a single T1w image to produce a template from. In this case, we need to simply pass through the original image.

## Changes proposed in this pull request

* Restore `t1_merge` to `StructuralReference`.

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->

None.

<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
