### PR TITLE
CI: Deploy poldracklab/fmriprep:unstable tracking master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -668,7 +668,7 @@ jobs:
       - store_artifacts:
           path: /tmp/ds210
 
-  deploy:
+  deploy_docker:
     machine:
       image: circleci/classic:201711-01
     working_directory: /tmp/src/fmriprep
@@ -692,10 +692,22 @@ jobs:
           command: |
             if [[ -n "$DOCKER_PASS" ]]; then
               docker login -u $DOCKER_USER -p $DOCKER_PASS
-              docker push poldracklab/fmriprep:latest
-              docker tag poldracklab/fmriprep poldracklab/fmriprep:$CIRCLE_TAG
-              docker push poldracklab/fmriprep:$CIRCLE_TAG
+              docker tag poldracklab/fmriprep poldracklab/fmriprep:unstable
+              docker push poldracklab/fmriprep:unstable
+              if [[ -n "$CIRCLE_TAG" ]]; then
+                docker push poldracklab/fmriprep:latest
+                docker tag poldracklab/fmriprep poldracklab/fmriprep:$CIRCLE_TAG
+                docker push poldracklab/fmriprep:$CIRCLE_TAG
+              fi
             fi
+
+  deploy_pypi:
+    machine:
+      image: circleci/classic:201711-01
+    working_directory: /tmp/src/fmriprep
+    steps:
+      - attach_workspace:
+          at: /tmp
       - run:
           name: Deploy to PyPi
           command: |
@@ -785,7 +797,21 @@ workflows:
             tags:
               only: /.*/
 
-      - deploy:
+      - deploy_docker:
+          requires:
+            - build
+            - test_pytest
+            - build_docs
+            - ds005
+            - ds054
+            - ds210
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
+
+      - deploy_pypi:
           requires:
             - build
             - test_pytest


### PR DESCRIPTION
By pushing the most recent master to Docker hub, we can iterate more quickly on issues that are only replicable on HPC environments.

This isn't addressing an urgent need at this time, but it would be nice to have this next time something comes up.

Thoughts?