### PR TITLE
[FIX] Ensure encoding when reading boilerplate

### DIFF
--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -145,7 +145,7 @@ class Report(object):
 
     @staticmethod
     def _read_txt(path):
-        lines = path.read_text().splitlines()
+        lines = path.read_text(encoding='UTF-8').splitlines()
         data = {'file': str(path)}
         traceback_start = 0
         if lines[0].startswith('Node'):
@@ -170,7 +170,7 @@ class Report(object):
         boiler_idx = 0
 
         if (logs_path / 'CITATION.html').exists():
-            text = (logs_path / 'CITATION.html').read_text()
+            text = (logs_path / 'CITATION.html').read_text(encoding='UTF-8')
             text = '<div class="boiler-html">%s</div>' % re.compile(
                 '<body>(.*?)</body>',
                 re.DOTALL | re.IGNORECASE).findall(text)[0].strip()
@@ -178,19 +178,19 @@ class Report(object):
             boiler_idx += 1
 
         if (logs_path / 'CITATION.md').exists():
-            text = '<pre>%s</pre>\n' % (logs_path / 'CITATION.md').read_text()
+            text = '<pre>%s</pre>\n' % (logs_path / 'CITATION.md').read_text(encoding='UTF-8')
             boilerplate.append((boiler_idx, 'Markdown', text))
             boiler_idx += 1
 
         if (logs_path / 'CITATION.tex').exists():
-            text = (logs_path / 'CITATION.tex').read_text()
+            text = (logs_path / 'CITATION.tex').read_text(encoding='UTF-8')
             text = re.compile(
                 r'\\begin{document}(.*?)\\end{document}',
                 re.DOTALL | re.IGNORECASE).findall(text)[0].strip()
             text = '<pre>%s</pre>\n' % text
             text += '<h3>Bibliography</h3>\n'
             text += '<pre>%s</pre>\n' % Path(
-                pkgrf('fmriprep', 'data/boilerplate.bib')).read_text()
+                pkgrf('fmriprep', 'data/boilerplate.bib')).read_text(encoding='UTF-8')
             boilerplate.append((boiler_idx, 'LaTeX', text))
             boiler_idx += 1
 
@@ -204,7 +204,7 @@ class Report(object):
                                           boilerplate=boilerplate)
 
         # Write out report
-        (self.out_dir / 'fmriprep' / self.out_filename).write_text(report_render)
+        (self.out_dir / 'fmriprep' / self.out_filename).write_text(report_render, encoding='UTF-8')
         return len(self.errors)
 
 


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

Fix for error in generate_report function encountered when running singularity image of fmriprep version 1.1.8 on a cluster, with singularity version 2.6.0 raised in issue #1313.   
<!--
-->

Fixes #1313.

## Documentation that should be reviewed
The flag encoding='UTF-8’ was added for all read_text and write_text functions.
<!--
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
