### PR TITLE
[ENH] add --bind method to singularity patch documentation

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -68,7 +68,15 @@ arguments in a ``docker`` command::
         -v $HOME/projects/fmriprep/fmriprep:/usr/local/miniconda/lib/python3.6/site-packages/fmriprep:ro --entrypoint=bash \
         poldracklab/fmriprep:latest
 
-Patching containers can be achieved in Singularity by using the PYTHONPATH variable: ::
+Patching containers can be achieved in Singularity analogous to ``docker``
+using the ``--bind`` (``-B``) option: ::
+
+    $ singularity run \
+        -B $HOME/projects/fmriprep/fmriprep:/usr/local/miniconda/lib/python3.6/site-packages/fmriprep \
+        fmriprep.img \
+        /scratch/dataset /scratch/out participant -w /out/work/
+
+Or you can patch Singularity containers using the PYTHONPATH variable: ::
 
    $ PYTHONPATH="$HOME/projects/fmriprep" singularity run fmriprep.img \
         /scratch/dataset /scratch/out participant -w /out/work/


### PR DESCRIPTION


<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request
closes #1338 
Changing the documentation to include the [bind method](https://www.sylabs.io/guides/3.0/user-guide/bind_paths_and_mounts.html) in singularity to patch singularity containers.
<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
- the documentation in `docs/contributors.rst`
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
