### PR TITLE
ENH: Conform confound regressor names to Derivatives RC2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,10 +354,10 @@ jobs:
           at: /tmp
       - restore_cache:
           keys:
-            - ds005-anat-v9-{{ .Branch }}-{{ epoch }}
-            - ds005-anat-v9-{{ .Branch }}
-            - ds005-anat-v9-master
-            - ds005-anat-v9-
+            - ds005-anat-v10-{{ .Branch }}-{{ epoch }}
+            - ds005-anat-v10-{{ .Branch }}
+            - ds005-anat-v10-master
+            - ds005-anat-v10-
       - run:
           name: Setting up test
           command: |
@@ -391,7 +391,7 @@ jobs:
                 --sloppy --write-graph --mem_mb 4096 \
                 --nthreads 2 --anat-only -vv
       - save_cache:
-         key: ds005-anat-v9-{{ .Branch }}-{{ epoch }}
+         key: ds005-anat-v10-{{ .Branch }}-{{ epoch }}
          paths:
             - /tmp/ds005/work
             - /tmp/ds005/derivatives/fmriprep

--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -6,6 +6,8 @@ fmriprep/logs/CITATION.md
 fmriprep/logs/CITATION.tex
 fmriprep/sub-01
 fmriprep/sub-01/anat
+fmriprep/sub-01/anat/sub-01_desc-aparcaseg_dseg.nii.gz
+fmriprep/sub-01/anat/sub-01_desc-aseg_dseg.nii.gz
 fmriprep/sub-01/anat/sub-01_desc-brain_mask.nii.gz
 fmriprep/sub-01/anat/sub-01_desc-preproc_T1w.nii.gz
 fmriprep/sub-01/anat/sub-01_dseg.nii.gz
@@ -21,8 +23,6 @@ fmriprep/sub-01/anat/sub-01_hemi-R_inflated.surf.gii
 fmriprep/sub-01/anat/sub-01_hemi-R_midthickness.surf.gii
 fmriprep/sub-01/anat/sub-01_hemi-R_pial.surf.gii
 fmriprep/sub-01/anat/sub-01_hemi-R_smoothwm.surf.gii
-fmriprep/sub-01/anat/sub-01_label-aparcaseg_dseg.nii.gz
-fmriprep/sub-01/anat/sub-01_label-aseg_dseg.nii.gz
 fmriprep/sub-01/anat/sub-01_label-CSF_probseg.nii.gz
 fmriprep/sub-01/anat/sub-01_label-GM_probseg.nii.gz
 fmriprep/sub-01/anat/sub-01_label-WM_probseg.nii.gz

--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -45,10 +45,10 @@ fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-MNI152NLin2009cAs
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-MNI152NLin2009cAsym_desc-smoothAROMAnonaggr_bold.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_boldref.nii.gz
+fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_desc-aparcaseg_dseg.nii.gz
+fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_desc-aseg_dseg.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_desc-brain_mask.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_desc-preproc_bold.nii.gz
-fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_label-aparcaseg_dseg.nii.gz
-fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_label-aseg_dseg.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_AROMAnoiseICs.csv
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_bold.dtseries.json
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_bold.dtseries.nii
@@ -61,9 +61,9 @@ fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin2009cAs
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin2009cAsym_desc-smoothAROMAnonaggr_bold.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_boldref.nii.gz
+fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-aparcaseg_dseg.nii.gz
+fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-aseg_dseg.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-brain_mask.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-preproc_bold.nii.gz
-fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_label-aparcaseg_dseg.nii.gz
-fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_label-aseg_dseg.nii.gz
 fmriprep/sub-01.html
 /tmp/ds005/derivatives

--- a/.circleci/ds005_partial_outputs.txt
+++ b/.circleci/ds005_partial_outputs.txt
@@ -6,6 +6,8 @@ fmriprep/logs/CITATION.md
 fmriprep/logs/CITATION.tex
 fmriprep/sub-01
 fmriprep/sub-01/anat
+fmriprep/sub-01/anat/sub-01_desc-aparcaseg_dseg.nii.gz
+fmriprep/sub-01/anat/sub-01_desc-aseg_dseg.nii.gz
 fmriprep/sub-01/anat/sub-01_desc-brain_mask.nii.gz
 fmriprep/sub-01/anat/sub-01_desc-preproc_T1w.nii.gz
 fmriprep/sub-01/anat/sub-01_dseg.nii.gz
@@ -21,8 +23,6 @@ fmriprep/sub-01/anat/sub-01_hemi-R_inflated.surf.gii
 fmriprep/sub-01/anat/sub-01_hemi-R_midthickness.surf.gii
 fmriprep/sub-01/anat/sub-01_hemi-R_pial.surf.gii
 fmriprep/sub-01/anat/sub-01_hemi-R_smoothwm.surf.gii
-fmriprep/sub-01/anat/sub-01_label-aparcaseg_dseg.nii.gz
-fmriprep/sub-01/anat/sub-01_label-aseg_dseg.nii.gz
 fmriprep/sub-01/anat/sub-01_label-CSF_probseg.nii.gz
 fmriprep/sub-01/anat/sub-01_label-GM_probseg.nii.gz
 fmriprep/sub-01/anat/sub-01_label-WM_probseg.nii.gz

--- a/.circleci/ds005_partial_outputs.txt
+++ b/.circleci/ds005_partial_outputs.txt
@@ -45,9 +45,9 @@ fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-MNI152NLin2009cAs
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-MNI152NLin2009cAsym_desc-smoothAROMAnonaggr_bold.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_boldref.nii.gz
+fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_desc-aparcaseg_dseg.nii.gz
+fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_desc-aseg_dseg.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_desc-brain_mask.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_desc-preproc_bold.nii.gz
-fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_label-aparcaseg_dseg.nii.gz
-fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_label-aseg_dseg.nii.gz
 fmriprep/sub-01.html
 /tmp/ds005/derivatives_partial

--- a/fmriprep/interfaces/confounds.py
+++ b/fmriprep/interfaces/confounds.py
@@ -10,6 +10,7 @@ Handling confounds
 
 """
 import os
+import re
 import shutil
 import numpy as np
 import pandas as pd
@@ -27,6 +28,7 @@ LOGGER = logging.getLogger('nipype.interface')
 class GatherConfoundsInputSpec(BaseInterfaceInputSpec):
     signals = File(exists=True, desc='input signals')
     dvars = File(exists=True, desc='file containing DVARS')
+    std_dvars = File(exists=True, desc='file containing standardized DVARS')
     fd = File(exists=True, desc='input framewise displacement')
     tcompcor = File(exists=True, desc='input tCompCorr')
     acompcor = File(exists=True, desc='input aCompCorr')
@@ -124,7 +126,7 @@ class ICAConfounds(SimpleInterface):
         return runtime
 
 
-def _gather_confounds(signals=None, dvars=None, fdisp=None,
+def _gather_confounds(signals=None, dvars=None, std_dvars=None, fdisp=None,
                       tcompcor=None, acompcor=None, cos_basis=None,
                       motion=None, aroma=None, newpath=None):
     """
@@ -134,16 +136,16 @@ def _gather_confounds(signals=None, dvars=None, fdisp=None,
     >>> from tempfile import TemporaryDirectory
     >>> tmpdir = TemporaryDirectory()
     >>> os.chdir(tmpdir.name)
-    >>> pd.DataFrame({'a': [0.1]}).to_csv('signals.tsv', index=False, na_rep='n/a')
-    >>> pd.DataFrame({'b': [0.2]}).to_csv('dvars.tsv', index=False, na_rep='n/a')
+    >>> pd.DataFrame({'Global Signal': [0.1]}).to_csv('signals.tsv', index=False, na_rep='n/a')
+    >>> pd.DataFrame({'stdDVARS': [0.2]}).to_csv('dvars.tsv', index=False, na_rep='n/a')
     >>> out_file, confound_list = _gather_confounds('signals.tsv', 'dvars.tsv')
     >>> confound_list
     ['Global signals', 'DVARS']
 
     >>> pd.read_csv(out_file, sep='\s+', index_col=None,
     ...             engine='python')  # doctest: +NORMALIZE_WHITESPACE
-         a    b
-    0  0.1  0.2
+       global_signal  std_dvars
+    0            0.1        0.2
     >>> tmpdir.cleanup()
 
 
@@ -152,6 +154,12 @@ def _gather_confounds(signals=None, dvars=None, fdisp=None,
     def less_breakable(a_string):
         ''' hardens the string to different envs (i.e. case insensitive, no whitespace, '#' '''
         return ''.join(a_string.split()).strip('#')
+
+    # Taken from https://stackoverflow.com/questions/1175208/
+    # If we end up using it more than just here, probably worth pulling in a well-tested package
+    def camel_to_snake(name):
+        s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+        return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
 
     def _adjust_indices(left_df, right_df):
         # This forces missing values to appear at the beggining of the DataFrame
@@ -167,6 +175,7 @@ def _gather_confounds(signals=None, dvars=None, fdisp=None,
     all_files = []
     confounds_list = []
     for confound, name in ((signals, 'Global signals'),
+                           (std_dvars, 'Standardized DVARS'),
                            (dvars, 'DVARS'),
                            (fdisp, 'Framewise displacement'),
                            (tcompcor, 'tCompCor'),
@@ -183,7 +192,7 @@ def _gather_confounds(signals=None, dvars=None, fdisp=None,
     for file_name in all_files:  # assumes they all have headings already
         new = pd.read_csv(file_name, sep="\t")
         for column_name in new.columns:
-            new.rename(columns={column_name: less_breakable(column_name)},
+            new.rename(columns={column_name: camel_to_snake(less_breakable(column_name))},
                        inplace=True)
 
         _adjust_indices(confounds_data, new)

--- a/fmriprep/interfaces/confounds.py
+++ b/fmriprep/interfaces/confounds.py
@@ -255,7 +255,7 @@ def _get_ica_confounds(ica_out_dir, skip_vols, newpath=None):
     # add one to motion_ic_indices to match melodic report.
     aroma_confounds = os.path.join(newpath, "AROMAAggrCompAROMAConfounds.tsv")
     pd.DataFrame(aggr_confounds.T,
-                 columns=['AROMAAggrComp%02d' % (x + 1) for x in motion_ic_indices]).to_csv(
+                 columns=['aroma_motion_%02d' % (x + 1) for x in motion_ic_indices]).to_csv(
         aroma_confounds, sep="\t", index=None)
 
     return aroma_confounds, motion_ics_out, melodic_mix_out

--- a/fmriprep/interfaces/confounds.py
+++ b/fmriprep/interfaces/confounds.py
@@ -81,6 +81,7 @@ class GatherConfounds(SimpleInterface):
         combined_out, confounds_list = _gather_confounds(
             signals=self.inputs.signals,
             dvars=self.inputs.dvars,
+            std_dvars=self.inputs.std_dvars,
             fdisp=self.inputs.fd,
             tcompcor=self.inputs.tcompcor,
             acompcor=self.inputs.acompcor,

--- a/fmriprep/workflows/anatomical.py
+++ b/fmriprep/workflows/anatomical.py
@@ -1313,10 +1313,10 @@ def init_anat_derivatives_wf(output_dir, output_spaces, template, freesurfer,
 
     if freesurfer:
         ds_t1_fsaseg = pe.Node(
-            DerivativesDataSink(base_directory=output_dir, suffix='label-aseg_dseg'),
+            DerivativesDataSink(base_directory=output_dir, desc='aseg', suffix='dseg'),
             name='ds_t1_fsaseg', run_without_submitting=True)
         ds_t1_fsparc = pe.Node(
-            DerivativesDataSink(base_directory=output_dir, suffix='label-aparcaseg_dseg'),
+            DerivativesDataSink(base_directory=output_dir, desc='aparcaseg', suffix='dseg'),
             name='ds_t1_fsparc', run_without_submitting=True)
         workflow.connect([
             (inputnode, lta_2_itk, [('t1_2_fsnative_forward_transform', 'in_lta')]),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -889,11 +889,11 @@ def init_func_derivatives_wf(output_dir, output_spaces, template, freesurfer,
 
     if freesurfer:
         ds_bold_aseg_t1 = pe.Node(DerivativesDataSink(
-            base_directory=output_dir, space='T1w', suffix='label-aseg_dseg'),
+            base_directory=output_dir, space='T1w', desc='aseg', suffix='dseg'),
             name='ds_bold_aseg_t1', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
         ds_bold_aparc_t1 = pe.Node(DerivativesDataSink(
-            base_directory=output_dir,  space='T1w', suffix='label-aparcaseg_dseg'),
+            base_directory=output_dir,  space='T1w', desc='aparcaseg', suffix='dseg'),
             name='ds_bold_aparc_t1', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
         workflow.connect([

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -45,7 +45,7 @@ def init_bold_confs_wf(mem_gb, metadata, name="bold_confs_wf"):
 
     #. Region-wise average signal (``csf``, ``white_matter``, ``global_signal``)
     #. DVARS - original and standardized variants (``dvars``, ``std_dvars``)
-    #. Framewise displacement, based on MCFLIRT motion parameters
+    #. Framewise displacement, based on head-motion parameters
        (``framewise_displacement``)
     #. Temporal CompCor (``t_comp_cor_XX``)
     #. Anatomical CompCor (``a_comp_cor_XX``)


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

Updating confounds headers to match the RC2.

Known remaining tasks:
* [x] Update the `cosine_*` headers in nipype or update in a separate function in nipype.
* [x] Update DVARS and FD headers (might need to be in nipype)

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed

Anywhere we discuss confounds. I believe we have example confounds that should be fixed, as well.