### PR TITLE
[ENH] Set maximum MELODIC components to 200 by default

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -49,7 +49,7 @@ is presented below:
         force_syn=True,
         template_out_grid='native',
         use_aroma=False,
-        aroma_melodic_dim=None,
+        aroma_melodic_dim=-200,
         ignore_aroma_err=False,
     )
 
@@ -271,7 +271,7 @@ BOLD preprocessing
         force_syn=True,
         template_out_grid='native',
         use_aroma=False,
-        aroma_melodic_dim=None,
+        aroma_melodic_dim=-200,
         ignore_aroma_err=False,
     )
 

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -568,9 +568,9 @@ can be automatically appended to the workflow.
 The number of ICA-AROMA components depends on a dimensionality estimate
 made by MELODIC.
 For datasets with a very short TR and a large number of timepoints, this may
-result in an unusually high number of components.
-In such cases, it may be useful to specify the number of components to be
-extracted with ``--aroma-melodic-dimensionality``.
+result in an unusually high number of components. By default, dimensionality is 
+limited to a maximum of 200 components. To override this upper limit one may specify 
+the number of components to be extracted with ``--aroma-melodic-dimensionality``.
 Further details on the implementation are given within the workflow generation
 function (:mod:`fmriprep.workflows.bold.confounds.init_ica_aroma_wf`).
 

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -563,16 +563,12 @@ ICA-AROMA
 ~~~~~~~~~
 :mod:`fmriprep.workflows.bold.confounds.init_ica_aroma_wf`
 
-When one of the `--output-spaces` selected is in MNI space, ICA-AROMA denoising
-can be automatically appended to the workflow.
-The number of ICA-AROMA components depends on a dimensionality estimate
-made by MELODIC.
-For datasets with a very short TR and a large number of timepoints, this may
-result in an unusually high number of components. By default, dimensionality is 
-limited to a maximum of 200 components. To override this upper limit one may specify 
-the number of components to be extracted with ``--aroma-melodic-dimensionality``.
-Further details on the implementation are given within the workflow generation
-function (:mod:`fmriprep.workflows.bold.confounds.init_ica_aroma_wf`).
+When one of the `--output-spaces` selected is in MNI space, ICA-AROMA denoising can be automatically appended to the workflow.
+The number of ICA-AROMA components depends on a dimensionality estimate made by MELODIC.
+For datasets with a very short TR and a large number of timepoints, this may result in an unusually high number of components. 
+By default, dimensionality is limited to a maximum of 200 components. 
+To override this upper limit one may specify the number of components to be extracted with ``--aroma-melodic-dimensionality``.
+Further details on the implementation are given within the workflow generation function (:mod:`fmriprep.workflows.bold.confounds.init_ica_aroma_wf`).
 
 *Note*: *non*-aggressive AROMA denoising is a fundamentally different procedure
 from its "aggressive" counterpart and cannot be performed only by using a set of noise

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -563,11 +563,14 @@ ICA-AROMA
 ~~~~~~~~~
 :mod:`fmriprep.workflows.bold.confounds.init_ica_aroma_wf`
 
-When one of the `--output-spaces` selected is in MNI space, ICA-AROMA denoising can be automatically appended to the workflow.
+When one of the `--output-spaces` selected is in MNI space, ICA-AROMA denoising 
+can be automatically appended to the workflow.
 The number of ICA-AROMA components depends on a dimensionality estimate made by MELODIC.
-For datasets with a very short TR and a large number of timepoints, this may result in an unusually high number of components. 
+For datasets with a very short TR and a large number of timepoints, this may result 
+in an unusually high number of components. 
 By default, dimensionality is limited to a maximum of 200 components. 
-To override this upper limit one may specify the number of components to be extracted with ``--aroma-melodic-dimensionality``.
+To override this upper limit one may specify the number of components to be extracted 
+with ``--aroma-melodic-dimensionality``.
 Further details on the implementation are given within the workflow generation function (:mod:`fmriprep.workflows.bold.confounds.init_ica_aroma_wf`).
 
 *Note*: *non*-aggressive AROMA denoising is a fundamentally different procedure

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -164,8 +164,8 @@ def get_parser():
                          help='add ICA_AROMA to your preprocessing stream')
     g_aroma.add_argument('--aroma-melodic-dimensionality', action='store',
                          default=-200, type=int,
-                         help='set the dimensionality of MELODIC before running'
-                         'ICA-AROMA')
+                         help='Exact or maximum number of MELODIC components to estimate '
+                         '(positive = exact, negative = maximum)')
 
     #  ANTs options
     g_ants = parser.add_argument_group('Specific options for ANTs registrations')

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -163,7 +163,7 @@ def get_parser():
     g_aroma.add_argument('--use-aroma', action='store_true', default=False,
                          help='add ICA_AROMA to your preprocessing stream')
     g_aroma.add_argument('--aroma-melodic-dimensionality', action='store',
-                         default=None, type=int,
+                         default=-200, type=int,
                          help='set the dimensionality of MELODIC before running'
                          'ICA-AROMA')
 

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -83,7 +83,7 @@ def init_fmriprep_wf(subject_list, task_id, run_uuid, work_dir, output_dir, bids
                               force_syn=True,
                               use_aroma=False,
                               ignore_aroma_err=False,
-                              aroma_melodic_dim=None,
+                              aroma_melodic_dim=-200,
                               template_out_grid='native')
 
 
@@ -277,7 +277,7 @@ def init_single_subject_wf(subject_id, task_id, name, reportlets_dir, output_dir
                                     force_syn=True,
                                     template_out_grid='native',
                                     use_aroma=False,
-                                    aroma_melodic_dim=None,
+                                    aroma_melodic_dim=-200,
                                     ignore_aroma_err=False)
 
     Parameters

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -85,7 +85,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
                                   cifti_output=False,
                                   use_aroma=False,
                                   ignore_aroma_err=False,
-                                  aroma_melodic_dim=None,
+                                  aroma_melodic_dim=-200,
                                   num_bold=1)
 
     **Parameters**

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -400,7 +400,7 @@ def init_ica_aroma_wf(template, metadata, mem_gb, omp_nthreads,
                       name='ica_aroma_wf',
                       susan_fwhm=6.0,
                       ignore_aroma_err=False,
-                      aroma_melodic_dim=None,
+                      aroma_melodic_dim=-200,
                       use_fieldwarp=True):
     """
     This workflow wraps `ICA-AROMA`_ to identify and remove motion-related
@@ -459,9 +459,11 @@ def init_ica_aroma_wf(template, metadata, mem_gb, omp_nthreads,
             Include SDC warp in single-shot transform from BOLD to MNI
         ignore_aroma_err : bool
             Do not fail on ICA-AROMA errors
-        aroma_melodic_dim: int or None
+        aroma_melodic_dim: int
             Set the dimensionality of the Melodic ICA decomposition
-            If None, MELODIC automatically estimates dimensionality.
+            By default, MELODIC automatically estimates dimensionality with an upper limit of 200 components.
+            If set to a negative number (int), the upper limit is changed to the absolute of that number. 
+            If set to a positive number (int), MELODIC tries to extract exactly that number of components
 
     **Inputs**
 
@@ -557,9 +559,8 @@ in the corresponding confounds file.
     melodic = pe.Node(fsl.MELODIC(
         no_bet=True, tr_sec=float(metadata['RepetitionTime']), mm_thresh=0.5, out_stats=True),
         name="melodic")
-
-    if aroma_melodic_dim is not None:
-        melodic.inputs.dim = aroma_melodic_dim
+    
+    melodic.inputs.dim = aroma_melodic_dim
 
     # ica_aroma node
     ica_aroma = pe.Node(ICA_AROMARPT(

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -557,8 +557,8 @@ in the corresponding confounds file.
 
     # melodic node
     melodic = pe.Node(fsl.MELODIC(
-        no_bet=True, tr_sec=float(metadata['RepetitionTime']), mm_thresh=0.5, out_stats=True),
-        name="melodic", dim=aroma_melodic_dim)
+        no_bet=True, tr_sec=float(metadata['RepetitionTime']), mm_thresh=0.5, out_stats=True, 
+        dim=aroma_melodic_dim), name="melodic")
 
     # ica_aroma node
     ica_aroma = pe.Node(ICA_AROMARPT(

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -558,8 +558,7 @@ in the corresponding confounds file.
     # melodic node
     melodic = pe.Node(fsl.MELODIC(
         no_bet=True, tr_sec=float(metadata['RepetitionTime']), mm_thresh=0.5, out_stats=True),
-        name="melodic")
-    melodic.inputs.dim = aroma_melodic_dim
+        name="melodic", dim=aroma_melodic_dim)
 
     # ica_aroma node
     ica_aroma = pe.Node(ICA_AROMARPT(

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -557,7 +557,7 @@ in the corresponding confounds file.
 
     # melodic node
     melodic = pe.Node(fsl.MELODIC(
-        no_bet=True, tr_sec=float(metadata['RepetitionTime']), mm_thresh=0.5, out_stats=True, 
+        no_bet=True, tr_sec=float(metadata['RepetitionTime']), mm_thresh=0.5, out_stats=True,
         dim=aroma_melodic_dim), name="melodic")
 
     # ica_aroma node

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -559,7 +559,6 @@ in the corresponding confounds file.
     melodic = pe.Node(fsl.MELODIC(
         no_bet=True, tr_sec=float(metadata['RepetitionTime']), mm_thresh=0.5, out_stats=True),
         name="melodic")
-    
     melodic.inputs.dim = aroma_melodic_dim
 
     # ica_aroma node

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -460,10 +460,10 @@ def init_ica_aroma_wf(template, metadata, mem_gb, omp_nthreads,
         ignore_aroma_err : bool
             Do not fail on ICA-AROMA errors
         aroma_melodic_dim: int
-            Set the dimensionality of the Melodic ICA decomposition
-            By default, MELODIC automatically estimates dimensionality with an upper limit of 200 components.
-            If set to a negative number (int), the upper limit is changed to the absolute of that number. 
-            If set to a positive number (int), MELODIC tries to extract exactly that number of components
+            Set the dimensionality of the MELODIC ICA decomposition.
+            Negative numbers set a maximum on automatic dimensionality estimation.
+            Positive numbers set an exact number of components to extract.
+            (default: -200, i.e., estimate <=200 components)
 
     **Inputs**
 

--- a/fmriprep/workflows/tests/test_base.py
+++ b/fmriprep/workflows/tests/test_base.py
@@ -37,7 +37,7 @@ class TestBase(TestWorkflow):
                                          fmap_bspline=True,
                                          fmap_demean=True,
                                          use_aroma=False,
-                                         aroma_melodic_dim=70,
+                                         aroma_melodic_dim=-200,
                                          ignore_aroma_err=False,
                                          use_syn=True,
                                          force_syn=True,


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

The proposed change to the documentation explains how to set a flexible upper limit for the number of ICA components extracted by MELODIC in the ICA-AROMA workflow. See #1051 
Default fmriprep behavior is changed to automatic dimensionality estimation limited to a maximum of 200 components.

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->

`docs/workflows.rst`
describes the new default behavior and points to 
`fmriprep/workflows/bold/confounds.py`
for further details.

<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->