### PR TITLE
[ENH] new sentry SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -168,6 +168,8 @@ RUN install -m 0755 \
     /root/src/fmriprep/scripts/generate_reference_mask.py \
     /usr/local/bin/generate_reference_mask
 
+ENV IS_DOCKER_8395080871=1
+
 RUN ldconfig
 WORKDIR /tmp/
 ENTRYPOINT ["/usr/local/miniconda/bin/fmriprep"]

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -30,3 +30,4 @@ dependencies:
     - nitime
     - nilearn
     - niworkflows==0.4.4
+    - git+https://github.com/nipy/nipype.git@67d6212a9cabd395ee74f7818d09d8ea6c8426a4#egg=nipype

--- a/fmriprep/__about__.py
+++ b/fmriprep/__about__.py
@@ -130,7 +130,7 @@ EXTRA_REQUIRES = {
     'duecredit': ['duecredit'],
     'datalad': ['datalad'],
     'resmon': ['psutil>=5.4.0'],
-    'sentry': ['raven'],
+    'sentry': ['sentry-sdk>=0.5.3'],
 }
 EXTRA_REQUIRES['docs'] = EXTRA_REQUIRES['doc']
 

--- a/fmriprep/__about__.py
+++ b/fmriprep/__about__.py
@@ -108,6 +108,7 @@ REQUIRES = [
 ]
 
 LINKS_REQUIRES = [
+    'git+https://github.com/nipy/nipype.git@67d6212a9cabd395ee74f7818d09d8ea6c8426a4#egg=nipype'
 ]
 
 TESTS_REQUIRES = [

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -279,9 +279,9 @@ def main():
                         environment=environment,
                         before_send=before_send)
         with sentry_sdk.configure_scope() as scope:
-            exec_env = 'native'
+            exec_env = os.name
             # special variable set in the container
-            if os.getenv('IS_DOCKER_8395080871', 0):
+            if os.getenv('IS_DOCKER_8395080871'):
                 # based on https://stackoverflow.com/a/42674935/616300
                 with open('/proc/1/cgroup', 'rt') as ifh:
                     if 'docker' in ifh.read():

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -371,6 +371,21 @@ def build_workflow(opts, retval):
     a hard-limited memory-scope.
 
     """
+    if not opts.notrack:
+        import sentry_sdk
+        from ..__about__ import __version__
+        environment = "prod"
+        if bool(int(os.getenv('FMRIPREP_DEV', 0))) or ('+' in __version__):
+            environment = "dev"
+        sentry_sdk.init("https://d5a16b0c38d84d1584dfc93b9fb1ade6@sentry.io/1137693",
+                        release=__version__,
+                        environment=environment)
+        with sentry_sdk.configure_scope() as scope:
+            for k, v in vars(opts).items():
+                scope.set_tag(k, v)
+
+        sentry_sdk.capture_message('build_workflow')
+
     from subprocess import check_call, CalledProcessError, TimeoutExpired
     from pkg_resources import resource_filename as pkgrf
 

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -377,7 +377,8 @@ def main():
             raise
     finally:
         # Generate reports phase
-        errno += generate_reports(subject_list, output_dir, work_dir, run_uuid, sentry_sdk=sentry_sdk)
+        errno += generate_reports(subject_list, output_dir, work_dir, run_uuid,
+                                  sentry_sdk=sentry_sdk)
         write_derivative_description(bids_dir, str(Path(output_dir) / 'fmriprep'))
 
         if not opts.notrack and errno == 0:

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -364,14 +364,14 @@ def main():
             errno = 1
         else:
             raise
+    finally:
+        # Generate reports phase
+        errno += generate_reports(subject_list, output_dir, work_dir, run_uuid, sentry_sdk=sentry_sdk)
+        write_derivative_description(bids_dir, str(Path(output_dir) / 'fmriprep'))
 
-    # Generate reports phase
-    errno += generate_reports(subject_list, output_dir, work_dir, run_uuid, sentry_sdk=sentry_sdk)
-    write_derivative_description(bids_dir, str(Path(output_dir) / 'fmriprep'))
-
-    if not opts.notrack and errno == 0:
-        sentry_sdk.capture_message('fMRIPrep finished without errors', level='info')
-    sys.exit(int(errno > 0))
+        if not opts.notrack and errno == 0:
+            sentry_sdk.capture_message('fMRIPrep finished without errors', level='info')
+        sys.exit(int(errno > 0))
 
 
 def build_workflow(opts, retval):

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -245,7 +245,6 @@ def main():
     """Entry point"""
     from nipype import logging as nlogging
     from multiprocessing import set_start_method, Process, Manager
-    from .. import __version__
     from ..viz.reports import generate_reports
     from ..utils.bids import write_derivative_description
     set_start_method('forkserver')

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -279,6 +279,17 @@ def main():
                         environment=environment,
                         before_send=before_send)
         with sentry_sdk.configure_scope() as scope:
+            exec_env = 'native'
+            # special variable set in the container
+            if os.getenv('IS_DOCKER_8395080871', 0):
+                # based on https://stackoverflow.com/a/42674935/616300
+                with open('/proc/1/cgroup', 'rt') as ifh:
+                    if 'docker' in ifh.read():
+                        exec_env = 'docker'
+                    else:
+                        exec_env = 'singularity'
+            scope.set_tag('exec_env', exec_env)
+
             for k, v in vars(opts).items():
                 scope.set_tag(k, v)
 

--- a/fmriprep/utils/misc.py
+++ b/fmriprep/utils/misc.py
@@ -40,5 +40,59 @@ def add_suffix(in_files, suffix):
                                        suffix=suffix))
 
 
+def read_crashfile(path):
+    if path.endswith('.pklz'):
+        return _read_pkl(path)
+    elif path.endswith('.txt'):
+        return _read_txt(path)
+
+
+def _read_pkl(path):
+    from nipype.utils.filemanip import loadcrash
+    crash_data = loadcrash(path)
+    data = {'file': path,
+            'traceback': ''.join(crash_data['traceback'])}
+    if 'node' in crash_data:
+        data['node'] = crash_data['node']
+        if data['node'].base_dir:
+            data['node_dir'] = data['node'].output_dir()
+        else:
+            data['node_dir'] = "Node crashed before execution"
+        data['inputs'] = sorted(data['node'].inputs.trait_get().items())
+    return data
+
+
+def _read_txt(path):
+    with open(path, 'r') as fp:
+        lines = fp.readlines()
+    data = {'file': path}
+    traceback_start = 0
+    if lines[0].startswith('Node'):
+        data['node'] = lines[0].split(': ', 1)[1].strip()
+        data['node_dir'] = lines[1].split(': ', 1)[1].strip()
+        inputs = []
+        cur_key = ''
+        cur_val = ''
+        for i, line in enumerate(lines[5:]):
+            if line[0].isspace():
+                cur_val += line
+                continue
+
+            if cur_val:
+                inputs.append((cur_key, cur_val.strip()))
+
+            if line.startswith("Traceback ("):
+                traceback_start = i + 5
+                break
+
+            cur_key, cur_val = tuple(line.split(' = ', 1))
+
+        data['inputs'] = sorted(inputs)
+    else:
+        data['node_dir'] = "Node crashed before execution"
+    data['traceback'] = ''.join(lines[traceback_start:]).strip()
+    return data
+
+
 if __name__ == '__main__':
     pass

--- a/fmriprep/viz/report.tpl
+++ b/fmriprep/viz/report.tpl
@@ -154,12 +154,12 @@ div#boilerplate pre {
         <div class="nipype_error">
             Node Name: <a target="_self" onclick="toggle('{{error.file|replace('.', '')}}_details_id');">{{ error.node }}</a><br>
             <div id="{{error.file|replace('.', '')}}_details_id" style="display:none">
-            File: <pre>{{ error.file }}</pre><br>
-            Working Directory: <pre>{{ error.node_dir }}</pre><br>
+            File: <code>{{ error.file }}</code><br>
+            Working Directory: <code>{{ error.node_dir }}</code><br>
             Inputs: <br>
             <ul>
             {% for name, spec in error.inputs %}
-                <li>{{ name }}: <pre>{{ spec }}</pre></li>
+                <li>{{ name }}: <code>{{ spec }}</code></li>
             {% endfor %}
             </ul>
             <pre>{{ error.traceback }}</pre>

--- a/fmriprep/viz/report.tpl
+++ b/fmriprep/viz/report.tpl
@@ -154,12 +154,12 @@ div#boilerplate pre {
         <div class="nipype_error">
             Node Name: <a target="_self" onclick="toggle('{{error.file|replace('.', '')}}_details_id');">{{ error.node }}</a><br>
             <div id="{{error.file|replace('.', '')}}_details_id" style="display:none">
-            File: {{ error.file }}<br>
-            Working Directory: {{ error.node_dir }}<br>
+            File: <pre>{{ error.file }}</pre><br>
+            Working Directory: <pre>{{ error.node_dir }}</pre><br>
             Inputs: <br>
             <ul>
             {% for name, spec in error.inputs %}
-                <li>{{ name }}: {{ spec }}</li>
+                <li>{{ name }}: <pre>{{ spec }}</pre></li>
             {% endfor %}
             </ul>
             <pre>{{ error.traceback }}</pre>

--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -12,11 +12,11 @@ from pathlib import Path
 import json
 import re
 
-import html
-
 import jinja2
-from nipype.utils.filemanip import loadcrash, copyfile
+from nipype.utils.filemanip import copyfile
 from pkg_resources import resource_filename as pkgrf
+
+from fmriprep.utils.misc import read_crashfile
 
 
 class Element(object):
@@ -59,13 +59,15 @@ class Report(object):
     """
     The full report object
     """
-    def __init__(self, path, config, out_dir, run_uuid, out_filename='report.html'):
+    def __init__(self, path, config, out_dir, run_uuid, out_filename='report.html',
+                 sentry_sdk=None):
         self.root = path
         self.sections = []
         self.errors = []
         self.out_dir = Path(out_dir)
         self.out_filename = out_filename
         self.run_uuid = run_uuid
+        self.sentry_sdk = sentry_sdk
 
         self._load_config(config)
 
@@ -119,49 +121,48 @@ class Report(object):
 
     def index_error_dir(self, error_dir):
         """
-        Crawl subjects crash directory for the corresponding run and return text for
-        .pklz crash file found.
+        Crawl subjects crash directory for the corresponding run, report to sentry, and
+        populate self.errors.
         """
         for crashfile in error_dir.glob('crash*.*'):
-            if crashfile.suffix == '.pklz':
-                self.errors.append(self._read_pkl(crashfile))
-            elif crashfile.suffix == '.txt':
-                self.errors.append(self._read_txt(crashfile))
+            crash_info = read_crashfile(str(crashfile))
+            if self.sentry_sdk:
+                with self.sentry_sdk.push_scope() as scope:
+                    node_name = crash_info['node'].split('.')[-1]
+                    # last line is probably most informative summary
+                    gist = crash_info['traceback'].split('\n')[-1]
+                    exception_text_start = 1
+                    for line in crash_info['traceback'].split('\n')[1:]:
+                        if not line[0].isspace():
+                            break
+                        exception_text_start += 1
 
-    @staticmethod
-    def _read_pkl(path):
-        fname = str(path)
-        crash_data = loadcrash(fname)
-        data = {'file': fname,
-                'traceback': ''.join(crash_data['traceback']).replace("\\n", "<br />")}
-        if 'node' in crash_data:
-            data['node'] = crash_data['node']
-            if data['node'].base_dir:
-                data['node_dir'] = data['node'].output_dir()
-            else:
-                data['node_dir'] = "Node crashed before execution"
-            data['inputs'] = sorted(data['node'].inputs.trait_get().items())
-        return data
+                    exception_text = '\n'.join(crash_info['traceback'].split('\n')[
+                                     exception_text_start:])
 
-    @staticmethod
-    def _read_txt(path):
-        lines = path.read_text(encoding='UTF-8').splitlines()
-        data = {'file': str(path)}
-        traceback_start = 0
-        if lines[0].startswith('Node'):
-            data['node'] = lines[0].split(': ', 1)[1]
-            data['node_dir'] = lines[1].split(': ', 1)[1]
-            inputs = []
-            for i, line in enumerate(lines[5:], 5):
-                if not line:
-                    traceback_start = i + 1
-                    break
-                inputs.append(tuple(map(html.escape, line.split(' = ', 1))))
-            data['inputs'] = sorted(inputs)
-        else:
-            data['node_dir'] = "Node crashed before execution"
-        data['traceback'] = '\n'.join(lines[traceback_start:])
-        return data
+                    scope.set_tag("node_name", node_name)
+                    for k, v in crash_info.items():
+                        if k == 'inputs':
+                            scope.set_extra(k, dict(v))
+                        else:
+                            scope.set_extra(k, v)
+                    scope.level = 'fatal'
+                    message = node_name + ': ' + gist + '\n\n' + exception_text
+
+                    # remove file paths
+                    fingerprint = re.sub(r"(/[^/ ]*)+/?",'', message)
+                    # remove words containing numbers
+                    fingerprint = re.sub(r"([a-zA-Z]*[0-9]+[a-zA-Z]*)+", '', fingerprint)
+                    # adding the return code if it exists
+                    for line in message.split('\n'):
+                        if line.startswith("Return code"):
+                            fingerprint += line
+                            break
+
+                    scope.fingerprint = [fingerprint]
+                    self.sentry_sdk.capture_message(message, 'fatal')
+
+            self.errors.append(crash_info)
 
     def generate_report(self):
         logs_path = self.out_dir / 'fmriprep' / 'logs'
@@ -271,7 +272,7 @@ def generate_name_title(filename):
     return name.strip('_'), title
 
 
-def run_reports(reportlets_dir, out_dir, subject_label, run_uuid):
+def run_reports(reportlets_dir, out_dir, subject_label, run_uuid, sentry_sdk=None):
     """
     Runs the reports
 
@@ -298,17 +299,18 @@ def run_reports(reportlets_dir, out_dir, subject_label, run_uuid):
     config = pkgrf('fmriprep', 'viz/config.json')
 
     out_filename = 'sub-{}.html'.format(subject_label)
-    report = Report(reportlet_path, config, out_dir, run_uuid, out_filename)
+    report = Report(reportlet_path, config, out_dir, run_uuid, out_filename, sentry_sdk=sentry_sdk)
     return report.generate_report()
 
 
-def generate_reports(subject_list, output_dir, work_dir, run_uuid):
+def generate_reports(subject_list, output_dir, work_dir, run_uuid, sentry_sdk=None):
     """
     A wrapper to run_reports on a given ``subject_list``
     """
     reports_dir = str(Path(work_dir) / 'reportlets')
     report_errors = [
-        run_reports(reports_dir, output_dir, subject_label, run_uuid=run_uuid)
+        run_reports(reports_dir, output_dir, subject_label, run_uuid=run_uuid,
+                    sentry_sdk=sentry_sdk)
         for subject_label in subject_list
     ]
 
@@ -316,8 +318,9 @@ def generate_reports(subject_list, output_dir, work_dir, run_uuid):
     if errno:
         import logging
         logger = logging.getLogger('cli')
-        logger.warning(
-            'Errors occurred while generating reports for participants: %s.',
-            ', '.join(['%s (%d)' % (subid, err)
-                       for subid, err in zip(subject_list, report_errors)]))
+        error_list = ', '.join(['%s (%d)' % (subid, err) for subid, err in zip(subject_list,
+                                                                               report_errors)])
+        logger.error('Preprocessing did not finish successfully. Errors occurred while processing '
+                     'data from participants: %s. Check the HTML reports for details.' %
+                     error_list)
     return errno

--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -150,7 +150,7 @@ class Report(object):
                     message = node_name + ': ' + gist + '\n\n' + exception_text
 
                     # remove file paths
-                    fingerprint = re.sub(r"(/[^/ ]*)+/?",'', message)
+                    fingerprint = re.sub(r"(/[^/ ]*)+/?", '', message)
                     # remove words containing numbers
                     fingerprint = re.sub(r"([a-zA-Z]*[0-9]+[a-zA-Z]*)+", '', fingerprint)
                     # adding the return code if it exists

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -682,7 +682,6 @@ def _maskroi(in_mask, roi_file):
     import numpy as np
     import nibabel as nb
     from nipype.utils.filemanip import fname_presuffix
-    failme
 
     roi = nb.load(roi_file)
     roidata = roi.get_data().astype(np.uint8)

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -682,6 +682,7 @@ def _maskroi(in_mask, roi_file):
     import numpy as np
     import nibabel as nb
     from nipype.utils.filemanip import fname_presuffix
+    failme
 
     roi = nb.load(roi_file)
     roidata = roi.get_data().astype(np.uint8)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ niworkflows==0.4.4
 grabbit==0.2.3
 pybids==0.6.5
 versioneer
+git+https://github.com/nipy/nipype.git@67d6212a9cabd395ee74f7818d09d8ea6c8426a4#egg=nipype


### PR DESCRIPTION
- Supersedes #1375 and closes #1367
- Fixes an issue with parsing crashfiles of Function interfaces
- Switches to the new sentry SDK (closes #1380) which is graceful when network is down (closes #1202)
- Logs sentry errors when stop on first crash is not enabled
- Improves grouping of sentry errors (closes #1362)
- Makes final message more explicit when errors were detected
- Minor tweaks in formatting errors in HTML reports