### PR TITLE
[ENH] Use standard T2* map as coregistration target

### DIFF
--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -117,7 +117,7 @@ def init_fmriprep_wf(subject_list, task_id, echo_idx, run_uuid, work_dir, output
             Treat multiple sessions as longitudinal (may increase runtime)
             See sub-workflows for specific differences
         t2s_coreg : bool
-            Use multiple BOLD echos to create T2*-map for T2*-driven coregistration
+            For multi-echo EPI, used the calculated T2*-map for T2*-driven coregistration
         omp_nthreads : int
             Maximum number of threads an individual process may use
         skull_strip_template : str
@@ -309,7 +309,7 @@ def init_single_subject_wf(subject_id, task_id, echo_idx, name, reportlets_dir, 
             Treat multiple sessions as longitudinal (may increase runtime)
             See sub-workflows for specific differences
         t2s_coreg : bool
-            Use multiple BOLDS echos to create T2*-map for T2*-driven coregistration
+            For multi-echo EPI, used the calculated T2*-map for T2*-driven coregistration
         omp_nthreads : int
             Maximum number of threads an individual process may use
         skull_strip_template : str

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -117,7 +117,7 @@ def init_fmriprep_wf(subject_list, task_id, echo_idx, run_uuid, work_dir, output
             Treat multiple sessions as longitudinal (may increase runtime)
             See sub-workflows for specific differences
         t2s_coreg : bool
-            For multi-echo EPI, used the calculated T2*-map for T2*-driven coregistration
+            For multi-echo EPI, use the calculated T2*-map for T2*-driven coregistration
         omp_nthreads : int
             Maximum number of threads an individual process may use
         skull_strip_template : str
@@ -309,7 +309,7 @@ def init_single_subject_wf(subject_id, task_id, echo_idx, name, reportlets_dir, 
             Treat multiple sessions as longitudinal (may increase runtime)
             See sub-workflows for specific differences
         t2s_coreg : bool
-            For multi-echo EPI, used the calculated T2*-map for T2*-driven coregistration
+            For multi-echo EPI, use the calculated T2*-map for T2*-driven coregistration
         omp_nthreads : int
             Maximum number of threads an individual process may use
         skull_strip_template : str

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -100,7 +100,7 @@ def init_func_preproc_wf(bold_file, ignore, freesurfer,
             When using ``t2s_coreg``, BBR will be enabled by default unless
             explicitly specified otherwise.
         t2s_coreg : bool
-            Use multiple BOLD echos to create T2*-map for T2*-driven coregistration
+            For multiecho EPI, use the calculated T2*-map for T2*-driven coregistration
         bold2t1w_dof : 6, 9 or 12
             Degrees-of-freedom for BOLD-T1w registration
         reportlets_dir : str
@@ -497,6 +497,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         bold_t2s_wf = init_bold_t2s_wf(echo_times=tes,
                                        mem_gb=mem_gb['resampled'],
                                        omp_nthreads=omp_nthreads,
+                                       t2s_coreg=t2s_coreg,
                                        name='bold_t2smap_wf')
 
         workflow.connect([

--- a/fmriprep/workflows/bold/t2s.py
+++ b/fmriprep/workflows/bold/t2s.py
@@ -73,7 +73,7 @@ decay model with log-linear regression.
 For each voxel, the maximal number of echoes with reliable signal in that voxel were
 used to fit the model.
 The calculated T2* map was then used to optimally combine preprocessed BOLD across
-echoes following the method described in @posse_t2s.
+echoes following the method described in [@posse_t2s].
 The optimally combined time series was carried forward as the *preprocessed BOLD*{}.
 """.format('' if not t2s_coreg else ', and the T2* map was also retained as the BOLD reference')
 

--- a/fmriprep/workflows/bold/t2s.py
+++ b/fmriprep/workflows/bold/t2s.py
@@ -89,7 +89,7 @@ the BOLD reference.
     workflow.connect([
         (inputnode, t2smap_node, [('bold_file', 'in_files')]),
         (t2smap_node, outputnode, [('optimal_comb', 'bold')]),
-        (t2smap_node, skullstrip_t2smap_wf, [('t2star_adaptive_map', 'inputnode.in_file')]),
+        (t2smap_node, skullstrip_t2smap_wf, [('t2star_map', 'inputnode.in_file')]),
         (skullstrip_t2smap_wf, outputnode, [
             ('outputnode.mask_file', 'bold_mask'),
             ('outputnode.skull_stripped_file', 'bold_ref_brain')]),

--- a/fmriprep/workflows/bold/t2s.py
+++ b/fmriprep/workflows/bold/t2s.py
@@ -73,9 +73,9 @@ decay model with log-linear regression.
 For each voxel, the maximal number of echoes with reliable signal in that voxel were
 used to fit the model.
 The calculated T2* map was then used to optimally combine preprocessed BOLD across
-echoes following the method described in @posse_t2s. The optimally combined time
-series was carried forward as the *preprocessed BOLD*{}.
-""".format('.' if not t2s_coreg else ', and the T2* map was also retained as the BOLD reference')
+echoes following the method described in @posse_t2s.
+The optimally combined time series was carried forward as the *preprocessed BOLD*{}.
+""".format('' if not t2s_coreg else ', and the T2* map was also retained as the BOLD reference')
 
     inputnode = pe.Node(niu.IdentityInterface(fields=['bold_file']), name='inputnode')
 

--- a/fmriprep/workflows/bold/t2s.py
+++ b/fmriprep/workflows/bold/t2s.py
@@ -67,22 +67,15 @@ def init_bold_t2s_wf(echo_times, mem_gb, omp_nthreads,
 
     """
     workflow = Workflow(name=name)
-    desc = """\
-A T2* map was estimated from preprocessed BOLD by fitting to a
-monoexponential signal decay model with log-linear regression.
-For each voxel, the maximal number of echoes with high signal in that voxel was
+    workflow.__desc__ = """\
+A T2* map was estimated from the preprocessed BOLD by fitting to a monoexponential signal
+decay model with log-linear regression.
+For each voxel, the maximal number of echoes with reliable signal in that voxel were
 used to fit the model.
 The calculated T2* map was then used to optimally combine preprocessed BOLD across
-echoes following the method described in @posse_t2s
-"""
-
-    desc += """\
-and was also retained as the BOLD reference.
-""" if t2s_coreg else """\
-.
-"""
-
-    workflow.__desc__ = desc
+echoes following the method described in @posse_t2s. The optimally combined time
+series was carried forward as the *preprocessed BOLD*{}.
+""".format('.' if not t2s_coreg else ', and the T2* map was also retained as the BOLD reference')
 
     inputnode = pe.Node(niu.IdentityInterface(fields=['bold_file']), name='inputnode')
 


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->

For MEEPI, changes the T2* map target from the adaptive to the standard T2* map. This updates the coregistration target in the case of `--t2s-coreg` and seems to produce more consistent alignment.

I have also updated the docstring for the `t2s_coreg` argument in all relevant workflows and updated the workflow description for `bold_t2s_wf`.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->

The workflow description will need review to ensure its correctness. 


<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
