### PR TITLE
ENH: Handle FreeSurfer subject directory preparation gracefully when run in parallel

### DIFF
--- a/fmriprep/interfaces/bids.py
+++ b/fmriprep/interfaces/bids.py
@@ -373,7 +373,11 @@ class BIDSFreeSurferDir(SimpleInterface):
             if os.path.exists(dest) and self.inputs.overwrite_fsaverage:
                 rmtree(dest)
             if not os.path.exists(dest):
-                copytree(source, dest)
+                try:
+                    copytree(source, dest)
+                except FileExistsError:
+                    LOGGER.warn("{} exists; if multiple jobs are running in parallel, this can be "
+                                "safely ignored.".format(dest))
 
         return runtime
 

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -173,7 +173,7 @@ def init_fmriprep_wf(subject_list, task_id, run_uuid, work_dir, output_dir, bids
                 derivatives=output_dir,
                 freesurfer_home=os.getenv('FREESURFER_HOME'),
                 spaces=output_spaces),
-            name='fsdir-run-' + run_uuid, run_without_submitting=True)
+            name='fsdir_run_' + run_uuid.replace('-', '_'), run_without_submitting=True)
 
     reportlets_dir = os.path.join(work_dir, 'reportlets')
     for subject_id in subject_list:

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -173,7 +173,7 @@ def init_fmriprep_wf(subject_list, task_id, run_uuid, work_dir, output_dir, bids
                 derivatives=output_dir,
                 freesurfer_home=os.getenv('FREESURFER_HOME'),
                 spaces=output_spaces),
-            name='fsdir', run_without_submitting=True)
+            name='fsdir-run-' + run_uuid, run_without_submitting=True)
 
     reportlets_dir = os.path.join(work_dir, 'reportlets')
     for subject_id in subject_list:


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

* Add run UUID to FreeSurfer subjects directory preparation node, to avoid multiple instances with a shared working directory from interfering with one another.
* Catch `FileExistsError` from `shutil.copytree` to ensure that parallel runs don't cause crashes when racing on `os.path.exists`.

Closes #1410.

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
