### PR TITLE
[ENH] Sentry event categorization propagation

### DIFF
--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -279,14 +279,10 @@ def main():
             if 'breadcrumbs' in event and isinstance(event['breadcrumbs'], list):
                 fingerprints_to_propagate = ['no-disk-space', 'memory-error', 'permission-denied',
                                              'keyboard-interrupt']
-                for bc in [b for b in event['breadcrumbs'] if 'message' in b]:
-                    break_outer = False
-                    for fp in fingerprints_to_propagate:
-                        if bc['message'] == fp:
-                            event['fingerprint'] = [fp]
-                            break_outer = True
-                            break
-                    if break_outer:
+                for bc in event['breadcrumbs']:
+                    msg = bc.get('message', 'empty-msg')
+                    if msg in fingerprints_to_propagate:
+                        event['fingerprint'] = [msg]
                         break
 
             return event

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -275,8 +275,21 @@ def main():
                     return None
                 elif re.match("Node .+ failed to run on host .+", msg):
                     return None
-            else:
-                return event
+
+            if 'breadcrumbs' in event and isinstance(event['breadcrumbs'], list):
+                fingerprints_to_propagate = ['no-disk-space', 'memory-error', 'permission-denied',
+                                             'keyboard-interrupt']
+                for bc in [b for b in event['breadcrumbs'] if 'message' in b]:
+                    break_outer = False
+                    for fp in fingerprints_to_propagate:
+                        if bc['message'] == fp:
+                            event['fingerprint'] = [fp]
+                            break_outer = True
+                            break
+                    if break_outer:
+                        break
+
+            return event
 
         sentry_sdk.init("https://d5a16b0c38d84d1584dfc93b9fb1ade6@sentry.io/1137693",
                         release=release,

--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -156,15 +156,14 @@ class Report(object):
                     scope.level = 'fatal'
 
                     # Group common events with pre specified fingerprints
-                    fingerprint_dict = {'permission-denied': ["PermissionError: [Errno 13] "
-                                                              "Permission denied"],
+                    fingerprint_dict = {'permission-denied': [
+                                            "PermissionError: [Errno 13] Permission denied"],
                                         'memory-error': ["MemoryError", "Cannot allocate memory"],
-                                        'reconall-already-running': ["ERROR: it appears that "
-                                                                     "recon-all is already "
-                                                                     "running"],
-                                        'no-disk-space': ["OSError: [Errno 28] No space left on "
-                                                          "device", "[Errno 122] Disk quota "
-                                                                    "exceeded"],
+                                        'reconall-already-running': [
+                                            "ERROR: it appears that recon-all is already running"],
+                                        'no-disk-space': [
+                                            "OSError: [Errno 28] No space left on device",
+                                            "[Errno 122] Disk quota exceeded"],
                                         'sigkill': ["Return code: 137"],
                                         'keyboard-interrupt': ["KeyboardInterrupt"]}
 

--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -181,7 +181,9 @@ class Report(object):
 
                     message = issue_title + '\n\n'
                     message += exception_text[-(8192-len(message)):]
-                    if not fingerprint:
+                    if fingerprint:
+                        self.sentry_sdk.add_breadcrumb(fingerprint, 'fatal')
+                    else:
                         # remove file paths
                         fingerprint = re.sub(r"(/[^/ ]*)+/?", '', message)
                         # remove words containing numbers

--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -165,7 +165,8 @@ class Report(object):
                                         'no-disk-space': ["OSError: [Errno 28] No space left on "
                                                           "device", "[Errno 122] Disk quota "
                                                                     "exceeded"],
-                                        'sigkill': ["Return code: 137"]}
+                                        'sigkill': ["Return code: 137"],
+                                        'keyboard-interrupt': ["KeyboardInterrupt"]}
 
                     fingerprint = ''
                     issue_title = node_name + ': ' + gist

--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -153,7 +153,8 @@ class Report(object):
                                                               "Permission denied"],
                                         'memory-error': ["MemoryError", "Cannot allocate memory"],
                                         'reconall-already-running': ["ERROR: it appears that "
-                                                                     "recon-all is already running"],
+                                                                     "recon-all is already "
+                                                                     "running"],
                                         'no-disk-space': ["OSError: [Errno 28] No space left on "
                                                           "device", "[Errno 122] Disk quota "
                                                                     "exceeded"],

--- a/fmriprep/viz/reports.py
+++ b/fmriprep/viz/reports.py
@@ -178,7 +178,8 @@ class Report(object):
                         if fingerprint:
                             break
 
-                    message = issue_title + '\n\n' + exception_text[-(8192-len(message)):]
+                    message = issue_title + '\n\n'
+                    message += exception_text[-(8192-len(message)):]
                     if not fingerprint:
                         # remove file paths
                         fingerprint = re.sub(r"(/[^/ ]*)+/?", '', message)

--- a/fmriprep/workflows/bold/hmc.py
+++ b/fmriprep/workflows/bold/hmc.py
@@ -73,7 +73,7 @@ parameters) are estimated before any spatiotemporal filtering using
         name='outputnode')
 
     # Head motion correction (hmc)
-    mcflirt = pe.Node(fsl.MCFLIRT(save_mats=True, save_plots=True, args="sdfsdf"),
+    mcflirt = pe.Node(fsl.MCFLIRT(save_mats=True, save_plots=True),
                       name='mcflirt', mem_gb=mem_gb * 3)
 
     fsl2itk = pe.Node(MCFLIRT2ITK(), name='fsl2itk',

--- a/fmriprep/workflows/bold/hmc.py
+++ b/fmriprep/workflows/bold/hmc.py
@@ -73,7 +73,7 @@ parameters) are estimated before any spatiotemporal filtering using
         name='outputnode')
 
     # Head motion correction (hmc)
-    mcflirt = pe.Node(fsl.MCFLIRT(save_mats=True, save_plots=True),
+    mcflirt = pe.Node(fsl.MCFLIRT(save_mats=True, save_plots=True, args="sdfsdf"),
                       name='mcflirt', mem_gb=mem_gb * 3)
 
     fsl2itk = pe.Node(MCFLIRT2ITK(), name='fsl2itk',


### PR DESCRIPTION
This update builds on top of #1418 and adds fingerprint propagation for certain events. In other words, if say memory error was raised during a run all events raised for that run will be marked as memory errors. This should limit noise and group side effects with common causes.