### PR TITLE
[ENH] Copy BibTeX file to log directory for LaTeX users

### DIFF
--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -1,6 +1,7 @@
 fmriprep
 fmriprep/dataset_description.json
 fmriprep/logs
+fmriprep/logs/CITATION.bib
 fmriprep/logs/CITATION.html
 fmriprep/logs/CITATION.md
 fmriprep/logs/CITATION.tex

--- a/.circleci/ds005_partial_outputs.txt
+++ b/.circleci/ds005_partial_outputs.txt
@@ -1,6 +1,7 @@
 fmriprep
 fmriprep/dataset_description.json
 fmriprep/logs
+fmriprep/logs/CITATION.bib
 fmriprep/logs/CITATION.html
 fmriprep/logs/CITATION.md
 fmriprep/logs/CITATION.tex

--- a/.circleci/ds054_outputs.txt
+++ b/.circleci/ds054_outputs.txt
@@ -1,6 +1,7 @@
 fmriprep
 fmriprep/dataset_description.json
 fmriprep/logs
+fmriprep/logs/CITATION.bib
 fmriprep/logs/CITATION.html
 fmriprep/logs/CITATION.md
 fmriprep/logs/CITATION.tex

--- a/.circleci/ds210_outputs.txt
+++ b/.circleci/ds210_outputs.txt
@@ -1,6 +1,7 @@
 fmriprep
 fmriprep/dataset_description.json
 fmriprep/logs
+fmriprep/logs/CITATION.bib
 fmriprep/logs/CITATION.html
 fmriprep/logs/CITATION.md
 fmriprep/logs/CITATION.tex

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -99,6 +99,11 @@
       "orcid": "0000-0001-7936-9991"
     },
     {
+      "name": "Stojic, Hrvoje",
+      "affiliation": "University College London",
+      "orcid": "0000-0002-9699-9052"
+    },
+    {
       "name": "Poldrack, Russell A.",
       "affiliation": "Department of Psychology, Stanford University",
       "orcid": "0000-0001-6755-0259"

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -550,6 +550,7 @@ def build_workflow(opts, retval):
     """
     from subprocess import check_call, CalledProcessError, TimeoutExpired
     from pkg_resources import resource_filename as pkgrf
+    from shutil import copyfile
 
     from nipype import logging, config as ncfg
     from ..__about__ import __version__
@@ -764,6 +765,7 @@ def build_workflow(opts, retval):
            '-o', str(logs_path / 'CITATION.tex')]
     try:
         check_call(cmd, timeout=10)
+        copyfile(pkgrf('fmriprep', 'data/boilerplate.bib'), str(logs_path / 'CITATION.bib'))
     except (FileNotFoundError, CalledProcessError, TimeoutExpired):
         logger.warning('Could not generate CITATION.tex file:\n%s',
                        ' '.join(cmd))


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

This PR is in response to #1444 

It copyies the `boilerplate.bib` file to logs folder together with other CITATION files as `CITATION.bib`, using `shutil.copyfile`.
