### PR TITLE
[FIX] Avoid warning when generating boilerplate

### DIFF
--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -753,7 +753,7 @@ def build_workflow(opts, retval):
         cmd = ['pandoc', '-s', '--bibliography',
                pkgrf('fmriprep', 'data/boilerplate.bib'),
                '--filter', 'pandoc-citeproc',
-               '--metadata', 'title="fMRIPrep citation boilerplate"',
+               '--metadata', 'pagetitle="fMRIPrep citation boilerplate"',
                str(logs_path / 'CITATION.md'),
                '-o', str(logs_path / 'CITATION.html')]
         try:

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -753,6 +753,7 @@ def build_workflow(opts, retval):
         cmd = ['pandoc', '-s', '--bibliography',
                pkgrf('fmriprep', 'data/boilerplate.bib'),
                '--filter', 'pandoc-citeproc',
+               '--metadata', 'title="fMRIPrep citation boilerplate"',
                str(logs_path / 'CITATION.md'),
                '-o', str(logs_path / 'CITATION.html')]
         try:


### PR DESCRIPTION
This warning would still happen even if we do not print the boilerplate out (which was planned to be done).