### PR TITLE
[ENH] More advanced heuristics for finding out echo train length

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -104,6 +104,11 @@
       "orcid": "0000-0002-9699-9052"
     },
     {
+      "name": "de Hollander, Gilles",
+      "affiliation": "Department of Experimental and Applied Psychology, Vrije Universiteit Amsterdam",
+      "orcid": "0000-0003-1988-5091"
+    },
+    {
       "name": "Poldrack, Russell A.",
       "affiliation": "Department of Psychology, Stanford University",
       "orcid": "0000-0001-6755-0259"

--- a/fmriprep/interfaces/fmap.py
+++ b/fmriprep/interfaces/fmap.py
@@ -419,7 +419,10 @@ def _get_etl(in_meta):
     # Prefer metadata over size of the nifti file (Philips data can have
     # different number of acquired versus reconstructed k-space lines
     # see https://github.com/poldracklab/fmriprep/issues/1029 )
-    etl = int(in_meta.get('EPIFactor', etl))
+    if 'EPIFactor' in in_meta:
+        etl = in_meta.get('EPIFactor') + 1 # ETL is EPIFactor + 1 for Philips
+
+    # Not part of the BIDS spec now
     etl = int(in_meta.get('EchoTrainLength', etl))
 
     return etl

--- a/fmriprep/interfaces/fmap.py
+++ b/fmriprep/interfaces/fmap.py
@@ -323,7 +323,7 @@ def get_ees(in_meta, in_file=None):
         return ees
 
     # All other cases require the parallel acc and npe (N vox in PE dir)
-    etl = _get_etl(in_meta)
+    etl = _get_etl(in_meta, in_file)
 
     # Use case 2: TRT is defined
     trt = in_meta.get('TotalReadoutTime', None)
@@ -391,7 +391,7 @@ def get_trt(in_meta, in_file=None):
         return trt
 
     # All other cases require the parallel acc and npe (N vox in PE dir)
-    etl = _get_etl(in_meta)
+    etl = _get_etl(in_meta, in_file)
 
     # Use case 2: TRT is defined
     ees = in_meta.get('EffectiveEchoSpacing', None)
@@ -409,7 +409,7 @@ def get_trt(in_meta, in_file=None):
 
     raise ValueError('Unknown total-readout time specification')
 
-def _get_etl(in_meta):
+def _get_etl(in_meta, in_file):
 
     acc = float(in_meta.get('ParallelReductionFactorInPlane', 1.0))
     npe = nb.load(in_file).shape[_get_pe_index(in_meta)]

--- a/fmriprep/interfaces/fmap.py
+++ b/fmriprep/interfaces/fmap.py
@@ -322,7 +322,6 @@ def get_ees(in_meta, in_file=None):
     if ees is not None:
         return ees
 
-
     # All other cases require the parallel acc and npe (N vox in PE dir)
     etl = _get_etl(in_meta)
 

--- a/fmriprep/interfaces/fmap.py
+++ b/fmriprep/interfaces/fmap.py
@@ -322,10 +322,9 @@ def get_ees(in_meta, in_file=None):
     if ees is not None:
         return ees
 
+
     # All other cases require the parallel acc and npe (N vox in PE dir)
-    acc = float(in_meta.get('ParallelReductionFactorInPlane', 1.0))
-    npe = nb.load(in_file).shape[_get_pe_index(in_meta)]
-    etl = npe // acc
+    etl = _get_etl(in_meta)
 
     # Use case 2: TRT is defined
     trt = in_meta.get('TotalReadoutTime', None)
@@ -393,9 +392,7 @@ def get_trt(in_meta, in_file=None):
         return trt
 
     # All other cases require the parallel acc and npe (N vox in PE dir)
-    acc = float(in_meta.get('ParallelReductionFactorInPlane', 1.0))
-    npe = nb.load(in_file).shape[_get_pe_index(in_meta)]
-    etl = npe // acc
+    etl = _get_etl(in_meta)
 
     # Use case 2: TRT is defined
     ees = in_meta.get('EffectiveEchoSpacing', None)
@@ -413,6 +410,19 @@ def get_trt(in_meta, in_file=None):
 
     raise ValueError('Unknown total-readout time specification')
 
+def _get_etl(in_meta):
+
+    acc = float(in_meta.get('ParallelReductionFactorInPlane', 1.0))
+    npe = nb.load(in_file).shape[_get_pe_index(in_meta)]
+    etl = npe // acc
+
+    # Prefer metadata over size of the nifti file (Philips data can have
+    # different number of acquired versus reconstructed k-space lines
+    # see https://github.com/poldracklab/fmriprep/issues/1029 )
+    etl = int(in_meta.get('EPIFactor', etl))
+    etl = int(in_meta.get('EchoTrainLength', etl))
+
+    return etl
 
 def _get_pe_index(meta):
     pe = meta['PhaseEncodingDirection']


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request
This pull request slightly changes the heuristics for finding the echo train length, taking into account that the length of the phase-encoding dimension in a nifti-file (or DICOM) is not necessarily the same as that of the acquired data. There can be a difference between the acquired and reconstructed matrix.

See also issue https://github.com/poldracklab/fmriprep/issues/1029
<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
None


<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
