### PR TITLE
[MAINT] Update sentry-sdk

### DIFF
--- a/fmriprep/__about__.py
+++ b/fmriprep/__about__.py
@@ -125,7 +125,7 @@ EXTRA_REQUIRES = {
     ],
     'duecredit': ['duecredit'],
     'resmon': [],
-    'sentry': ['sentry-sdk>=0.5.3'],
+    'sentry': ['sentry-sdk>=0.6.9'],
     'tests': TESTS_REQUIRES,
 }
 EXTRA_REQUIRES['docs'] = EXTRA_REQUIRES['doc']


### PR DESCRIPTION
> Fix a bug where a crashing `before_send` would crash the SDK and app.