### PR TITLE
FIX: Set TemplateFlow directory world-writeable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,10 +160,8 @@ ENV TEMPLATEFLOW_HOME="/opt/templateflow"
 RUN pip install "datalad==0.10.0" && \
     rm -rf ~/.cache/pip
 
-RUN git config --global user.name "First Last" && \
-    git config --global user.email "mail@domain.com"
-
-RUN datalad install -r https://github.com/templateflow/templateflow.git && \
+RUN umask 000 && \
+    datalad install -r https://github.com/templateflow/templateflow.git && \
     datalad get $TEMPLATEFLOW_HOME/tpl-MNI152NLin2009cAsym/*_T1w.nii.gz \
                 $TEMPLATEFLOW_HOME/tpl-MNI152NLin2009cAsym/*_desc-brain_mask.nii.gz \
                 $TEMPLATEFLOW_HOME/tpl-MNI152NLin2009cAsym/tpl-MNI152NLin2009cAsym_res-02_desc-fMRIPrep_boldref.nii.gz \
@@ -174,6 +172,11 @@ RUN datalad install -r https://github.com/templateflow/templateflow.git && \
                 $TEMPLATEFLOW_HOME/tpl-OASIS30ANTs/tpl-OASIS30ANTs_res-01_desc-brain_mask.nii.gz \
                 $TEMPLATEFLOW_HOME/tpl-OASIS30ANTs/tpl-OASIS30ANTs_res-01_label-brain_probseg.nii.gz \
                 $TEMPLATEFLOW_HOME/tpl-OASIS30ANTs/tpl-OASIS30ANTs_res-01_desc-BrainCerebellumExtraction_mask.nii.gz
+
+# Stop datalad complaining about user info when using templateflow on Singularity
+RUN cd $TEMPLATEFLOW_HOME && \
+    git config user.name "fMRIPrep User" && \
+    git config user.email "mail@domain.tld"
 
 # Installing dev requirements (packages that are not in pypi)
 WORKDIR /src/


### PR DESCRIPTION
## Changes proposed in this pull request

No real way to test this until merged, built and pushed to `poldracklab/fmriprep:unstable` to build a Singularity image off of.

Fixes #1500.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
