### PR TITLE
FIX: Not having ``template`` as one ``--output-space`` crashes fMRIPrep

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -404,11 +404,13 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         # Artifacts resampled in MNI space can only be sinked if they
         # were actually generated. See #1348.
         workflow.connect([
-            ('bold_mni_ref', 'inputnode.bold_mni_ref'),
-            ('bold_mni', 'inputnode.bold_mni'),
-            ('bold_aseg_mni', 'inputnode.bold_aseg_mni'),
-            ('bold_aparc_mni', 'inputnode.bold_aparc_mni'),
-            ('bold_mask_mni', 'inputnode.bold_mask_mni'),
+            (outputnode, func_derivatives_wf, [
+                ('bold_mni_ref', 'inputnode.bold_mni_ref'),
+                ('bold_mni', 'inputnode.bold_mni'),
+                ('bold_aseg_mni', 'inputnode.bold_aseg_mni'),
+                ('bold_aparc_mni', 'inputnode.bold_aparc_mni'),
+                ('bold_mask_mni', 'inputnode.bold_mask_mni'),
+            ]),
         ])
 
     # Generate a tentative boldref

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -389,11 +389,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ('bold_aseg_t1', 'inputnode.bold_aseg_t1'),
             ('bold_aparc_t1', 'inputnode.bold_aparc_t1'),
             ('bold_mask_t1', 'inputnode.bold_mask_t1'),
-            ('bold_mni', 'inputnode.bold_mni'),
-            ('bold_mni_ref', 'inputnode.bold_mni_ref'),
-            ('bold_aseg_mni', 'inputnode.bold_aseg_mni'),
-            ('bold_aparc_mni', 'inputnode.bold_aparc_mni'),
-            ('bold_mask_mni', 'inputnode.bold_mask_mni'),
             ('confounds', 'inputnode.confounds'),
             ('surfaces', 'inputnode.surfaces'),
             ('aroma_noise_ics', 'inputnode.aroma_noise_ics'),
@@ -404,6 +399,17 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ('cifti_variant_key', 'inputnode.cifti_variant_key')
         ]),
     ])
+
+    if 'template' in output_spaces:
+        # Artifacts resampled in MNI space can only be sinked if they
+        # were actually generated. See #1348.
+        workflow.connect([
+            ('bold_mni_ref', 'inputnode.bold_mni_ref'),
+            ('bold_mni', 'inputnode.bold_mni'),
+            ('bold_aseg_mni', 'inputnode.bold_aseg_mni'),
+            ('bold_aparc_mni', 'inputnode.bold_aparc_mni'),
+            ('bold_mask_mni', 'inputnode.bold_mask_mni'),
+        ])
 
     # Generate a tentative boldref
     bold_reference_wf = init_bold_reference_wf(omp_nthreads=omp_nthreads)


### PR DESCRIPTION
This PR checks that ``template`` is in the output spaces list, skipping the connection to datasinks of workflows resampling the BOLD in MNI.

In particular, we were getting (see #1348):
```
AttributeError: 'DynamicTraitedSpec' object has no attribute 'bold_mni_ref'
```

When forwarding the IdentityInterface of the derivatives data sink because it wasn't included within the input fields.