### PR TITLE
ENH: Force compression of derivative NIfTI volumes

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -910,13 +910,14 @@ def init_func_derivatives_wf(bids_root, cifti_output, freesurfer,
             name='ds_bold_t1', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
         ds_bold_t1_ref = pe.Node(
-            DerivativesDataSink(base_directory=output_dir, space='T1w', suffix='boldref'),
+            DerivativesDataSink(base_directory=output_dir, space='T1w', suffix='boldref',
+                                compress=True),
             name='ds_bold_t1_ref', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
 
         ds_bold_mask_t1 = pe.Node(
             DerivativesDataSink(base_directory=output_dir, space='T1w', desc='brain',
-                                suffix='mask'),
+                                suffix='mask', compress=True),
             name='ds_bold_mask_t1', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
         workflow.connect([
@@ -930,11 +931,13 @@ def init_func_derivatives_wf(bids_root, cifti_output, freesurfer,
         ])
         if freesurfer:
             ds_bold_aseg_t1 = pe.Node(DerivativesDataSink(
-                base_directory=output_dir, space='T1w', desc='aseg', suffix='dseg'),
+                base_directory=output_dir, space='T1w', desc='aseg', suffix='dseg',
+                compress=True),
                 name='ds_bold_aseg_t1', run_without_submitting=True,
                 mem_gb=DEFAULT_MEMORY_MIN_GB)
             ds_bold_aparc_t1 = pe.Node(DerivativesDataSink(
-                base_directory=output_dir, space='T1w', desc='aparcaseg', suffix='dseg'),
+                base_directory=output_dir, space='T1w', desc='aparcaseg', suffix='dseg',
+                compress=True),
                 name='ds_bold_aparc_t1', run_without_submitting=True,
                 mem_gb=DEFAULT_MEMORY_MIN_GB)
             workflow.connect([
@@ -953,13 +956,14 @@ def init_func_derivatives_wf(bids_root, cifti_output, freesurfer,
             name='ds_bold_mni', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
         ds_bold_mni_ref = pe.Node(
-            DerivativesDataSink(base_directory=output_dir, space=template, suffix='boldref'),
+            DerivativesDataSink(base_directory=output_dir, space=template, suffix='boldref',
+                                compress=True),
             name='ds_bold_mni_ref', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
 
         ds_bold_mask_mni = pe.Node(
             DerivativesDataSink(base_directory=output_dir, space=template, desc='brain',
-                                suffix='mask'),
+                                suffix='mask', compress=True),
             name='ds_bold_mask_mni', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
         workflow.connect([
@@ -974,11 +978,13 @@ def init_func_derivatives_wf(bids_root, cifti_output, freesurfer,
 
         if freesurfer:
             ds_bold_aseg_mni = pe.Node(DerivativesDataSink(
-                base_directory=output_dir, space=template, desc='aseg', suffix='dseg'),
+                base_directory=output_dir, space=template, desc='aseg', suffix='dseg',
+                compress=True),
                 name='ds_bold_aseg_mni', run_without_submitting=True,
                 mem_gb=DEFAULT_MEMORY_MIN_GB)
             ds_bold_aparc_mni = pe.Node(DerivativesDataSink(
-                base_directory=output_dir, space=template, desc='aparcaseg', suffix='dseg'),
+                base_directory=output_dir, space=template, desc='aparcaseg', suffix='dseg',
+                compress=True),
                 name='ds_bold_aparc_mni', run_without_submitting=True,
                 mem_gb=DEFAULT_MEMORY_MIN_GB)
             workflow.connect([
@@ -1040,7 +1046,8 @@ def init_func_derivatives_wf(bids_root, cifti_output, freesurfer,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
         ds_aroma_mni = pe.Node(
             DerivativesDataSink(base_directory=output_dir, space=template,
-                                desc='smoothAROMAnonaggr', keep_dtype=True),
+                                desc='smoothAROMAnonaggr', keep_dtype=True,
+                                compress=True),
             name='ds_aroma_mni', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
 


### PR DESCRIPTION
## Changes proposed in this pull request

* Add `compress=True` to all volumetric BOLD `DerivativesDataSink`s to ensure that we always produce `.nii.gz` files.

Related: poldracklab/smriprep#80, #1555, poldracklab/niworkflows#356.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
