### PR TITLE
FIX: Mount Nipype config file under new ``$HOME``

### DIFF
--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -396,8 +396,8 @@ def main():
         unknown_args.extend(['-w', '/scratch'])
 
     if opts.config:
-        command.extend(['-v', ':'.join((opts.config,
-                                        '/root/.nipype/nipype.cfg', 'ro'))])
+        command.extend(['-v', ':'.join((
+            opts.config, '/home/fmriprep/.nipype/nipype.cfg', 'ro'))])
 
     if opts.use_plugin:
         command.extend(['-v', ':'.join((opts.use_plugin, '/tmp/plugin.yml',


### PR DESCRIPTION
When ``$HOME`` was changed to ``/home/fmriprep`` for Docker images I
missed updating the mount point of the wrapper.

This PR addresses that issue.
