### PR TITLE
CI: Use caches to pass data between jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             apk add --no-cache pigz python3
       - restore_cache:
           keys:
-            - docker-v3-{{ .Branch }}-{{ epoch }}
+            - docker-v3-{{ .Branch }}-{{ .Revision }}
             - docker-v3-{{ .Branch }}-
             - docker-v3-master-
             - docker-v3-
@@ -73,7 +73,7 @@ jobs:
           paths:
             - src/fmriprep
       - save_cache:
-         key: docker-v3-{{ .Branch }}-{{ epoch }}
+         key: docker-v3-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
          paths:
             - /tmp/cache/docker.tar.gz
 
@@ -85,7 +85,7 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - data-v6-{{ epoch }}
+            - data-v6-{{ .Revision }}
             - data-v6-
       - run:
           name: Get test data from ds000005
@@ -152,7 +152,7 @@ jobs:
             - ds054/nipype.cfg
             - ds210/nipype.cfg
       - save_cache:
-         key: data-v6-{{ epoch }}
+         key: data-v6-{{ .Revision }}-{{ epoch }}
          paths:
             - /tmp/data
             - /tmp/ds005/derivatives/freesurfer
@@ -165,7 +165,7 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - regression-v3-{{ epoch }}
+            - regression-v3-{{ .Revision }}
             - regression-v3-
       - run:
           name: Get truncated BOLD series
@@ -189,7 +189,7 @@ jobs:
               echo "Pre-computed masks were cached"
             fi
       - save_cache:
-         key: regression-v3-{{ epoch }}
+         key: regression-v3-{{ .Revision }}-{{ epoch }}
          paths:
             - /tmp/data
 
@@ -213,10 +213,10 @@ jobs:
           at: /tmp
       - restore_cache:
           keys:
-            - docker-v3-{{ .Branch }}-
+            - docker-v3-{{ .Branch }}-{{ .Revision }}
       - restore_cache:
           keys:
-            - regression-v3-
+            - regression-v3-{{ .Revision }}
       - run:
           name: Load Docker image layer cache
           no_output_timeout: 30m
@@ -330,13 +330,13 @@ jobs:
           at: /tmp
       - restore_cache:
           keys:
-            - docker-v3-{{ .Branch }}-
+            - docker-v3-{{ .Branch }}-{{ .Revision }}
       - restore_cache:
           keys:
-            - data-v6-
+            - data-v6-{{ .Revision }}
       - restore_cache:
           keys:
-            - ds005-anat-v14-{{ .Branch }}-{{ epoch }}
+            - ds005-anat-v14-{{ .Branch }}-{{ .Revision }}
             - ds005-anat-v14-{{ .Branch }}
             - ds005-anat-v14-master
             - ds005-anat-v14-
@@ -380,7 +380,7 @@ jobs:
             rm -rf /tmp/ds005/work/reportlets
             rm -rf /tmp/ds005/derivatives/fmriprep
       - save_cache:
-         key: ds005-anat-v14-{{ .Branch }}-{{ epoch }}
+         key: ds005-anat-v14-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
          paths:
             - /tmp/ds005/work
 
@@ -480,13 +480,13 @@ jobs:
           at: /tmp
       - restore_cache:
           keys:
-            - docker-v3-{{ .Branch }}-
+            - docker-v3-{{ .Branch }}-{{ .Revision }}
       - restore_cache:
           keys:
-            - data-v6-
+            - data-v6-{{ .Revision }}
       - restore_cache:
           keys:
-            - ds054-anat-v12-{{ .Branch }}-{{ epoch }}
+            - ds054-anat-v12-{{ .Branch }}-{{ .Revision }}
             - ds054-anat-v12-{{ .Branch }}
             - ds054-anat-v12-master
             - ds054-anat-v12-
@@ -529,7 +529,7 @@ jobs:
             rm -rf /tmp/ds054/work/reportlets
             rm -rf /tmp/ds054/derivatives/fmriprep
       - save_cache:
-         key: ds054-anat-v12-{{ .Branch }}-{{ epoch }}
+         key: ds054-anat-v12-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
          paths:
             - /tmp/ds054/work
 
@@ -615,14 +615,14 @@ jobs:
           at: /tmp
       - restore_cache:
           keys:
-            - docker-v3-{{ .Branch }}-
+            - docker-v3-{{ .Branch }}-{{ .Revision }}
       - restore_cache:
           keys:
-            - data-v6-
+            - data-v6-{{ .Revision }}
       - restore_cache:
           keys:
-            - ds210-anat-v10-{{ .Branch }}-{{ epoch }}
-            - ds210-anat-v10-{{ .Branch }}
+            - ds210-anat-v10-{{ .Branch }}-{{ .Revision }}
+            - ds210-anat-v10-{{ .Branch }}-
             - ds210-anat-v10-master
             - ds210-anat-v10-
       - run:
@@ -664,7 +664,7 @@ jobs:
             rm -rf /tmp/ds210/work/reportlets
             rm -rf /tmp/ds210/derivatives/fmriprep
       - save_cache:
-         key: ds210-anat-v10-{{ .Branch }}-{{ epoch }}
+         key: ds210-anat-v10-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
          paths:
             - /tmp/ds210/work
 
@@ -710,7 +710,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - docker-v3-{{ .Branch }}-
+            - docker-v3-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Load Docker image layer cache
           no_output_timeout: 30m
@@ -739,7 +739,7 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - docker-v3-{{ .Branch }}-
+            - docker-v3-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Load Docker image layer cache
           no_output_timeout: 30m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,11 @@ jobs:
       - persist_to_workspace:
           root: /tmp
           paths:
-            - cache/docker.tar.gz
             - src/fmriprep
+      - save_cache:
+         key: docker-v3-{{ .Branch }}-{{ epoch }}
+         paths:
+            - /tmp/cache/docker.tar.gz
 
   get_data:
     machine:
@@ -144,10 +147,8 @@ jobs:
       - persist_to_workspace:
           root: /tmp
           paths:
-            - data
             - fslicense
             - ds005/nipype.cfg
-            - ds005/derivatives
             - ds054/nipype.cfg
             - ds210/nipype.cfg
       - save_cache:
@@ -187,27 +188,10 @@ jobs:
             else
               echo "Pre-computed masks were cached"
             fi
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-            - data
       - save_cache:
          key: regression-v3-{{ epoch }}
          paths:
             - /tmp/data
-
-  update_cache:
-    machine:
-      # Ubuntu 14.04 with Docker 17.10.0-ce
-      image: circleci/classic:201711-01
-    working_directory: /tmp/src/fmriprep
-    steps:
-      - attach_workspace:
-          at: /tmp
-      - save_cache:
-         key: docker-v3-{{ .Branch }}-{{ epoch }}
-         paths:
-            - /tmp/cache/docker.tar.gz
 
   test_pytest:
     machine:
@@ -227,6 +211,12 @@ jobs:
 
       - attach_workspace:
           at: /tmp
+      - restore_cache:
+          keys:
+            - docker-v3-{{ .Branch }}-
+      - restore_cache:
+          keys:
+            - regression-v3-
       - run:
           name: Load Docker image layer cache
           no_output_timeout: 30m
@@ -338,6 +328,12 @@ jobs:
 
       - attach_workspace:
           at: /tmp
+      - restore_cache:
+          keys:
+            - docker-v3-{{ .Branch }}-
+      - restore_cache:
+          keys:
+            - data-v6-
       - restore_cache:
           keys:
             - ds005-anat-v14-{{ .Branch }}-{{ epoch }}
@@ -484,6 +480,12 @@ jobs:
           at: /tmp
       - restore_cache:
           keys:
+            - docker-v3-{{ .Branch }}-
+      - restore_cache:
+          keys:
+            - data-v6-
+      - restore_cache:
+          keys:
             - ds054-anat-v12-{{ .Branch }}-{{ epoch }}
             - ds054-anat-v12-{{ .Branch }}
             - ds054-anat-v12-master
@@ -613,6 +615,12 @@ jobs:
           at: /tmp
       - restore_cache:
           keys:
+            - docker-v3-{{ .Branch }}-
+      - restore_cache:
+          keys:
+            - data-v6-
+      - restore_cache:
+          keys:
             - ds210-anat-v10-{{ .Branch }}-{{ epoch }}
             - ds210-anat-v10-{{ .Branch }}
             - ds210-anat-v10-master
@@ -700,8 +708,9 @@ jobs:
     working_directory: /tmp/src/fmriprep
     steps:
 
-      - attach_workspace:
-          at: /tmp
+      - restore_cache:
+          keys:
+            - docker-v3-{{ .Branch }}-
       - run:
           name: Load Docker image layer cache
           no_output_timeout: 30m
@@ -728,9 +737,9 @@ jobs:
       image: circleci/classic:201711-01
     working_directory: /tmp/src/fmriprep
     steps:
-
-      - attach_workspace:
-          at: /tmp
+      - restore_cache:
+          keys:
+            - docker-v3-{{ .Branch }}-
       - run:
           name: Load Docker image layer cache
           no_output_timeout: 30m
@@ -933,18 +942,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - /docker\/.*/
-            tags:
-              only: /.*/
-
-      - update_cache:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore:
-                - /docs?\/.*/
-                - /tests?\/.*/
                 - /docker\/.*/
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
           command: |
             mkdir -p /tmp/cache
             docker save ubuntu:xenial-20161213 poldracklab/fmriprep:latest \
-            | pigz -8 -p 3 > /tmp/cache/docker.tar.gz
+            | pigz -3 > /tmp/cache/docker.tar.gz
 
       - persist_to_workspace:
           root: /tmp


### PR DESCRIPTION
This one is fiddling with Circle caches, which we persist anyway, to pass data between jobs. Saving to cache seems to be slightly faster than persisting to the workspace, so this:

1) De-duplicates saving cached/workspace data, choosing the cheaper option.
2) Eliminates the separate `update_cache` job, which persists, reloads and then caches.

The savings of the save/load steps seems to be within the variance of the whole job, so I'm not sure that we'll see much of a speed up (I expect the effect is there, but ~2 minutes in 30-70 minute jobs is not much to brag of. That said, this does eliminate a 7 minute job.

I also experimented with reducing the compression level to 3 and only using 2 threads, and that appears to shave 3-5 minutes off of the save step while not significantly adding to the load step. We can fiddle with this more if there's interest in being systematic.