### PR TITLE
ENH: Reduce BSplineFieldmap memory usage

### DIFF
--- a/fmriprep/utils/bspline.py
+++ b/fmriprep/utils/bspline.py
@@ -38,8 +38,7 @@ class BSplineFieldmap(object):
         self._padding = padding
 
         # Pad data with zeros
-        self._data = np.zeros(tuple(np.array(
-            self._fmapnii.get_data().shape) + 2 * padding))
+        self._data = np.zeros(tuple(np.array(fmapnii.shape) + 2 * padding))
 
         # The list of ijk coordinates
         self._fmapijk = get_ijk(self._data)
@@ -53,13 +52,13 @@ class BSplineFieldmap(object):
         # Set data
         self._data[padding:-padding,
                    padding:-padding,
-                   padding:-padding] = fmapnii.get_data()
+                   padding:-padding] = fmapnii.get_fdata(caching='unchanged')
 
         # Get ijk in homogeneous coords
         ijk_h = np.hstack((self._fmapijk, np.array([1.0] * len(self._fmapijk))[..., np.newaxis]))
 
         # The list of xyz coordinates
-        self._fmapaff = compute_affine(self._data, self._fmapnii.header.get_zooms())
+        self._fmapaff = compute_affine(self._data, fmapnii.header.get_zooms())
         self._fmapxyz = self._fmapaff.dot(ijk_h.T)[:3, :].T
 
         # Mask coordinates


### PR DESCRIPTION
## Changes proposed in this pull request

Was looking at the `maths.pyx` thing to see about splitting it out into its own package. Noticed some `get_data()` uses in `BSplineFieldmap`. `get_data()` is supposed to be being deprecated any day now... and the two calls to it are sub-optimal.

The first can just be replaced by the image shape, which is just read from the header and doesn't require loading the data.

The second can use `get_fdata`, and if we use `caching='unchanged'`, then it won't store a copy of the array internally, so it can get garbage-collected after filling `_data`.

I don't expect this is going to have a significant effect, but just while I was there.

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
