### PR TITLE
FIX: Writing functional derivatives in standard spaces

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -761,7 +761,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         if freesurfer:
             workflow.connect([
                 (bold_std_trans_wf, func_derivatives_wf, [
-                    ('poutputnode.templates', 'inputnode.template'),
                     ('poutputnode.bold_aseg_std', 'inputnode.bold_aseg_std'),
                     ('poutputnode.bold_aparc_std', 'inputnode.bold_aparc_std'),
                 ]),
@@ -808,6 +807,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         # Uses the parameterized outputnode to generate all outputs
         workflow.connect([
             (bold_std_trans_wf, func_derivatives_wf, [
+                ('poutputnode.templates', 'inputnode.template'),
                 ('poutputnode.bold_std_ref', 'inputnode.bold_std_ref'),
                 ('poutputnode.bold_std', 'inputnode.bold_std'),
                 ('poutputnode.bold_mask_std', 'inputnode.bold_mask_std'),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -431,8 +431,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     )
 
     workflow.connect([
-        (inputnode, func_derivatives_wf, [
-            ('template', 'inputnode.template')]),
         (outputnode, func_derivatives_wf, [
             ('bold_t1', 'inputnode.bold_t1'),
             ('bold_t1_ref', 'inputnode.bold_t1_ref'),
@@ -763,6 +761,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         if freesurfer:
             workflow.connect([
                 (bold_std_trans_wf, func_derivatives_wf, [
+                    ('poutputnode.templates', 'inputnode.template'),
                     ('poutputnode.bold_aseg_std', 'inputnode.bold_aseg_std'),
                     ('poutputnode.bold_aparc_std', 'inputnode.bold_aparc_std'),
                 ]),


### PR DESCRIPTION
Fixes #1630.

This PR resolves the situation where the derivatives data sinks received
parameterized inputs from two sources of iterables, with overlapping
names.