### PR TITLE
ENH: Write outputs in native-BOLD space

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,8 +577,7 @@ jobs:
                 --config $PWD/nipype.cfg -w /tmp/ds054/work \
                 /tmp/data/ds054 /tmp/ds054/derivatives participant \
                 --fs-no-reconall --sloppy \
-                --output-space T1w template \
-                --template-resampling-grid 2mm \
+                --output-spaces MNI152NLin2009cAsym:res-2 anat func \
                 --mem_mb 4096 --nthreads 2 -vv
       - run:
           name: Checking outputs of fMRIPrep
@@ -602,8 +601,7 @@ jobs:
                 --config $PWD/nipype.cfg -w /tmp/ds054/work \
                 /tmp/data/ds054 /tmp/ds054/derivatives participant \
                 --fs-no-reconall --sloppy --write-graph \
-                --output-space T1w template \
-                --template-resampling-grid 2mm \
+                --output-spaces MNI152NLin2009cAsym:res-2 anat func \
                 --reports-only --run-uuid $UUID
             RET=$?
             set -e

--- a/.circleci/ds054_outputs.txt
+++ b/.circleci/ds054_outputs.txt
@@ -27,8 +27,13 @@ fmriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_label-CSF_probseg.
 fmriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_label-GM_probseg.nii.gz
 fmriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_label-WM_probseg.nii.gz
 fmriprep/sub-100185/func
+fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_boldref.nii.gz
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_desc-confounds_regressors.json
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_desc-confounds_regressors.tsv
+fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_desc-brain_mask.json
+fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_desc-brain_mask.nii.gz
+fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_desc-preproc_bold.json
+fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_desc-preproc_bold.nii.gz
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_space-MNI152NLin2009cAsym_boldref.nii.gz
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_space-MNI152NLin2009cAsym_desc-brain_mask.json
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz
@@ -39,8 +44,13 @@ fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_space-T1w_desc-brain
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_space-T1w_desc-brain_mask.nii.gz
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_space-T1w_desc-preproc_bold.json
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_space-T1w_desc-preproc_bold.nii.gz
+fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_boldref.nii.gz
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_desc-confounds_regressors.json
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_desc-confounds_regressors.tsv
+fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_desc-brain_mask.json
+fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_desc-brain_mask.nii.gz
+fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_desc-preproc_bold.json
+fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_desc-preproc_bold.nii.gz
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_space-MNI152NLin2009cAsym_boldref.nii.gz
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_space-MNI152NLin2009cAsym_desc-brain_mask.json
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz

--- a/.circleci/ds054_outputs.txt
+++ b/.circleci/ds054_outputs.txt
@@ -28,10 +28,10 @@ fmriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_label-GM_probseg.n
 fmriprep/sub-100185/anat/sub-100185_space-MNI152NLin2009cAsym_label-WM_probseg.nii.gz
 fmriprep/sub-100185/func
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_boldref.nii.gz
-fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_desc-confounds_regressors.json
-fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_desc-confounds_regressors.tsv
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_desc-brain_mask.json
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_desc-brain_mask.nii.gz
+fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_desc-confounds_regressors.json
+fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_desc-confounds_regressors.tsv
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_desc-preproc_bold.json
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_desc-preproc_bold.nii.gz
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_space-MNI152NLin2009cAsym_boldref.nii.gz
@@ -45,10 +45,10 @@ fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_space-T1w_desc-brain
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_space-T1w_desc-preproc_bold.json
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-01_space-T1w_desc-preproc_bold.nii.gz
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_boldref.nii.gz
-fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_desc-confounds_regressors.json
-fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_desc-confounds_regressors.tsv
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_desc-brain_mask.json
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_desc-brain_mask.nii.gz
+fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_desc-confounds_regressors.json
+fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_desc-confounds_regressors.tsv
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_desc-preproc_bold.json
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_desc-preproc_bold.nii.gz
 fmriprep/sub-100185/func/sub-100185_task-machinegame_run-02_space-MNI152NLin2009cAsym_boldref.nii.gz

--- a/docs/spaces.rst
+++ b/docs/spaces.rst
@@ -84,7 +84,11 @@ that do not generate *standardized* coordinate spaces:
     including the ``fsnative`` space will instruct fMRIPrep to sample the
     original BOLD data onto FreeSurfer's reconstructed surfaces for this
     individual.
-  * **Additional nonstandard spaces** which are being discussed
+  * ``func``, ``bold``, ``run``, ``boldref`` or ``sbref`` can be used to
+    generate BOLD data in their original grid, after slice-timing,
+    head-motion, and susceptibility-distortion corrections.
+    These keywords are experimental, and expected to change because
+    **additional nonstandard spaces** are currently being discussed
     `here <https://github.com/poldracklab/fmriprep/issues/1604>`__.
 
 Modifiers are not allowed when providing nonstandard spaces.

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -399,8 +399,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     outputnode = pe.Node(niu.IdentityInterface(
         fields=['bold_t1', 'bold_t1_ref', 'bold_mask_t1', 'bold_aseg_t1', 'bold_aparc_t1',
                 'bold_std', 'bold_std_ref' 'bold_mask_std', 'bold_aseg_std', 'bold_aparc_std',
-                'bold_cifti', 'cifti_variant', 'cifti_variant_key', 'confounds', 'surfaces',
-                'aroma_noise_ics', 'melodic_mix', 'nonaggr_denoised_file',
+                'bold_native', 'bold_cifti', 'cifti_variant', 'cifti_variant_key', 'surfaces',
+                'confounds', 'aroma_noise_ics', 'melodic_mix', 'nonaggr_denoised_file',
                 'confounds_metadata']),
         name='outputnode')
 
@@ -442,6 +442,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ('bold_aseg_t1', 'inputnode.bold_aseg_t1'),
             ('bold_aparc_t1', 'inputnode.bold_aparc_t1'),
             ('bold_mask_t1', 'inputnode.bold_mask_t1'),
+            ('bold_native', 'inputnode.bold_native'),
             ('confounds', 'inputnode.confounds'),
             ('surfaces', 'inputnode.surfaces'),
             ('aroma_noise_ics', 'inputnode.aroma_noise_ics'),
@@ -733,6 +734,15 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 ('outputnode.bold_mask', 'input_image')]),
             (boldmask_to_t1w, outputnode, [
                 ('output_image', 'bold_mask_t1')]),
+        ])
+
+    if set(['func', 'run', 'bold', 'boldref', 'sbref']).intersection(output_spaces):
+        workflow.connect([
+            (bold_bold_trans_wf, outputnode, [
+                ('outputnode.bold', 'bold_native')]),
+            (bold_bold_trans_wf, func_derivatives_wf, [
+                ('outputnode.bold_ref', 'inputnode.bold_native_ref'),
+                ('outputnode.bold_mask', 'inputnode.bold_mask_native')]),
         ])
 
     if volume_std_spaces:

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -72,12 +72,12 @@ def init_func_derivatives_wf(
             name='ds_bold_native', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
         ds_bold_native_ref = pe.Node(
-            DerivativesDataSink(base_directory=output_dir, suffix='boldref'),
+            DerivativesDataSink(base_directory=output_dir, suffix='boldref', compress=True),
             name='ds_bold_native_ref', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
         ds_bold_mask_native = pe.Node(
             DerivativesDataSink(base_directory=output_dir, desc='brain',
-                                suffix='mask'),
+                                suffix='mask', compress=True),
             name='ds_bold_mask_native', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
 

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -100,13 +100,14 @@ def init_func_derivatives_wf(
             name='ds_bold_t1', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
         ds_bold_t1_ref = pe.Node(
-            DerivativesDataSink(base_directory=output_dir, space='T1w', suffix='boldref'),
+            DerivativesDataSink(base_directory=output_dir, space='T1w',
+                                suffix='boldref', compress=True),
             name='ds_bold_t1_ref', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
 
         ds_bold_mask_t1 = pe.Node(
             DerivativesDataSink(base_directory=output_dir, space='T1w', desc='brain',
-                                suffix='mask'),
+                                suffix='mask', compress=True),
             name='ds_bold_mask_t1', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
         workflow.connect([


### PR DESCRIPTION
This PR enables writing data resampled after STC-HMC-SDC in their
original BOLD grid.

Closes #1376.
