### PR TITLE
FIX: Do not set ``TEMPLATEFLOW_HOME``

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,10 +363,10 @@ jobs:
             - data-v6-{{ .Revision }}
       - restore_cache:
           keys:
-            - ds005-anat-v14-{{ .Branch }}-{{ .Revision }}
-            - ds005-anat-v14-{{ .Branch }}
-            - ds005-anat-v14-master
-            - ds005-anat-v14-
+            - ds005-anat-v15-{{ .Branch }}-{{ .Revision }}
+            - ds005-anat-v15-{{ .Branch }}
+            - ds005-anat-v15-master
+            - ds005-anat-v15-
       - run:
           name: Setting up test
           command: |
@@ -408,7 +408,7 @@ jobs:
             rm -rf /tmp/ds005/work/reportlets
             rm -rf /tmp/ds005/derivatives/fmriprep
       - save_cache:
-         key: ds005-anat-v14-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
+         key: ds005-anat-v15-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
          paths:
             - /tmp/ds005/work
 
@@ -519,10 +519,10 @@ jobs:
             - data-v6-{{ .Revision }}
       - restore_cache:
           keys:
-            - ds054-anat-v12-{{ .Branch }}-{{ .Revision }}
-            - ds054-anat-v12-{{ .Branch }}
-            - ds054-anat-v12-master
-            - ds054-anat-v12-
+            - ds054-anat-v13-{{ .Branch }}-{{ .Revision }}
+            - ds054-anat-v13-{{ .Branch }}
+            - ds054-anat-v13-master
+            - ds054-anat-v13-
       - run:
           name: Setting up test
           command: |
@@ -562,7 +562,7 @@ jobs:
             rm -rf /tmp/ds054/work/reportlets
             rm -rf /tmp/ds054/derivatives/fmriprep
       - save_cache:
-         key: ds054-anat-v12-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
+         key: ds054-anat-v13-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
          paths:
             - /tmp/ds054/work
 
@@ -656,10 +656,10 @@ jobs:
             - data-v6-{{ .Revision }}
       - restore_cache:
           keys:
-            - ds210-anat-v10-{{ .Branch }}-{{ .Revision }}
-            - ds210-anat-v10-{{ .Branch }}-
-            - ds210-anat-v10-master
-            - ds210-anat-v10-
+            - ds210-anat-v11-{{ .Branch }}-{{ .Revision }}
+            - ds210-anat-v11-{{ .Branch }}-
+            - ds210-anat-v11-master
+            - ds210-anat-v11-
       - run:
           name: Setting up test
           command: |
@@ -699,7 +699,7 @@ jobs:
             rm -rf /tmp/ds210/work/reportlets
             rm -rf /tmp/ds210/derivatives/fmriprep
       - save_cache:
-         key: ds210-anat-v10-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
+         key: ds210-anat-v11-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
          paths:
             - /tmp/ds210/work
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -161,15 +161,13 @@ RUN python -c "from matplotlib import font_manager" && \
     sed -i 's/\(backend *: \).*$/\1Agg/g' $( python -c "import matplotlib; print(matplotlib.matplotlib_fname())" )
 
 # Precaching atlases
-ENV TEMPLATEFLOW_HOME="/opt/templateflow"
-RUN mkdir -p $TEMPLATEFLOW_HOME
 RUN pip install --no-cache-dir "templateflow>=0.3.0,<0.4.0a0" && \
     python -c "from templateflow import api as tfapi; \
                tfapi.get('MNI152NLin6Asym'); \
                tfapi.get('MNI152NLin2009cAsym'); \
                tfapi.get('OASIS30ANTs');" && \
-    find $TEMPLATEFLOW_HOME -type d -exec chmod go=u {} + && \
-    find $TEMPLATEFLOW_HOME -type f -exec chmod go=u {} +
+    find $HOME/.cache/templateflow -type d -exec chmod go=u {} + && \
+    find $HOME/.cache/templateflow -type f -exec chmod go=u {} +
 
 # Installing FMRIPREP
 COPY . /src/fmriprep

--- a/Dockerfile
+++ b/Dockerfile
@@ -163,8 +163,8 @@ RUN python -c "from matplotlib import font_manager" && \
 # Precaching atlases
 RUN pip install --no-cache-dir "templateflow>=0.3.0,<0.4.0a0" && \
     python -c "from templateflow import api as tfapi; \
-               tfapi.get('MNI152NLin6Asym'); \
-               tfapi.get('MNI152NLin2009cAsym'); \
+               tfapi.get('MNI152NLin6Asym', atlas=None); \
+               tfapi.get('MNI152NLin2009cAsym', atlas=None); \
                tfapi.get('OASIS30ANTs');" && \
     find $HOME/.cache/templateflow -type d -exec chmod go=u {} + && \
     find $HOME/.cache/templateflow -type f -exec chmod go=u {} +


### PR DESCRIPTION
Setting ``$TEMPLATEFLOW_HOME`` within the image [precludes overwriting the variable via ``$SINGULARITYENV_`` exports](https://github.com/sylabs/singularity/issues/2892#issuecomment-500104786).

Additionally, it seems that in some systems (e.g., Sherlock), bound directories do not replace existing directories. That, in practice, led to permission errors when the templates are not pre-cached.

Leaving ``$TEMPLATEFLOW_HOME`` unset will make TemplateFlow use the default path (``$HOME/.cache/templateflow``), which in many systems will be automatically bound and writable.

Therefore, there is little point in setting the variable. This PR also avoids pulling atlases into the Docker image.