### PR TITLE
ENH: Show informative warning for phase1/2 type of fieldmaps

### DIFF
--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -139,7 +139,7 @@ Non-standard spaces (valid keywords: %s) imply specific orientations and samplin
 grids. \
 Important to note, the ``res-*`` modifier does not define the resolution used for \
 the spatial normalization """ % (', '.join('"%s"' % s for s in templates()),
-            ', '.join(NONSTANDARD_REFERENCES)))
+                                 ', '.join(NONSTANDARD_REFERENCES)))
 
     g_conf.add_argument(
         '--output-space', required=False, action='store', type=str, nargs='+',

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -338,9 +338,16 @@ def init_func_preproc_wf(
         # Find fieldmaps. Options: (phase1|phase2|phasediff|epi|fieldmap|syn)
         fmaps = []
         if 'fieldmaps' not in ignore:
-            fmaps = layout.get_fieldmap(ref_file, return_list=True)
-            for fmap in fmaps:
-                fmap['metadata'] = layout.get_metadata(fmap[fmap['suffix']])
+            for fmap in layout.get_fieldmap(ref_file, return_list=True):
+                if fmap['suffix'] == 'phase':
+                    LOGGER.warning("""\
+Found phase1/2 type of fieldmaps, which are not currently supported. \
+fMRIPrep will discard them for susceptibility distortion correction. \
+Please, follow up on this issue at \
+https://github.com/poldracklab/fmriprep/issues/1655.""")
+                else:
+                    fmap['metadata'] = layout.get_metadata(fmap[fmap['suffix']])
+                    fmaps.append(fmap)
 
         # Run SyN if forced or in the absence of fieldmap correction
         if force_syn or (use_syn and not fmaps):


### PR DESCRIPTION
Close #1536

<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

A quick fix to alert users that phase1/2 correction is not yet available.

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->

None


<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
