### PR TITLE
FIX: Use MNI152NLin2009cAsym for SDC if no templates are specified

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -547,8 +547,11 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     bold_sdc_wf = init_sdc_wf(
         fmaps, metadata, omp_nthreads=omp_nthreads,
         debug=debug, fmap_demean=fmap_demean, fmap_bspline=fmap_bspline)
-    bold_sdc_wf.inputs.inputnode.template = 'MNI152NLin2009cAsym' \
-        if 'MNI152NLin2009cAsym' in volume_std_spaces else next(iter(volume_std_spaces))
+    # If no standard space is given, use the default for SyN-SDC
+    if not volume_std_spaces or 'MNI152NLin2009cAsym' in volume_std_spaces:
+        bold_sdc_wf.inputs.inputnode.template = 'MNI152NLin2009cAsym'
+    else:
+        bold_sdc_wf.inputs.inputnode.template = next(iter(volume_std_spaces))
 
     if not fmaps:
         LOGGER.warning('SDC: no fieldmaps found or they were ignored (%s).',


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

This PR will resolve #1675, which fails to identify a template to be used for SDC normalization when no template is specified as an output space.

I'm beginning with the portion that raises the exception, which is simply failure to find an object in an empty container. It may be that doing this is insufficient to ensure that a normalization to the default template is found, and further work will be needed.
<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
