### PR TITLE
FIX: Postpone ``pandoc`` conversion of boilerplate after workflow has fully run

### DIFF
--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -664,7 +664,7 @@ def build_workflow(opts, retval):
 
         citation_files['md'].write_text(boilerplate)
         build_log.log(25, 'Works derived from this fMRIPrep execution should '
-                   'include the following boilerplate:\n\n%s', boilerplate)
+                      'include the following boilerplate:\n\n%s', boilerplate)
     return retval
 
 

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -428,6 +428,8 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
                    '--metadata', 'pagetitle="fMRIPrep citation boilerplate"',
                    str(citation_files['md']),
                    '-o', str(citation_files['html'])]
+
+            logger.info('Generating an HTML version of the citation boilerplate...')
             try:
                 check_call(cmd, timeout=10)
             except (FileNotFoundError, CalledProcessError, TimeoutExpired):
@@ -439,6 +441,7 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
                    pkgrf('fmriprep', 'data/boilerplate.bib'),
                    '--natbib', str(citation_files['md']),
                    '-o', str(citation_files['tex'])]
+            logger.info('Generating a LaTeX version of the citation boilerplate...')
             try:
                 check_call(cmd, timeout=10)
             except (FileNotFoundError, CalledProcessError, TimeoutExpired):
@@ -447,6 +450,10 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
             else:
                 copyfile(pkgrf('fmriprep', 'data/boilerplate.bib'),
                          citation_files['bib'])
+        else:
+            logger.warning('fMRIPrep could not find the markdown version of '
+                           'the citation boilerplate (%s). HTML and LaTeX versions'
+                           ' of it will not be available', citation_files['md'])
 
         # Generate reports phase
         failed_reports = generate_reports(


### PR DESCRIPTION
## Changes proposed in this pull request
This PR addresses the memory peak caused by pandoc, running the process
at the very end of fMRIPrep.

We probably want to explicitly clear up as many objects as we can from
memory and force gc before the subprocess opens pandoc, but that's left
for a future PR.

This PR just closes #1709 with the delayed pandoc run. I'm not
implementing the flag to avoid the boilerplate generation because I'm
not sure we want to introduce an additioinal argument for this.

Coincidentally, it also closes #1667 - now the deletion of citation
files is done inside a try..catch where ``FileNotFoundError`` is
dismissed. That should avert the issue, while keeping the functionality
of #1567.

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
Individual reports should keep rendering exactly the same after this PR.


<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
