### PR TITLE
MAINT: Bump pybids and nipype dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,9 @@ install_requires =
     nibabel >=2.2.1
     indexed_gzip >=0.8.8
     nilearn !=0.5.0, !=0.5.1
-    nipype >=1.2.0
+    nipype >=1.2.1
     psutil >=5.4
-    pybids ~= 0.9.2
+    pybids ~= 0.9.3
     tedana >=0.0.5
     nitime
     numpy


### PR DESCRIPTION
Closes #1674.
Addresses [Neurostars #4771](https://neurostars.org/t/naming-of-bids-events-tsv-files-seems-to-disrupt-fmriprep-1-5-0rc1/4771).