### PR TITLE
FIX: Passing surface template keywords into carpetplot workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,8 +388,7 @@ jobs:
                 --sloppy --write-graph --use-syn-sdc --mem_mb 4096 \
                 --use-aroma \
                 --skull-strip-template OASIS30ANTs:res-1 \
-                --output-space T1w template fsaverage5 fsnative \
-                --template-resampling-grid native \
+                --output-spaces MNI152NLin2009cAsym fsaverage5 fsnative MNI152NLin6Asym anat \
                 --use-plugin /home/circleci/src/fmriprep/.circleci/legacy.yml \
                 --nthreads 2 --cifti-output -vv
       - run:
@@ -416,9 +415,8 @@ jobs:
                 --config $PWD/nipype.cfg -w /tmp/ds005/work_partial \
                 /tmp/data/ds005 /tmp/ds005/derivatives_partial participant \
                 --sloppy --write-graph --use-syn-sdc --mem_mb 4096 \
-                --output-space T1w template fsaverage5 fsnative \
+                --output-spaces MNI152NLin2009cAsym fsaverage5 fsnative MNI152NLin6Asym anat \
                 --aroma-melodic-dimensionality 2 --use-aroma \
-                --template-resampling-grid native \
                 --nthreads 2 --cifti-output -vv
       - run:
           name: Checking outputs of partial fMRIPrep run

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ RUN curl -sSL "http://neuro.debian.net/lists/$( lsb_release -c | cut -f2 ).us-ca
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
                     fsl-core=5.0.9-5~nd16.04+1 \
+                    fsl-mni152-templates=5.0.7-2 \
                     afni=16.2.07~dfsg.1-5~nd16.04+1 \
                     convert3d \
                     git-annex-standalone && \

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -778,7 +778,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             freesurfer=freesurfer,
             mem_gb=mem_gb['resampled'],
             omp_nthreads=omp_nthreads,
-            standard_spaces=std_spaces,
+            standard_spaces=volume_std_spaces,
             name='bold_std_trans_wf',
             use_compression=not low_mem,
             use_fieldwarp=fmaps is not None,


### PR DESCRIPTION
## Changes proposed in this pull request

Ensure only volumetric templates are passed as indexing keys into the
carpetplot-creation workflow. Fixes #1721.
