### PR TITLE
DOC: Improve documentation about TemplateFlow and Containers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-fmriprep: A Robust Preprocessing Pipeline for fMRI Data
-=======================================================
+*fMRIPrep*: A Robust Preprocessing Pipeline for fMRI Data
+=========================================================
 
 This pipeline is developed by the `Poldrack lab at Stanford University
 <https://poldracklab.stanford.edu/>`_ for use at the `Center for Reproducible
@@ -43,7 +43,7 @@ About
 .. image:: https://github.com/oesteban/fmriprep/raw/38a63e9504ab67812b63813c5fe9af882109408e/docs/_static/fmriprep-workflow-all.png
 
 
-``fmriprep`` is a functional magnetic resonance imaging (fMRI) data
+*fMRIPrep* is a functional magnetic resonance imaging (fMRI) data
 preprocessing pipeline that is designed to provide an easily accessible,
 state-of-the-art interface that is robust to variations in scan acquisition
 protocols and that requires minimal user input, while providing easily
@@ -56,12 +56,12 @@ volume-based statistics, etc.
 
 .. note::
 
-   fmriprep performs minimal preprocessing.
+   *fMRIPrep* performs minimal preprocessing.
    Here we define 'minimal preprocessing'  as motion correction, field
    unwarping, normalization, bias field correction, and brain extraction.
    See the workflows_ for more details.
 
-The ``fmriprep`` pipeline uses a combination of tools from well-known software
+The *fMRIPrep* pipeline uses a combination of tools from well-known software
 packages, including FSL_, ANTs_, FreeSurfer_ and AFNI_.
 This pipeline was designed to provide the best software implementation for each
 state of preprocessing, and will be updated as newer and better neuroimaging
@@ -86,7 +86,7 @@ https://fmriprep.readthedocs.io/
 Principles
 ----------
 
-``fmriprep`` is built around three principles:
+*fMRIPrep* is built around three principles:
 
 1. **Robustness** - The pipeline adapts the preprocessing steps depending on
    the input dataset and should provide results as good as possible
@@ -97,22 +97,22 @@ Principles
    automatic fashion.
 3. **"Glass box"** philosophy - Automation should not mean that one should not
    visually inspect the results or understand the methods.
-   Thus, ``fmriprep`` provides visual reports for each subject, detailing the
+   Thus, *fMRIPrep* provides visual reports for each subject, detailing the
    accuracy of the most important processing steps.
    This, combined with the documentation, can help researchers to understand
    the process and decide which subjects should be kept for the group level
    analysis.
 
 
-Limitations and reasons not to use ``fmriprep``
------------------------------------------------
+Limitations and reasons not to use *fMRIPrep*
+---------------------------------------------
 
 1. Very narrow :abbr:`FoV (field-of-view)` images oftentimes do not contain
    enough information for standard image registration methods to work correctly.
    Also, problems may arise when extracting the brain from these data.
    Supporting these particular images is already a future line of the development
    road-map.
-2. ``fmriprep`` may also underperform for particular populations (e.g., infants) and
+2. *fMRIPrep* may also underperform for particular populations (e.g., infants) and
    non-human brains, although appropriate templates can be provided to overcome the
    issue.
 3. The "EPInorm" approach is currently not supported, although we plan to implement
@@ -131,6 +131,6 @@ Acknowledgements
 ----------------
 
 Please acknowledge this work by mentioning explicitly the name of this software
-(fmriprep) and the version, along with a link to the `GitHub repository
+(*fMRIPrep*) and the version, along with a link to the `GitHub repository
 <https://github.com/poldracklab/fmriprep>`_ or the Zenodo reference.
 For more details, please see :ref:`citation`.

--- a/docs/_static/sbatch.slurm
+++ b/docs/_static/sbatch.slurm
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+#SBATCH -J fmriprep
+#SBATCH --time=48:00:00
+#SBATCH -n 1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem-per-cpu=4G
+#SBATCH -p normal,mygroup  # Queue names you can submit to
+# Outputs ----------------------------------
+#SBATCH -o log/%x-%A-%a.out
+#SBATCH -e log/%x-%A-%a.err
+#SBATCH --mail-user=%u@domain.tld
+#SBATCH --mail-type=ALL
+# ------------------------------------------
+
+BIDS_DIR="$STUDY/data"
+DERIVS_DIR="derivatives/fmriprep-1.5.0"
+
+# Prepare some writeable bind-mount points.
+TEMPLATEFLOW_HOST_HOME=$HOME/.cache/templateflow
+FMRIPREP_HOST_CACHE=$HOME/.cache/fmriprep
+mkdir -p ${TEMPLATEFLOW_HOST_HOME}
+mkdir -p ${FMRIPREP_HOST_CACHE}
+
+# Prepare derivatives folder
+mkdir -p ${BIDS_DIR}/${DERIVS_DIR}
+
+# This trick will help you reuse freesurfer results across pipelines and fMRIPrep versions
+mkdir -p ${BIDS_DIR}/derivatives/freesurfer-6.0.1
+if [ ! -d ${BIDS_DIR}/${DERIVS_DIR}/freesurfer ]; then
+    ln -s ${BIDS_DIR}/derivatives/freesurfer-6.0.1 ${BIDS_DIR}/${DERIVS_DIR}/freesurfer
+fi
+
+# Make sure FS_LICENSE is defined in the container.
+export SINGULARITYENV_FS_LICENSE=$HOME/.freesurfer.txt
+
+# Designate a templateflow bind-mount point
+export SINGULARITYENV_TEMPLATEFLOW_HOME="/templateflow"
+SINGULARITY_CMD="singularity run --cleanenv -B $BIDS_DIR:/data -B ${TEMPLATEFLOW_HOST_HOME}:${SINGULARITYENV_TEMPLATEFLOW_HOME} -B $L_SCRATCH:/work $STUDY/images/poldracklab_fmriprep_1.5.0.simg"
+
+# Parse the participants.tsv file and extract one subject ID from the line corresponding to this SLURM task.
+subject=$( sed -n -E "$((${SLURM_ARRAY_TASK_ID} + 1))s/sub-(\S*)\>.*/\1/gp" ${BIDS_DIR}/participants.tsv )
+
+# Remove IsRunning files from FreeSurfer
+find ${BIDS_DIR}/derivatives/freesurfer-6.0.1/sub-$subject/ -name "*IsRunning*" -type f -delete
+
+# Compose the command line
+cmd="${SINGULARITY_CMD} /data /data/${DERIVS_DIR} participant --participant-label $subject -w /work/ -vv --omp-nthreads 8 --nthreads 12 --mem_mb 30000 --output-spaces MNI152NLin2009cAsym:res-2 anat fsnative fsaverage5 --use-aroma"
+
+# Setup done, run the command
+echo Running task ${SLURM_ARRAY_TASK_ID}
+echo Commandline: $cmd
+eval $cmd
+exitcode=$?
+
+# Output results to a table
+echo "sub-$subject   ${SLURM_ARRAY_TASK_ID}    $exitcode" \
+      >> ${SLURM_JOB_NAME}.${SLURM_ARRAY_JOB_ID}.tsv
+echo Finished tasks ${SLURM_ARRAY_TASK_ID} with exit code $exitcode
+exit $exitcode

--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -2,11 +2,11 @@
 
 .. _citation:
 
-===============
-Citing FMRIPREP
-===============
+=================
+Citing *fMRIPrep*
+=================
 
-Select which options you have run FMRIPREP with to generate custom language
+Select which options you have run *fMRIPrep* with to generate custom language
 we recommend to include in your paper.
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'fmriprep'
-author = 'The FMRIPREP developers'
+author = 'The fMRIPrep developers'
 copyright = '2016-%s, %s' % (datetime.now().year, author)
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -24,7 +24,7 @@ Patching working repositories
 In order to test new code without rebuilding the Docker image, it is
 possible to mount working repositories as source directories within the
 container.
-The `*fMRIPrep* Docker-Wrapper <DockerWrapper>`_ script simplifies this
+The `Docker wrapper`_ script simplifies this
 for the most common repositories::
 
     -f PATH, --patch-fmriprep PATH
@@ -132,7 +132,7 @@ version string from the current repository state.
 
 To work in this image, replace ``poldracklab/fmriprep:latest`` with
 ``fmriprep`` in any of the above commands.
-This image may be accessed by the `*fMRIPrep* Docker-Wrapper <DockerWrapper>`_
+This image may be accessed by the `Docker wrapper`_
 via the ``-i`` flag, e.g., ::
 
     $ fmriprep-docker -i fmriprep --shell

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -24,7 +24,8 @@ Patching working repositories
 In order to test new code without rebuilding the Docker image, it is
 possible to mount working repositories as source directories within the
 container.
-The `fmriprep-docker`_ script simplifies this for the most common repositories::
+The `*fMRIPrep* Docker-Wrapper <DockerWrapper>`_ script simplifies this
+for the most common repositories::
 
     -f PATH, --patch-fmriprep PATH
                           working fmriprep repository (default: None)
@@ -131,8 +132,8 @@ version string from the current repository state.
 
 To work in this image, replace ``poldracklab/fmriprep:latest`` with
 ``fmriprep`` in any of the above commands.
-This image may be accessed by the `fmriprep-docker`_ wrapper via the
-``-i`` flag, e.g., ::
+This image may be accessed by the `*fMRIPrep* Docker-Wrapper <DockerWrapper>`_
+via the ``-i`` flag, e.g., ::
 
     $ fmriprep-docker -i fmriprep --shell
 

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -1,0 +1,122 @@
+.. include:: links.rst
+
+.. _run_docker:
+
+Running *fMRIPrep* via Docker containers
+========================================
+For every new version of *fMRIPrep* that is released, a corresponding Docker
+image is generated.
+The Docker image *becomes* a container when the execution engine loads the
+image and adds an extra layer that makes it *runnable*.
+In order to run *fMRIPrep* Docker images, the Docker Engine must be installed
+(see :ref:`installation_docker`).
+
+If you used *fMRIPrep* via Docker in the past, you might need to pull down a
+more recent version of the image: ::
+
+    $ docker pull poldracklab/fmriprep:<latest-version>
+
+You can run *fMRIPrep* interacting directly with the Docker Engine via the `docker run`
+command line, or you can use a lightweight wrapper we created for convenience.
+
+.. _docker_wrapper:
+
+Running *fMRIPrep* with the ``fmriprep-docker`` wrapper
+-------------------------------------------------------
+This is the easiest way to run *fMRIPrep*.
+`*fMRIPrep* Docker-Wrapper utility <DockerWrapper>`_ is a command that allows 
+you to write your command line as if you were running ``fmriprep`` directly,
+and converts it into a ``docker`` command.
+The wrapper just requires Python and an Internet connection.
+Install the wrapper using a Python distribution system, e.g.::
+
+    $ pip install --user --upgrade fmriprep-docker
+
+When you run ``fmriprep-docker``, it will generate a Docker command line for you,
+print it out for reporting purposes, and then execute it without further action
+needed, e.g.::
+
+    $ fmriprep-docker /path/to/data/dir /path/to/output/dir participant
+    RUNNING: docker run --rm -it -v /path/to/data/dir:/data:ro \
+        -v /path/to_output/dir:/out poldracklab/fmriprep:1.0.0 \
+        /data /out participant
+    ...
+
+``fmriprep-docker`` accepts all of the typical options for *fMRIPrep* (see :ref:`usage`),
+automatically translating directories into Docker mount points.
+
+We have published a `step-by-step tutorial
+<http://reproducibility.stanford.edu/fmriprep-tutorial-running-the-docker-image/>`_
+illustrating how to run ``fmriprep-docker``. 
+This tutorial also provides valuable troubleshooting insights and advice on 
+what to do after *fMRIPrep* has run.
+
+
+Running *fMRIPrep* directly interacting with the Docker Engine
+--------------------------------------------------------------
+If you need a finer control over the container execution, or you feel comfortable
+with the Docker Engine, avoiding the extra software layer of the wrapper might be
+a good decision.
+
+**Accessing filesystems in the host within the container**.
+Containers are confined in a sandbox, so they can't access the host in any ways unless 
+you explicitly prescribe acceptable accesses to the host.
+The Docker Engine provides mounting filesystems into the container with the ``-v`` argument
+and the following syntax: ``-v some/path/in/host:/absolute/path/within/container:ro``,
+where the trailing ``:ro`` specifies that the mount is read-only.
+The mount permissions modifiers can be omitted, which means the mount will have read-write
+permissions.
+In general, you'll want to at least provide two mount-points: one set in read-only mode
+for the input data and one read/write to store the outputs.
+Potentially, you'll want to provide one or two more mount-points: one for the working
+directory, in case you need to debug some issue or reuse pre-cached results; and
+a :ref:`TemplateFlow` folder to preempt the download of your favorite templates in every
+run.
+
+**Running containers as a user**.
+By default, Docker will run the container as **root**.
+Some share systems my limit this feature and only allow running containers as a user.
+When the container is run as **root**, files written out to filesystems mounted from the
+host will have the user id ``1000`` by default.
+In other words, you'll need to be able to run as root in the host to change permissions
+or manage these files.
+Alternatively, running as a user allows preempting these permissions issues.
+It is possible to run as a user with the ``-u`` argument.
+In general, we will want to use the same user ID as the running user in the host to
+ensure the ownership of files written during the container execution.
+Therefore, you will generally run the container with ``-u $( id -u )``.
+
+You may also invoke ``docker`` directly::
+
+    $ docker run -ti --rm \
+        -v path/to/data:/data:ro \
+        -v path/to/output:/out \
+        poldracklab/fmriprep:<latest-version> \
+        /data /out/out \
+        participant
+
+For example: ::
+
+    $ docker run -ti --rm \
+        -v $HOME/ds005:/data:ro \
+        -v $HOME/ds005/derivatives:/out \
+        -v $HOME/tmp/ds005-workdir:/work \
+        poldracklab/fmriprep:<latest-version> \
+        /data /out/fmriprep-<latest-version> \
+        participant \
+        -w /work
+
+Once the Docker Engine arguments are written, the remainder of the command line follows
+the :ref:`usage`.
+In other words, the first section of the command line is all equivalent to the ``fmriprep``
+executable in a bare-metal installation: ::
+
+    $ docker run -ti --rm \                      | These lines
+        -v $HOME/ds005:/data:ro \                | are equivalent
+        -v $HOME/ds005/derivatives:/out \        | to the fmriprep
+        -v $HOME/tmp/ds005-workdir:/work \       | executable.
+        poldracklab/fmriprep:<latest-version> \  |
+        \
+        /data /out/fmriprep-<latest-version> \   | These lines
+        participant \                            | correspond to
+        -w /work                                 | fmriprep arguments.

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -23,15 +23,8 @@ command line, or you can use a lightweight wrapper we created for convenience.
 
 Running *fMRIPrep* with the ``fmriprep-docker`` wrapper
 -------------------------------------------------------
-This is the easiest way to run *fMRIPrep*.
-The `Docker wrapper`_ script is a command that allows 
-you to write your command line as if you were running ``fmriprep`` directly,
-and converts it into a ``docker`` command.
-The wrapper just requires Python and an Internet connection.
-Install the wrapper using a Python distribution system, e.g.::
-
-    $ pip install --user --upgrade fmriprep-docker
-
+Before starting, make sure you
+`have the wrapper installed <installation.html#the-fmriprep-docker-wrapper>`__.
 When you run ``fmriprep-docker``, it will generate a Docker command line for you,
 print it out for reporting purposes, and then execute it without further action
 needed, e.g.::

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -24,7 +24,7 @@ command line, or you can use a lightweight wrapper we created for convenience.
 Running *fMRIPrep* with the ``fmriprep-docker`` wrapper
 -------------------------------------------------------
 This is the easiest way to run *fMRIPrep*.
-`*fMRIPrep* Docker-Wrapper utility <DockerWrapper>`_ is a command that allows 
+The `Docker wrapper`_ script is a command that allows 
 you to write your command line as if you were running ``fmriprep`` directly,
 and converts it into a ``docker`` command.
 The wrapper just requires Python and an Internet connection.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -6,7 +6,6 @@ FAQ, Tips, and Tricks
 
 Should I run quality control of my images before running *fMRIPrep*?
 --------------------------------------------------------------------
-
 Yes. You should do so before any processing/analysis takes place.
 
 Oftentimes (more often than we would like), images have fatal artifacts and problems.
@@ -27,7 +26,6 @@ some kind of preprocessing (see next question).
 
 What if I find some images have undergone some pre-processing already (e.g., my T1w image is already skull-stripped)?
 ---------------------------------------------------------------------------------------------------------------------
-
 These images imply an unknown level of preprocessing (e.g. was it already bias-field corrected?),
 which makes it difficult to decide on best-practices for further processing.
 Hence, supporting such images was considered very low priority for *fMRIPrep*.
@@ -40,7 +38,6 @@ reverting to the original, defaced, T1w images to ensure more uniform preprocess
 
 My *fMRIPrep* run is hanging...
 -------------------------------
-
 When running on Linux platforms (or containerized environments, because they are built around
 Ubuntu), there is a Python bug that affects *fMRIPrep* that drives the Linux kernel to kill
 processes as a response to running out of memory.
@@ -62,7 +59,6 @@ Additionally, consider using the ``--low-mem`` flag, which will make some memory
 
 ERROR: it appears that ``recon-all`` is already running
 -------------------------------------------------------
-
 When running FreeSurfer_'s ``recon-all``, an error may say *it appears it is already running*.
 FreeSurfer creates files (called ``IsRunning.{rh,lh,lh+rh}``, under the ``scripts/`` folder)
 to determine whether it is already executing ``recon-all`` on that particular subject
@@ -117,7 +113,6 @@ In general, please be cautious of deleting files and mindful why a file may exis
 
 Running subjects in parallel
 ----------------------------
-
 When running several subjects in parallel, and depending on your settings, fMRIPrep may
 fall into race conditions.
 A symptomatic output looks like: ::
@@ -155,7 +150,6 @@ number of CPUs divided by the number of subjects is most efficient.
 
 A new version of *fMRIPrep* has been published, when should I upgrade?
 ----------------------------------------------------------------------
-
 We follow a philosophy of releasing very often, although the pace is slowing down
 with the maturation of the software.
 It is very likely that your version gets outdated over the extent of your study.
@@ -169,3 +163,16 @@ using the latest version of the tool.
 In any case, if you can find your release listed as *flagged* in `this file
 of our repo <https://github.com/poldracklab/fmriprep/blob/master/.versions.json>`__,
 then please update as soon as possible.
+
+What is *TemplateFlow* for?
+---------------------------
+*TemplateFlow* enables *fMRIPrep* to generate preprocessed outputs spatially normalized to
+a number of different neuroimaging templates (e.g. MNI).
+For further details, please check `its documentation section <spaces.html#templateflow>`__.
+
+I'm running *fMRIPrep* via Singularity containers - how can I troubleshoot problems?
+------------------------------------------------------------------------------------
+We have extended `this documentation <singularity.html>`__ to cover some of the most
+frequent issues other Singularity users have been faced with.
+Generally, users have found it hard to `get TemplateFlow and Singularity to work
+together <singularity.html#singularity-tf>`__.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,13 +15,15 @@ Contents
    :maxdepth: 3
 
    installation
-   changes
    usage
+   docker
+   singularity
    workflows
    sdc
-   spaces
    outputs
+   spaces
    faq
    contributors
    citing
    api/index.rst
+   changes

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,7 +16,6 @@ see :ref:`usage` for details.
 
 Container technologies: Docker and Singularity
 ==============================================
-
 Container technologies are operating-system-level virtualization methods to run Linux systems
 using the host's Linux kernel.
 This is a lightweight approach to virtualization, as compares to virtual machines.
@@ -26,7 +25,6 @@ This is a lightweight approach to virtualization, as compares to virtual machine
 
 Docker (recommended for PC/laptop and commercial Cloud)
 -------------------------------------------------------
-
 Probably, the most popular framework to execute containers is Docker.
 If you are to run *fMRIPrep* on your PC/laptop, this is the RECOMMENDED way of execution.
 Please make sure you follow the `Docker installation`_ instructions.
@@ -62,6 +60,18 @@ and `check out our documentation <docker.html>`_ to run the *fMRIPrep* image.
 The list of Docker images ready to use is found at the `Docker Hub`_, 
 under the ``poldracklab/fmriprep`` identifier.
 
+The ``fmriprep-docker`` wrapper
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This is the easiest way to `run fMRIPrep using Docker
+<docker.html#running-fmriprep-with-the-fmriprep-docker-wrapper>`__.
+The `Docker wrapper`_ is a Python script that operates the Docker Engine seamlessly
+as if you were running ``fmriprep`` directly.
+To that end, ``fmriprep-docker`` reinterprets the command-line you are passing and
+converts it into a ``docker run`` command.
+The wrapper just requires Python and an Internet connection.
+Install the wrapper using a Python distribution system, e.g.::
+
+    $ python -m pip install --user --upgrade fmriprep-docker
 
 Singularity (recommended for HPC)
 ---------------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,10 +27,10 @@ This is a lightweight approach to virtualization, as compares to virtual machine
 Docker (recommended for PC/laptop and commercial Cloud)
 -------------------------------------------------------
 
-Probably, the most popular framework to execute containers is DockerEngine_.
+Probably, the most popular framework to execute containers is Docker.
 If you are to run *fMRIPrep* on your PC/laptop, this is the RECOMMENDED way of execution.
-Please make sure you follow the DockerInstallation_ instructions.
-You can check your Docker Engine installation running their ``hello-world`` image: ::
+Please make sure you follow the `Docker installation`_ instructions.
+You can check your `Docker Engine`_ installation running their ``hello-world`` image: ::
 
     $ docker run --rm hello-world
 
@@ -58,7 +58,7 @@ If you have a functional installation, then you should obtain the following outp
      https://docs.docker.com/get-started/
 
 After checking your Docker Engine is capable of running Docker images, then go ahead
-and `check out our documentation <run_docker>`_ to run the *fMRIPrep* image.
+and `check out our documentation <docker.html>`_ to run the *fMRIPrep* image.
 The list of Docker images ready to use is found at the `Docker Hub`_, 
 under the ``poldracklab/fmriprep`` identifier.
 
@@ -70,8 +70,8 @@ For security reasons, many :abbr:`HPCs (High-Performance Computing)` (e.g., TACC
 do not allow Docker containers, but do allow Singularity_ containers.
 The improved security for multi-tenant systems comes at the price of some limitations
 and extra steps necessary for execution.
-Please make sure you `follow our tips and tricks to run *fMRIPrep*'s Singularity images
-<run_singularity>`_.
+Please make sure you `follow our tips and tricks to run fMRIPrep's Singularity images
+<singularity.html>`_.
 
 
 Manually Prepared Environment (Python 3.5+)
@@ -79,8 +79,8 @@ Manually Prepared Environment (Python 3.5+)
 
 .. warning::
 
-   This method is not recommended! Make sure you would rather do this than 
-   use a :ref:`run_docker` or a :ref:`run_singularity`.
+   This method is not recommended! Please checkout container alternatives
+   in :ref:`run_docker`, and :ref:`run_singularity`.
 
 Make sure all of *fMRIPRep*'s `External Dependencies`_ are installed.
 These tools must be installed and their binaries available in the

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,173 +4,75 @@
 Installation
 ------------
 
-There are four ways to use fmriprep: on the free cloud service OpenNeuro.org,
-in a `Docker Container`_, in a `Singularity Container`_, or in a `Manually
-Prepared Environment (Python 3.5+)`_.
-Using OpenNeuro or a local container method is highly recommended.
-Once you are ready to run fmriprep, see Usage_ for details.
+There are two ways to use *fMRIPrep*:
 
-OpenNeuro
-=========
+* within a `Manually Prepared Environment (Python 3.5+)`_; or
+* using container technologies (RECOMMENDED), such as :ref:`run_docker`
+  or :ref:`run_singularity`.
 
-fmriprep is available on the free cloud platform `OpenNeuro.org
-<http://openneuro.org>`_.
-After uploading your BIDS-compatible dataset to OpenNeuro you will be able to
-run fmriprep for free using OpenNeuro servers.
-This is the easiest way to run fmriprep, as there is no installation required.
-
-Docker Container
-================
-
-In order to run fmriprep in a Docker container, Docker must be `installed
-<https://docs.docker.com/engine/installation/>`_.
-Once Docker is installed, the recommended way to run fmriprep is to use the
-fmriprep-docker_ wrapper, which requires Python and an Internet connection.
-``fmriprep-docker`` is a command that allows you to write your command line 
-as if you were running ``fmriprep`` directly, and converts it into a ``docker`` 
-command.
-
-To install::
-
-    $ pip install --user --upgrade fmriprep-docker
-
-When you run ``fmriprep-docker``, it will generate a Docker command line for you,
-print it out for reporting purposes, and then execute it without further action
-needed, e.g.::
-
-    $ fmriprep-docker /path/to/data/dir /path/to/output/dir participant
-    RUNNING: docker run --rm -it -v /path/to/data/dir:/data:ro \
-        -v /path/to_output/dir:/out poldracklab/fmriprep:1.0.0 \
-        /data /out participant
-    ...
-
-``fmriprep-docker`` accepts all of the typical options for ``fmriprep``,
-automatically translating directories into Docker mount points.
-
-We have published a `step-by-step tutorial
-<http://reproducibility.stanford.edu/fmriprep-tutorial-running-the-docker-image/>`_
-illustrating how to run ``fmriprep-docker``. 
-This tutorial also provides valuable troubleshooting insights and advice on 
-what to do after fmriprep has run.
-
-You may also invoke ``docker`` directly::
-
-    $ docker run -ti --rm \
-        -v filepath/to/data/dir:/data:ro \
-        -v filepath/to/output/dir:/out \
-        poldracklab/fmriprep:latest \
-        /data /out/out \
-        participant
-
-For example: ::
-
-    $ docker run -ti --rm \
-        -v $HOME/fullds005:/data:ro \
-        -v $HOME/dockerout:/out \
-        poldracklab/fmriprep:latest \
-        /data /out/out \
-        participant \
-        --ignore fieldmaps
-
-See `External Dependencies`_ for more information (e.g., specific versions) on
-what is included in the latest Docker images.
+Once you are ready to run *fMRIPrep* via either of the options above,
+see :ref:`usage` for details.
 
 
-Singularity Container
-=====================
+Container technologies: Docker and Singularity
+==============================================
 
-For security reasons, many HPCs (e.g., TACC) do not allow Docker containers, but do
-allow `Singularity <https://github.com/singularityware/singularity>`_ containers.
-
-Preparing a Singularity image (Singularity version >= 2.5)
-----------------------------------------------------------
-If the version of Singularity on your HPC is modern enough you can create Singularity
-image directly on the HCP.
-This is as simple as: ::
-
-    $ singularity build /my_images/fmriprep-<version>.simg docker://poldracklab/fmriprep:<version>
-
-Where ``<version>`` should be replaced with the desired version of fMRIPrep that you want to download.
+Container technologies are operating-system-level virtualization methods to run Linux systems
+using the host's Linux kernel.
+This is a lightweight approach to virtualization, as compares to virtual machines.
 
 
-Preparing a Singularity image (Singularity version < 2.5)
----------------------------------------------------------
-In this case, start with a machine (e.g., your personal computer) with Docker installed.
-Use `docker2singularity <https://github.com/singularityware/docker2singularity>`_ to 
-create a singularity image.
-You will need an active internet connection and some time. ::
+.. _installation_docker:
 
-    $ docker run --privileged -t --rm \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        -v D:\host\path\where\to\output\singularity\image:/output \
-        singularityware/docker2singularity \
-        poldracklab/fmriprep:<version>
+Docker (recommended for PC/laptop and commercial Cloud)
+-------------------------------------------------------
 
-Where ``<version>`` should be replaced with the desired version of fMRIPrep that you want 
-to download.
+Probably, the most popular framework to execute containers is DockerEngine_.
+If you are to run *fMRIPrep* on your PC/laptop, this is the RECOMMENDED way of execution.
+Please make sure you follow the DockerInstallation_ instructions.
+You can check your Docker Engine installation running their ``hello-world`` image: ::
 
-Beware of the back slashes, expected for Windows systems.
-For \*nix users the command translates as follows: ::
+    $ docker run --rm hello-world
 
-    $ docker run --privileged -t --rm \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        -v /absolute/path/to/output/folder:/output \
-        singularityware/docker2singularity \
-        poldracklab/fmriprep:<version>
+If you have a functional installation, then you should obtain the following output. ::
+    
+    Hello from Docker!
+    This message shows that your installation appears to be working correctly.
+    
+    To generate this message, Docker took the following steps:
+     1. The Docker client contacted the Docker daemon.
+     1. The Docker daemon pulled the "hello-world" image from the Docker Hub.
+        (amd64)
+     1. The Docker daemon created a new container from that image which runs the
+        executable that produces the output you are currently reading.
+     1. The Docker daemon streamed that output to the Docker client, which sent it
+        to your terminal.
+    
+    To try something more ambitious, you can run an Ubuntu container with:
+     $ docker run -it ubuntu bash
+    
+    Share images, automate workflows, and more with a free Docker ID:
+     https://hub.docker.com/
+    
+    For more examples and ideas, visit:
+     https://docs.docker.com/get-started/
 
-
-Transfer the resulting Singularity image to the HPC, for example, using ``scp``. ::
-
-    $ scp poldracklab_fmriprep*.img user@hcpserver.edu:/my_images
-
-Running a Singularity Image
----------------------------
-
-If the data to be preprocessed is also on the HPC, you are ready to run fmriprep. ::
-
-    $ singularity run --cleanenv /my_images/fmriprep-1.1.2.simg \
-        path/to/data/dir path/to/output/dir \
-        participant \
-        --participant-label label
-
-.. note::
-
-   Singularity by default `exposes all environment variables from the host inside 
-   the container <https://github.com/singularityware/singularity/issues/445>`_.
-   Because of this your host libraries (such as nipype) could be accidentally used 
-   instead of the ones inside the container - if they are included in ``PYTHONPATH``.
-   To avoid such situation we recommend using the ``--cleanenv`` singularity flag 
-   in production use. For example: ::
-
-      $ singularity run --cleanenv ~/poldracklab_fmriprep_latest-2016-12-04-5b74ad9a4c4d.img \
-        /work/04168/asdf/lonestar/ $WORK/lonestar/output \
-        participant \
-        --participant-label 387 --nthreads 16 -w $WORK/lonestar/work \
-        --omp-nthreads 16
+After checking your Docker Engine is capable of running Docker images, then go ahead
+and `check out our documentation <run_docker>`_ to run the *fMRIPrep* image.
+The list of Docker images ready to use is found at the `Docker Hub`_, 
+under the ``poldracklab/fmriprep`` identifier.
 
 
-   or, unset the ``PYTHONPATH`` variable before running: ::
+Singularity (recommended for HPC)
+---------------------------------
 
-      $ unset PYTHONPATH; singularity run ~/poldracklab_fmriprep_latest-2016-12-04-5b74ad9a4c4d.img \
-        /work/04168/asdf/lonestar/ $WORK/lonestar/output \
-        participant \
-        --participant-label 387 --nthreads 16 -w $WORK/lonestar/work \
-        --omp-nthreads 16
+For security reasons, many :abbr:`HPCs (High-Performance Computing)` (e.g., TACC_)
+do not allow Docker containers, but do allow Singularity_ containers.
+The improved security for multi-tenant systems comes at the price of some limitations
+and extra steps necessary for execution.
+Please make sure you `follow our tips and tricks to run *fMRIPrep*'s Singularity images
+<run_singularity>`_.
 
-
-.. note::
-
-   Depending on how Singularity is configured on your cluster it might or might not 
-   automatically bind (mount or expose) host folders to the container. 
-   If this is not done automatically you will need to bind the necessary folders using 
-   the ``-B <host_folder>:<container_folder>`` Singularity argument.
-   For example: ::
-
-      $ singularity run --cleanenv -B /work:/work ~/poldracklab_fmriprep_latest-2016-12-04-5b74ad9a4c4d.simg \
-        /work/my_dataset/ /work/my_dataset/derivatives/fmriprep \
-        participant \
-        --participant-label 387 --nthreads 16 \
-        --omp-nthreads 16
 
 Manually Prepared Environment (Python 3.5+)
 ===========================================
@@ -178,9 +80,9 @@ Manually Prepared Environment (Python 3.5+)
 .. warning::
 
    This method is not recommended! Make sure you would rather do this than 
-   use a `Docker Container`_ or a `Singularity Container`_.
+   use a :ref:`run_docker` or a :ref:`run_singularity`.
 
-Make sure all of fmriprep's `External Dependencies`_ are installed.
+Make sure all of *fMRIPRep*'s `External Dependencies`_ are installed.
 These tools must be installed and their binaries available in the
 system's ``$PATH``.
 A relatively interpretable description of how your environment can be set-up
@@ -188,9 +90,9 @@ is found in the `Dockerfile <https://github.com/poldracklab/fmriprep/blob/master
 As an additional installation setting, FreeSurfer requires a license file (see :ref:`fs_license`).
 
 On a functional Python 3.5 (or above) environment with ``pip`` installed,
-fMRIPrep can be installed using the habitual command ::
+*fMRIPRep* can be installed using the habitual command ::
 
-    $ pip install fmriprep
+    $ python -m pip install fmriprep
 
 Check your installation with the ``--version`` argument ::
 
@@ -200,10 +102,10 @@ Check your installation with the ``--version`` argument ::
 External Dependencies
 ---------------------
 
-FMRIPrep is written using Python 3.5 (or above), and is based on
+*fMRIPRep* is written using Python 3.5 (or above), and is based on
 nipype_.
 
-FMRIPrep requires some other neuroimaging software tools that are
+*fMRIPRep* requires some other neuroimaging software tools that are
 not handled by the Python's packaging system (Pypi) used to deploy
 the ``fmriprep`` package:
 
@@ -216,54 +118,18 @@ the ``fmriprep`` package:
 - `bids-validator <https://github.com/bids-standard/bids-validator>`_ (version 1.1.0)
 
 
-.. _fs_license:
+Not running on a local machine? - Data transfer
+===============================================
 
-The FreeSurfer license
-======================
+If you intend to run *fMRIPRep* on a remote system, you will need to
+make your data available within that system first.
 
-FMRIPREP uses FreeSurfer tools, which require a license to run.
+For instance, here at the Poldrack Lab we use Stanford's
+:abbr:`HPC (high-performance computing)` system, called Sherlock.
+Sherlock enables `the following data transfer options
+<https://www.sherlock.stanford.edu/docs/user-guide/storage/data-transfer/>`_.
 
-To obtain a FreeSurfer license, simply register for free at
-https://surfer.nmr.mgh.harvard.edu/registration.html.
-
-When using manually-prepared environments or singularity, FreeSurfer will search 
-for a license key file first using the ``$FS_LICENSE`` environment variable and then 
-in the default path to the license key file (``$FREESURFER_HOME/license.txt``). 
-If using the ``--cleanenv`` flag and ``$FS_LICENSE`` is set, use ``--fs-license-file $FS_LICENSE`` 
-to pass the license file location to fMRIPrep.
-
-It is possible to run the docker container pointing the image to a local path
-where a valid license file is stored.
-For example, if the license is stored in the ``$HOME/.licenses/freesurfer/license.txt``
-file on the host system: ::
-
-    $ docker run -ti --rm \
-        -v $HOME/fullds005:/data:ro \
-        -v $HOME/dockerout:/out \
-        -v $HOME/.licenses/freesurfer/license.txt:/opt/freesurfer/license.txt \
-        poldracklab/fmriprep:latest \
-        /data /out/out \
-        participant \
-        --ignore fieldmaps
-
-Using FreeSurfer can also be enabled when using ``fmriprep-docker``: ::
-
-    $ fmriprep-docker --fs-license-file $HOME/.licenses/freesurfer/license.txt \
-        /path/to/data/dir /path/to/output/dir participant
-    RUNNING: docker run --rm -it -v /path/to/data/dir:/data:ro \
-        -v /home/user/.licenses/freesurfer/license.txt:/opt/freesurfer/license.txt \
-        -v /path/to_output/dir:/out poldracklab/fmriprep:1.0.0 \
-        /data /out participant
-    ...
-
-If the environment variable ``$FS_LICENSE`` is set in the host system, then
-it will automatically used by ``fmriprep-docker``. For instance, the following
-would be equivalent to the latest example: ::
-
-    $ export FS_LICENSE=$HOME/.licenses/freesurfer/license.txt
-    $ fmriprep-docker /path/to/data/dir /path/to/output/dir participant
-    RUNNING: docker run --rm -it -v /path/to/data/dir:/data:ro \
-        -v /home/user/.licenses/freesurfer/license.txt:/opt/freesurfer/license.txt \
-        -v /path/to_output/dir:/out poldracklab/fmriprep:1.0.0 \
-        /data /out participant
-    ...
+Alternatively, more comprehensive solutions such as `Datalad
+<http://www.datalad.org/>`_ will handle data transfers with the appropriate
+settings and commands.
+Datalad also performs version control over your data.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,15 +4,37 @@
 Installation
 ------------
 
-There are two ways to use *fMRIPrep*:
+There are two ways to get *fMRIPrep* installed:
 
-* within a `Manually Prepared Environment (Python 3.5+)`_; or
+* within a `Manually Prepared Environment (Python 3.5+)`_, also known as
+  *bare-metal installation*; or
 * using container technologies (RECOMMENDED), such as :ref:`run_docker`
   or :ref:`run_singularity`.
 
-Once you are ready to run *fMRIPrep* via either of the options above,
-see :ref:`usage` for details.
+Once you have your *bare-metal* environment set-up (first option above),
+the next step is executing the ``fmriprep`` command-line.
+The ``fmriprep`` command-line options are documented in the :ref:`usage`
+section.
+The ``fmriprep`` command-line adheres to the `BIDS-Apps recommendations
+for the user interface <usage.html#execution-and-the-bids-format>`__.
+Therefore, the command-line has the following structure:
+::
 
+  $ fmriprep <input_bids_path> <derivatives_path> <analysis_level> <named_options>
+
+On the other hand, if you chose a container infrastructure, then
+the command-line will be composed of a preamble to configure the
+container execution followed by the ``fmriprep`` command-line options
+as if you were running it on a *bare-metal* installation.
+The command-line structure above is then modified as follows:
+::
+
+  $ <container_command_and_options> <container_image> \
+       <input_bids_path> <derivatives_path> <analysis_level> <fmriprep_named_options>
+
+Therefore, once specified the container options and the image to be run
+the command line is the same as for the *bare-metal* installation but dropping
+the ``fmriprep`` executable name.
 
 Container technologies: Docker and Singularity
 ==============================================

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -3,9 +3,9 @@ License information
 
 We use the 3-clause BSD license; the full license may be found in the
 `LICENSE <https://github.com/poldracklab/fmriprep/blob/master/LICENSE>`_ file
-in the ``fmriprep`` distribution.
+in the *fMRIPrep* distribution.
 
 All trademarks referenced herein are property of their respective holders.
 
-Copyright (c) 2015-2018, the fMRIPrep developers and the CRN.
+Copyright (c) 2015-2019, the *fMRIPrep* developers and the CRN.
 All rights reserved.

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -12,9 +12,9 @@
 .. _AFNI: https://afni.nimh.nih.gov/
 .. _GIFTI: https://www.nitrc.org/projects/gifti/
 .. _`Connectome Workbench`: https://www.humanconnectome.org/software/connectome-workbench.html
-.. _DockerWrapper: https://pypi.python.org/pypi/fmriprep-docker
-.. _DockerEngine: https://www.docker.com/products/container-runtime
-.. _DockerInstallation: https://docs.docker.com/install/
+.. _`Docker wrapper`: https://pypi.python.org/pypi/fmriprep-docker
+.. _`Docker Engine`: https://www.docker.com/products/container-runtime
+.. _`Docker installation`: https://docs.docker.com/install/
 .. _`Docker Hub`: https://hub.docker.com/r/poldracklab/fmriprep/tags
 .. _Singularity: https://github.com/singularityware/singularity
 .. _TACC: https://www.tacc.utexas.edu/

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -2,7 +2,6 @@
 .. _BIDS: http://bids.neuroimaging.io
 .. _`BIDS Derivatives`: https://docs.google.com/document/d/17ebopupQxuRwp7U7TFvS6BH03ALJOgGHufxK8ToAvyI
 .. _`BIDS Derivatives RC1`: https://docs.google.com/document/d/17ebopupQxuRwp7U7TFvS6BH03ALJOgGHufxK8ToAvyI
-.. _Usage: usage.html
 .. _Installation: installation.html
 .. _workflows: workflows.html
 .. _FSL: https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/
@@ -13,4 +12,9 @@
 .. _AFNI: https://afni.nimh.nih.gov/
 .. _GIFTI: https://www.nitrc.org/projects/gifti/
 .. _`Connectome Workbench`: https://www.humanconnectome.org/software/connectome-workbench.html
-.. _`fmriprep-docker`: https://pypi.python.org/pypi/fmriprep-docker
+.. _DockerWrapper: https://pypi.python.org/pypi/fmriprep-docker
+.. _DockerEngine: https://www.docker.com/products/container-runtime
+.. _DockerInstallation: https://docs.docker.com/install/
+.. _`Docker Hub`: https://hub.docker.com/r/poldracklab/fmriprep/tags
+.. _Singularity: https://github.com/singularityware/singularity
+.. _TACC: https://www.tacc.utexas.edu/

--- a/docs/singularity.rst
+++ b/docs/singularity.rst
@@ -1,0 +1,218 @@
+.. include:: links.rst
+
+
+.. _run_singularity:
+
+Running *fMRIPrep* via Singularity containers
+=============================================
+Preparing a Singularity image
+-----------------------------
+**Singularity version >= 2.5**.
+If the version of Singularity installed on your :abbr:`HPC (High-Performance Computing)`
+system is modern enough you can create Singularity image directly on the system.
+This is as simple as: ::
+
+    $ singularity build /my_images/fmriprep-<version>.simg docker://poldracklab/fmriprep:<version>
+
+where ``<version>`` should be replaced with the desired version of *fMRIPrep* that you
+want to download.
+
+**Singularity version < 2.5**.
+In this case, start with a machine (e.g., your personal computer) with Docker installed.
+Use `docker2singularity <https://github.com/singularityware/docker2singularity>`_ to 
+create a singularity image.
+You will need an active internet connection and some time. ::
+
+    $ docker run --privileged -t --rm \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v D:\host\path\where\to\output\singularity\image:/output \
+        singularityware/docker2singularity \
+        poldracklab/fmriprep:<version>
+
+Where ``<version>`` should be replaced with the desired version of *fMRIPrep* that you want 
+to download.
+
+Beware of the back slashes, expected for Windows systems.
+For \*nix users the command translates as follows: ::
+
+    $ docker run --privileged -t --rm \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v /absolute/path/to/output/folder:/output \
+        singularityware/docker2singularity \
+        poldracklab/fmriprep:<version>
+
+
+Transfer the resulting Singularity image to the HPC, for example, using ``scp``. ::
+
+    $ scp poldracklab_fmriprep*.img user@hcpserver.edu:/my_images
+
+Running a Singularity Image
+---------------------------
+If the data to be preprocessed is also on the HPC, you are ready to run *fMRIPrep*. ::
+
+    $ singularity run --cleanenv fmriprep.simg \
+        path/to/data/dir path/to/output/dir \
+        participant \
+        --participant-label label
+
+Handling environment variables
+------------------------------
+Singularity by default `exposes all environment variables from the host inside 
+the container <https://github.com/singularityware/singularity/issues/445>`__.
+Because of this, your host libraries (e.g., nipype_ or a Python 2.7 environment)
+could be accidentally used instead of the ones inside the container.
+To avoid such a situation, we recommend using the ``--cleanenv`` argument in
+all scenarios. For example: ::
+
+    $ singularity run --cleanenv fmriprep.simg \
+      /work/04168/asdf/lonestar/ $WORK/lonestar/output \
+      participant \
+      --participant-label 387 --nthreads 16 -w $WORK/lonestar/work \
+      --omp-nthreads 16
+
+
+Alternatively, conflicts might be preempted and some problems mitigated by 
+unsetting potentially problematic settings, such as the ``PYTHONPATH`` variable,
+before running: ::
+
+    $ unset PYTHONPATH; singularity run fmriprep.simg \
+      /work/04168/asdf/lonestar/ $WORK/lonestar/output \
+      participant \
+      --participant-label 387 --nthreads 16 -w $WORK/lonestar/work \
+      --omp-nthreads 16
+
+It is possible to define environment variables scoped within the container by
+using the ``SINGULARITYENV_*`` magic, in combination with ``--cleanenv``.
+For example, we can set the FreeSurfer license variable (see :ref:`fs_license`)
+as follows: ::
+
+    $ export SINGULARITYENV_FS_LICENSE=$HOME/.freesurfer.txt
+    $ singularity exec --cleanenv fmriprep.simg env | grep FS_LICENSE
+    FS_LICENSE=/home/users/oesteban/.freesurfer.txt
+
+As we can see, the export in the first line tells Singularity to set a
+corresponding environment variable of the same name after dropping the
+prefix ``SINGULARITYENV_``.
+
+Accessing the host's filesystem
+-------------------------------
+Depending on how Singularity is configured on your cluster it might or might not 
+automatically bind (mount or expose) host folders to the container.
+This is particularly relevant because, *if you can't run Singularity in privileged
+mode* (which is almost certainly true in all the scenarios), **Singularity containers
+are read only**.
+This is to say that you won't be able to write *anything* unless Singularity can
+access the host's filesystem in write mode.
+
+By default, Singularity automatically binds (mounts) the user's *home* directory and
+a *scratch* directory.
+In addition, Singularity generally allows binding the necessary folders with
+the ``-B <host_folder>:<container_folder>`` Singularity argument.
+For example: ::
+
+    $ singularity run --cleanenv -B /work:/work fmriprep.smig \
+      /work/my_dataset/ /work/my_dataset/derivatives/fmriprep \
+      participant \
+      --participant-label 387 --nthreads 16 \
+      --omp-nthreads 16
+
+**Relevant aspects of the ``$HOME`` directory within the container**.
+By default, Singularity will bind the user's ``$HOME`` directory in the host
+into the ``/home/$USER`` (or equivalent) in the container.
+Most of the times, it will also redefine the ``$HOME`` environment variable and
+update it to point to the corresponding mount point in ``/home/$USER``.
+However, these defaults can be overwritten in your system.
+It is recommended to check your settings with your system's administrators.
+If your Singularity installation allows it, you can workaround the ``$HOME``
+specification combining the bind mounts argument (``-B``) with the home overwrite
+argument (``--home``) as follows: ::
+
+    $ singularity run -B $HOME:/home/fmriprep --home /home/fmriprep \
+          --cleanenv fmriprep.simg <fmriprep arguments>
+
+*TemplateFlow* and Singularity
+------------------------------
+:ref:`TemplateFlow` is a helper tool that allows *fMRIPrep* (or any other neuroimaging workflow)
+to programmatically access a repository of standard neuroimaging templates.
+In other words, *TemplateFlow* allows *fMRIPrep* to dynamically change the templates that
+are used, e.g., in the atlas-based brain extraction step or spatial normalization.
+
+Default settings in the Singularity image should get along with the Singularity
+installation of your system.
+However, deviations from the default configurations of your installation may break
+this compatibility.
+A particularly problematic case arises when the home directory is mounted in the
+container, but the ``$HOME`` environment variable is not correspondingly updated.
+Typically, you will experience errors like ``OSError: [Errno 30] Read-only file system``
+or ``FileNotFoundError: [Errno 2] No such file or directory: '/home/fmriprep/.cache'``.
+
+If it is not explicitly forbidden in your installation, the first attempt to overcome this
+issue is manually setting the ``$HOME`` directory as follows: ::
+
+    $ singularity run --home $HOME --cleanenv fmriprep.simg <fmriprep arguments>
+
+If the user's home directory is not automatically bound, then the second step would include
+manually binding it as in the section above: ::
+
+    $ singularity run -B $HOME:/home/fmriprep --home /home/fmriprep \
+          --cleanenv fmriprep.simg <fmriprep arguments>
+
+Finally, if the ``--home`` argument cannot be used, you'll need to provide the container with
+writable filesystems where *TemplateFlow*'s files can be downloaded.
+In addition, you will need to indicate *fMRIPrep* to update the default paths with the new mount
+points setting the ``SINGULARITYENV_TEMPLATEFLOW_HOME`` variable. ::
+
+    $ export SINGULARITYENV_TEMPLATEFLOW_HOME=/opt/templateflow  # Tell fMRIPrep the mount point
+    $ singularity run -B <writable-path-on-host>:/opt/templateflow \
+          --cleanenv fmriprep.simg <fmriprep arguments>
+
+Running Singularity on a SLURM system
+-------------------------------------
+An example of ``sbatch`` script to run *fMRIPrep* on a SLURM system with Singularity
+available is given below: ::
+
+    #!/bin/bash
+    #
+    #SBATCH -J fmriprep
+    #SBATCH --array=1-36  # Replace indices with the right number of subjects
+    #SBATCH --time=48:00:00
+    #SBATCH -n 1
+    #SBATCH --cpus-per-task=16
+    #SBATCH --mem-per-cpu=4G
+    #SBATCH -p queues,you,can,submit  # Partition names, separated by comma
+    # Outputs ----------------------------------
+    #SBATCH -o log/%x-%A-%a.out
+    #SBATCH -e log/%x-%A-%a.err
+    #SBATCH --mail-user=%u@domain.tld
+    #SBATCH --mail-type=ALL
+    # ------------------------------------------
+    
+    BIDS_DIR="$PROJECT/data/ds000109"
+    DERIVS_DIR="derivatives/fmriprep-1.5.0"
+
+    mkdir -p $HOME/.cache/templateflow
+    mkdir -p ${BIDS_DIR}/${DERIVS_DIR}
+    mkdir -p ${BIDS_DIR}/derivatives/freesurfer-6.0.1
+    ln -s ${BIDS_DIR}/derivatives/freesurfer-6.0.1 ${BIDS_DIR}/${DERIVS_DIR}/freesurfer
+
+
+    export SINGULARITYENV_FS_LICENSE=$HOME/.freesurfer.txt
+    export SINGULARITYENV_TEMPLATEFLOW_HOME="/templateflow"
+    SINGULARITY_CMD="singularity run --cleanenv -B $PROJECT:/project -B $HOME/.cache/templateflow:/templateflow -B $L_SCRATCH:/work $PROJECT/images/poldracklab_fmriprep_1.5.0-2019-09-10-6157fec3d0ea.simg"
+
+    
+    subject=$( sed -n -E "$((${SLURM_ARRAY_TASK_ID} + 1))s/sub-(\S*)\>.*/\1/gp" ${BIDS_DIR}/participants.tsv )
+    cmd="${SINGULARITY_CMD} /project/data/ds000109 /project/data/ds000109/${DERIVS_DIR} participant --participant-label $subject -w /work/ -vv --omp-nthreads 8 --nthreads 12 --mem_mb 30000 --output-spaces MNI152NLin2009cAsym:res-2 anat fsnative fsaverage5 --cifti-output --use-aroma"
+
+    # Setup done, run the command
+    echo Running task ${SLURM_ARRAY_TASK_ID}
+    echo Commandline: $cmd
+    eval $cmd
+    exitcode=$?
+    
+    # Output results to a table
+    echo "sub-$subject   ${SLURM_ARRAY_TASK_ID}    $exitcode" \
+          >> ${SLURM_JOB_NAME}.${SLURM_ARRAY_JOB_ID}.tsv
+    echo Finished tasks ${SLURM_ARRAY_TASK_ID} with exit code $exitcode
+    exit $exitcode
+

--- a/docs/spaces.rst
+++ b/docs/spaces.rst
@@ -110,7 +110,7 @@ In other words, running fMRIPrep with ``--output-spaces MNI152NLin6Asym:res-2
 .. _TemplateFlow:
 
 *TemplateFlow*
-==============
+""""""""""""""
 Group inference and reporting of neuroimaging studies require that individual's
 features are spatially aligned into a common frame where their location can be
 called *standard*.

--- a/docs/spaces.rst
+++ b/docs/spaces.rst
@@ -111,9 +111,56 @@ In other words, running fMRIPrep with ``--output-spaces MNI152NLin6Asym:res-2
 
 *TemplateFlow*
 ==============
-*TemplateFlow* comprehends a repository for the redistribution of neuroimaging
-templatates and a Python client tool to access them programmatically when used
-as a library by other software, or interactively by humans.
+Group inference and reporting of neuroimaging studies require that individual's
+features are spatially aligned into a common frame where their location can be
+called *standard*.
+To that end, a multiplicity of brain templates with anatomical annotations
+(i.e., atlases) have been published.
+However, a centralized resource that allows programmatic access to templates
+was lacking.
+*TemplateFlow* is a modular, version-controlled resource that allows researchers
+to use templates "off-the-shelf" and share new ones.
 
+In addition to the repository from which neuroimaging templates are redistributed,
+*TemplateFlow* also comprehends a Python client tool to access them programmatically
+when used as a library by other software, or interactively by humans.
 Therefore *TemplateFlow* is the software module that allows *fMRIPrep* to flexibly
 change, and dynamically pull down, new standardized template information.
+
+.. _tf_no_internet:
+
+**How do you use TemplateFlow in the absence of access to the Internet?**.
+This is a fairly common situation in :abbr:`HPCs (high-performance computing)`
+systems, where the so-called login nodes have access to the Internet but
+compute nodes are isolated, or in PC/laptop enviroments if you are travelling.
+*TemplateFlow* will require Internet access the first time it receives a
+query for a template resource that has not been previously accessed.
+If you know what are the templates you are planning to use, you could
+prefetch them using the Python client.
+To do so, follow the next steps.
+
+  1. By default, a mirror of *TemplateFlow* to store the resources will be
+     created in ``$HOME/.cache/templateflow``.
+     You can modify such a configuration with the ``TEMPLATEFLOW_HOME``
+     environment variable, e.g.:
+     ::
+  
+       $ export TEMPLATEFLOW_HOME=$HOME/.templateflow
+  
+  2. Install the client within your favorite Python 3 environment (this can
+     be done in your login-node, or in a host with Internet access, 
+     without need for Docker/Singularity):
+     ::
+       
+       $ python -m pip install -U templateflow
+  
+  3. Use the ``get()`` utility of the client to pull down all the templates you'll
+     want to use. For example:
+     ::
+  
+       $ python -c "from templateflow.api import get; get(['MNI152NLin2009cAsym', 'MNI152NLin6Asym', 'OASIS30ANTs', 'MNIPediatricAsym', 'MNIInfant'])"
+
+After pulling down the resources you'll need, you will just need to make sure your
+runtime environment is able to access the filesystem, at the location of your
+*TemplateFlow home* directory.
+If you are a Singularity user, please check out :ref:`singularity_tf`.

--- a/docs/spaces.rst
+++ b/docs/spaces.rst
@@ -1,4 +1,4 @@
-
+.. include:: links.rst
 
 .. _output-spaces:
 
@@ -106,3 +106,14 @@ identifier not be found within the ``--output-spaces`` list already.
 In other words, running fMRIPrep with ``--output-spaces MNI152NLin6Asym:res-2
 --use-syn-sdc`` will expand the list of output spaces to be
 ``MNI152NLin6Asym:res-2 MNI152NLin2009cAsym``.
+
+.. _TemplateFlow:
+
+*TemplateFlow*
+==============
+*TemplateFlow* comprehends a repository for the redistribution of neuroimaging
+templatates and a Python client tool to access them programmatically when used
+as a library by other software, or interactively by humans.
+
+Therefore *TemplateFlow* is the software module that allows *fMRIPrep* to flexibly
+change, and dynamically pull down, new standardized template information.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,18 +1,18 @@
 .. include:: links.rst
 
-Usage
------
+.. _Usage :
 
+Usage Notes
+===========
 .. warning::
-   As of FMRIPREP 1.0.12, the software includes a tracking system
+   As of *fMRIPRep* 1.0.12, the software includes a tracking system
    to report usage statistics and errors. Users can opt-out using
    the ``--notrack`` command line argument.
 
 
 Execution and the BIDS format
-=============================
-
-The ``fmriprep`` workflow takes as principal input the path of the dataset
+-----------------------------
+The *fMRIPRep* workflow takes as principal input the path of the dataset
 that is to be processed.
 The input dataset is required to be in valid :abbr:`BIDS (Brain Imaging Data
 Structure)` format, and it must include at least one T1w structural image and
@@ -20,7 +20,7 @@ Structure)` format, and it must include at least one T1w structural image and
 We highly recommend that you validate your dataset with the free, online
 `BIDS Validator <http://bids-standard.github.io/bids-validator/>`_.
 
-The exact command to run ``fmriprep`` depends on the Installation_ method.
+The exact command to run *fMRIPRep* depends on the Installation_ method.
 The common parts of the command follow the `BIDS-Apps
 <https://github.com/BIDS-Apps>`_ definition.
 Example: ::
@@ -29,8 +29,7 @@ Example: ::
 
 
 Command-Line Arguments
-======================
-
+----------------------
 .. argparse::
    :ref: fmriprep.cli.run.get_parser
    :prog: fmriprep
@@ -38,8 +37,8 @@ Command-Line Arguments
    :nodefaultconst:
 
 
-The docker wrapper CLI
-======================
+The command-line interface of the docker wrapper 
+------------------------------------------------
 
 .. argparse::
    :ref: fmriprep_docker.get_parser
@@ -48,8 +47,61 @@ The docker wrapper CLI
    :nodefaultconst:
 
 
-Debugging
-=========
+.. _fs_license:
+
+The FreeSurfer license
+----------------------
+
+*fMRIPRep* uses FreeSurfer tools, which require a license to run.
+
+To obtain a FreeSurfer license, simply register for free at
+https://surfer.nmr.mgh.harvard.edu/registration.html.
+
+When using manually-prepared environments or singularity, FreeSurfer will search 
+for a license key file first using the ``$FS_LICENSE`` environment variable and then 
+in the default path to the license key file (``$FREESURFER_HOME/license.txt``). 
+If using the ``--cleanenv`` flag and ``$FS_LICENSE`` is set, use ``--fs-license-file $FS_LICENSE`` 
+to pass the license file location to *fMRIPRep*.
+
+It is possible to run the docker container pointing the image to a local path
+where a valid license file is stored.
+For example, if the license is stored in the ``$HOME/.licenses/freesurfer/license.txt``
+file on the host system: ::
+
+    $ docker run -ti --rm \
+        -v $HOME/fullds005:/data:ro \
+        -v $HOME/dockerout:/out \
+        -v $HOME/.licenses/freesurfer/license.txt:/opt/freesurfer/license.txt \
+        poldracklab/fmriprep:latest \
+        /data /out/out \
+        participant \
+        --ignore fieldmaps
+
+Using FreeSurfer can also be enabled when using ``fmriprep-docker``: ::
+
+    $ fmriprep-docker --fs-license-file $HOME/.licenses/freesurfer/license.txt \
+        /path/to/data/dir /path/to/output/dir participant
+    RUNNING: docker run --rm -it -v /path/to/data/dir:/data:ro \
+        -v /home/user/.licenses/freesurfer/license.txt:/opt/freesurfer/license.txt \
+        -v /path/to_output/dir:/out poldracklab/fmriprep:1.0.0 \
+        /data /out participant
+    ...
+
+If the environment variable ``$FS_LICENSE`` is set in the host system, then
+it will automatically used by ``fmriprep-docker``. For instance, the following
+would be equivalent to the latest example: ::
+
+    $ export FS_LICENSE=$HOME/.licenses/freesurfer/license.txt
+    $ fmriprep-docker /path/to/data/dir /path/to/output/dir participant
+    RUNNING: docker run --rm -it -v /path/to/data/dir:/data:ro \
+        -v /home/user/.licenses/freesurfer/license.txt:/opt/freesurfer/license.txt \
+        -v /path/to_output/dir:/out poldracklab/fmriprep:1.0.0 \
+        /data /out participant
+    ...
+
+
+Troubleshooting
+---------------
 
 Logs and crashfiles are outputted into the
 ``<output dir>/fmriprep/sub-<participant_label>/log`` directory.
@@ -57,38 +109,19 @@ Information on how to customize and understand these files can be found on the
 `nipype debugging <http://nipype.readthedocs.io/en/latest/users/debug.html>`_
 page.
 
-Support and communication
-=========================
-
+**Support and communication**.
 The documentation of this project is found here: http://fmriprep.readthedocs.org/en/latest/.
 
 All bugs, concerns and enhancement requests for this software can be submitted here:
 https://github.com/poldracklab/fmriprep/issues.
 
-If you have a problem or would like to ask a question about how to use ``fmriprep``,
+If you have a problem or would like to ask a question about how to use *fMRIPRep*,
 please submit a question to `NeuroStars.org <http://neurostars.org/tags/fmriprep>`_ with an ``fmriprep`` tag.
 NeuroStars.org is a platform similar to StackOverflow but dedicated to neuroinformatics.
 
-All previous ``fmriprep`` questions are available here:
+Previous questions about *fMRIPRep* are available here:
 http://neurostars.org/tags/fmriprep/
 
-To participate in the ``fmriprep`` development-related discussions please use the
+To participate in the *fMRIPRep* development-related discussions please use the
 following mailing list: http://mail.python.org/mailman/listinfo/neuroimaging
 Please add *[fmriprep]* to the subject line when posting on the mailing list.
-
-
-Not running on a local machine? - Data transfer
-===============================================
-
-If you intend to run ``fmriprep`` on a remote system, you will need to
-make your data available within that system first.
-
-For instance, here at the Poldrack Lab we use Stanford's
-:abbr:`HPC (high-performance computing)` system, called Sherlock.
-Sherlock enables `the following data transfer options
-<https://www.sherlock.stanford.edu/docs/user-guide/storage/data-transfer/>`_.
-
-Alternatively, more comprehensive solutions such as `Datalad
-<http://www.datalad.org/>`_ will handle data transfers with the appropriate
-settings and commands.
-Datalad also performs version control over your data.


### PR DESCRIPTION

This PR addresses #1801. The intent is to provide clearer documentation about how to run fMRIPrep via Singularity containers. In particular, the interaction between TemplateFlow and Singularity should be better described.
