### PR TITLE
MAINT: pin python 3.7.4 in circle's build_docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,7 +260,7 @@ jobs:
 
   build_docs:
     docker:
-      - image: python:latest
+      - image: python:3.7.4
     working_directory: /tmp/src/fmriprep
     environment:
       - FSLOUTPUTTYPE: 'NIFTI'


### PR DESCRIPTION
Addresses #1835 trying to get lucky (as python version is the most significant change w.r.t. to the latest successful build).