### PR TITLE
ENH: Restore ``space-MNI152NLin6Asym`` for AROMA denoised outputs

### DIFF
--- a/.circleci/ds005_outputs.txt
+++ b/.circleci/ds005_outputs.txt
@@ -56,7 +56,6 @@ fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_bold.dtseries.nii
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-confounds_regressors.json
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-confounds_regressors.tsv
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-MELODIC_mixing.tsv
-fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_desc-smoothAROMAnonaggr_bold.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-fsaverage5_hemi-L.func.gii
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-fsaverage5_hemi-R.func.gii
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-fsnative_hemi-L.func.gii
@@ -75,6 +74,7 @@ fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-MNI152NLin6Asym_d
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-MNI152NLin6Asym_desc-brain_mask.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-MNI152NLin6Asym_desc-preproc_bold.json
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-MNI152NLin6Asym_desc-preproc_bold.nii.gz
+fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-MNI152NLin6Asym_desc-smoothAROMAnonaggr_bold.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_boldref.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_desc-aparcaseg_dseg.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-01_space-T1w_desc-aseg_dseg.nii.gz
@@ -88,7 +88,6 @@ fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_bold.dtseries.nii
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_regressors.json
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_regressors.tsv
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-MELODIC_mixing.tsv
-fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-smoothAROMAnonaggr_bold.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-fsaverage5_hemi-L.func.gii
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-fsaverage5_hemi-R.func.gii
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-fsnative_hemi-L.func.gii
@@ -107,6 +106,7 @@ fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin6Asym_d
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin6Asym_desc-brain_mask.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin6Asym_desc-preproc_bold.json
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin6Asym_desc-preproc_bold.nii.gz
+fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin6Asym_desc-smoothAROMAnonaggr_bold.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_boldref.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-aparcaseg_dseg.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-aseg_dseg.nii.gz

--- a/.circleci/ds005_partial_outputs.txt
+++ b/.circleci/ds005_partial_outputs.txt
@@ -56,7 +56,6 @@ fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_bold.dtseries.nii
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_regressors.json
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-confounds_regressors.tsv
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-MELODIC_mixing.tsv
-fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_desc-smoothAROMAnonaggr_bold.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-fsaverage5_hemi-L.func.gii
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-fsaverage5_hemi-R.func.gii
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-fsnative_hemi-L.func.gii
@@ -75,6 +74,7 @@ fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin6Asym_d
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin6Asym_desc-brain_mask.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin6Asym_desc-preproc_bold.json
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin6Asym_desc-preproc_bold.nii.gz
+fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-MNI152NLin6Asym_desc-smoothAROMAnonaggr_bold.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_boldref.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-aparcaseg_dseg.nii.gz
 fmriprep/sub-01/func/sub-01_task-mixedgamblestask_run-02_space-T1w_desc-aseg_dseg.nii.gz

--- a/fmriprep/workflows/bold/outputs.py
+++ b/fmriprep/workflows/bold/outputs.py
@@ -236,7 +236,7 @@ def init_func_derivatives_wf(
             name="ds_melodic_mix", run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
         ds_aroma_std = pe.Node(
-            DerivativesDataSink(base_directory=output_dir,
+            DerivativesDataSink(base_directory=output_dir, space='MNI152NLin6Asym',
                                 desc='smoothAROMAnonaggr', keep_dtype=True),
             name='ds_aroma_std', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)


### PR DESCRIPTION
Brings the space keyword back as suggested in https://github.com/poldracklab/fmriprep/pull/1838#issuecomment-543758805