### PR TITLE
FIX: Do not run STC if SliceTiming metadata is set but empty

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -357,7 +357,7 @@ https://github.com/poldracklab/fmriprep/issues/1655.""")
             fmaps.append({'suffix': 'syn'})
 
         # Short circuits: (True and True and (False or 'TooShort')) == 'TooShort'
-        run_stc = ("SliceTiming" in metadata and
+        run_stc = (metadata.get("SliceTiming") and
                    'slicetiming' not in ignore and
                    (_get_series_len(ref_file) > 4 or "TooShort"))
 

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -357,7 +357,7 @@ https://github.com/poldracklab/fmriprep/issues/1655.""")
             fmaps.append({'suffix': 'syn'})
 
         # Short circuits: (True and True and (False or 'TooShort')) == 'TooShort'
-        run_stc = (metadata.get("SliceTiming") and
+        run_stc = (metadata.get("SliceTiming", False) and
                    'slicetiming' not in ignore and
                    (_get_series_len(ref_file) > 4 or "TooShort"))
 

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -357,7 +357,7 @@ https://github.com/poldracklab/fmriprep/issues/1655.""")
             fmaps.append({'suffix': 'syn'})
 
         # Short circuits: (True and True and (False or 'TooShort')) == 'TooShort'
-        run_stc = (metadata.get("SliceTiming", False) and
+        run_stc = (bool(metadata.get("SliceTiming")) and
                    'slicetiming' not in ignore and
                    (_get_series_len(ref_file) > 4 or "TooShort"))
 


### PR DESCRIPTION
Currently, the BIDS-Validator would just raise a Warning when metadata contains:

```
{
  "SliceTiming": []
}
```