### PR TITLE
FIX: Read the docs always serves the latest Zenodo DOI

### DIFF
--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -21,7 +21,7 @@ we recommend to include in your paper.
 
       function cb(err, zenodoID) {
          getCitation(zenodoID, 'vancouver-brackets-no-et-al', function(err, citation) {
-            $('#fmriprep_citation').text(citation);
+            $('#fmriprep_citation').text(citation.substring(2));
          });
          getDOI(zenodoID, function(err, DOI) {
             $('#fmriprep_doi_url').text('https://doi.org/' + DOI);

--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -13,7 +13,7 @@ we recommend to include in your paper.
 .. raw:: html
 
    <script language="javascript">
-   var version = 'latest';
+   var version = window.location.pathname.split("/")[2];
    function fillCitation(){
       $('#fmriprep_version').text(version);
       $('#workflow_url').text('https://fmriprep.readthedocs.io/en/' + version + '/workflows.html');

--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -24,8 +24,14 @@ we recommend to include in your paper.
             $('#fmriprep_citation').text(citation.substring(2));
          });
          getDOI(zenodoID, function(err, DOI) {
-            $('#fmriprep_doi_url').text('https://doi.org/' + DOI);
-            $('#fmriprep_doi_url').attr('href', 'https://doi.org/' + DOI);
+
+            if(DOI == null) {
+               $('#fmriprep_doi_url').text("10.5281/zenodo.852659");
+               $('#fmriprep_doi_url').attr('href', 'https://doi.org/' + "10.5281/zenodo.852659");
+            } else {
+               $('#fmriprep_doi_url').text('https://doi.org/' + DOI);
+               $('#fmriprep_doi_url').attr('href', 'https://doi.org/' + DOI);
+            }
          });
       }
 
@@ -43,7 +49,7 @@ we recommend to include in your paper.
         for (var i = 0; i < controlElementsIdsLength; i++) {
             controlElement = document.getElementById(controlElementsIds[i])
 
-            if (controlElement.checked == null){
+            if (controlElement.checked == null) {
                 var value = controlElement.value;
             } else {
           	    var value = controlElement.checked;
@@ -160,7 +166,7 @@ we recommend to include in your paper.
         Nat Meth. 2018; doi:<a href="https://doi.org/10.1038/s41592-018-0235-4">10.1038/s41592-018-0235-4</a>
    </p>
    <p>
-     2. <span id="fmriprep_citation">fMRIPrep</span> Available from: <a id="fmriprep_doi_url" href="https://doi.org/10.5281/zenodo.852659">10.5281/zenodo.852659</a>.
+     2. <span id="fmriprep_citation">fMRIPrep</span> Available from: <a id="fmriprep_doi_url" > </a>.
      <img src onerror='fillCitation()' alt="" />
    </p>
    <p>


### PR DESCRIPTION
## Changes proposed in this pull request

Trying to solve #813 

There are a pair of issues:

- Annoying 1 (one) after the 2 (two). The first "one" comes from the citation itself. 
`2. *1.* Esteban, Oscar, Blair, Ross(...)`

Solved with `citation.substring(2)`

- Read the docs always serves the latest Zenodo DOI

In [this](https://github.com/poldracklab/fmriprep/blame/278fb84c5407520cdbcc7228c8bcbe8f82d19c6c/docs/citing.rst#L16) line, there's this assignment `var version = 'latest';`. If assigned to the desired version, it changes and works adequately. I guess this can be obtained from the HTML? I've no experience with javascript, I'll give it a try though.