### PR TITLE
MNT: Enable circleci-artifacts-redirector

### DIFF
--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,0 +1,1 @@
+/0/tmp/src/fmriprep/docs/_build/html/index.html


### PR DESCRIPTION
## Changes proposed in this pull request

I've enabled Eric Larson's [circleci-artifacts-redirector](https://github.com/larsoner/circleci-artifacts-redirector) to make it easier to immediately open the rendered docs. This change tells it where to find the artifacts.