### PR TITLE
Added skip_citation_process flag to skip processing citation.md

### DIFF
--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -73,6 +73,9 @@ def get_parser():
     g_bids.add_argument('--skip_bids_validation', '--skip-bids-validation', action='store_true',
                         default=False,
                         help='assume the input dataset is BIDS compliant and skip the validation')
+    g_bids.add_argument('--skip_citation_process', '--skip-citation-process', action='store_true',
+                        default=False,
+                        help='skip processing HTML and LaTeX formatted citation with pandoc')
     g_bids.add_argument('--participant_label', '--participant-label', action='store', nargs='+',
                         help='a space delimited list of participant identifiers or a single '
                              'identifier (the sub- prefix can be removed)')
@@ -444,7 +447,7 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
             for ext in ('bib', 'tex', 'md', 'html')
         }
 
-        if citation_files['md'].exists():
+        if not opts.skip_citation_process and citation_files['md'].exists():
             # Generate HTML file resolving citations
             cmd = ['pandoc', '-s', '--bibliography',
                    pkgrf('fmriprep', 'data/boilerplate.bib'),

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -108,9 +108,9 @@ def get_parser():
                          help='DEPRECATED (now does nothing, see --error-on-aroma-warnings) '
                               '- ignores the errors ICA_AROMA returns when there are no '
                               'components classified as either noise or signal')
-    g_perfm.add_argument('--md-only-boilerplate', action='store_true', 
+    g_perfm.add_argument('--md-only-boilerplate', action='store_true',
                          default=False,
-                         help='skip generation of HTML and LaTeX formatted citation from citation.md with pandoc')
+                         help='skip generation of HTML and LaTeX formatted citation with pandoc')
     g_perfm.add_argument('--error-on-aroma-warnings', action='store_true',
                          default=False,
                          help='Raise an error if ICA_AROMA does not produce sensible output '

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -73,9 +73,6 @@ def get_parser():
     g_bids.add_argument('--skip_bids_validation', '--skip-bids-validation', action='store_true',
                         default=False,
                         help='assume the input dataset is BIDS compliant and skip the validation')
-    g_bids.add_argument('--skip_citation_process', '--skip-citation-process', action='store_true',
-                        default=False,
-                        help='skip processing HTML and LaTeX formatted citation with pandoc')
     g_bids.add_argument('--participant_label', '--participant-label', action='store', nargs='+',
                         help='a space delimited list of participant identifiers or a single '
                              'identifier (the sub- prefix can be removed)')
@@ -111,6 +108,9 @@ def get_parser():
                          help='DEPRECATED (now does nothing, see --error-on-aroma-warnings) '
                               '- ignores the errors ICA_AROMA returns when there are no '
                               'components classified as either noise or signal')
+    g_perfm.add_argument('--md-only-boilerplate', action='store_true', 
+                         default=False,
+                         help='skip generation of HTML and LaTeX formatted citation from citation.md with pandoc')
     g_perfm.add_argument('--error-on-aroma-warnings', action='store_true',
                          default=False,
                          help='Raise an error if ICA_AROMA does not produce sensible output '
@@ -447,7 +447,7 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
             for ext in ('bib', 'tex', 'md', 'html')
         }
 
-        if not opts.skip_citation_process and citation_files['md'].exists():
+        if not opts.md_only_boilerplate and citation_files['md'].exists():
             # Generate HTML file resolving citations
             cmd = ['pandoc', '-s', '--bibliography',
                    pkgrf('fmriprep', 'data/boilerplate.bib'),


### PR DESCRIPTION
## Changes proposed in this pull request

This PR workarounds the issue of pandoc running out of vmem at the end of the fmriprep pipeline which then terminates the workflow on our HPC environement. #1870 

Here is Neurostart discussion about this issue.
> https://neurostars.org/t/large-virtual-memory-allocations-in-fmriprep-on-pbs-system/4665/8

Our workflow doesn't just run a single fmriprep, so if fmriprep fails at the end, it will kill the entire workflow. For us, it's important that fmriprep survives the post-processing. The memory issue with pando has been a known issue since 2016 according to this thread (https://github.com/jgm/pandoc/issues/3169) .. 
