### PR TITLE
MAINT: Remove deprecated command-line arguments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -678,8 +678,8 @@ jobs:
                 --config $PWD/nipype.cfg -w /tmp/ds210/work \
                 /tmp/data/ds210 /tmp/ds210/derivatives participant \
                 --fs-no-reconall --t2s-coreg --use-syn-sdc \
-                --template-resampling-grid native --dummy-scans 1 \
-                --sloppy --write-graph --mem_mb 4096 --nthreads 2 -vv
+                --dummy-scans 1 --sloppy --write-graph \
+                --mem_mb 4096 --nthreads 2 -vv
       - run:
           name: Checking outputs of fMRIPrep
           command: |

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -697,7 +697,6 @@ def parse_spaces(opts):
     """Ensures the spaces are correctly parsed"""
     from sys import stderr
     from collections import OrderedDict
-    from templateflow.api import templates as get_templates
     # Set the default template to 'MNI152NLin2009cAsym'
     output_spaces = opts.output_spaces or OrderedDict([('MNI152NLin2009cAsym', {})])
 

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -637,7 +637,7 @@ It is released under the [CC0]\
               ('outputnode.joint_template', 'inputnode.joint_template'),
               ('outputnode.joint_anat2std_xfm', 'inputnode.joint_anat2std_xfm'),
               ('outputnode.joint_std2anat_xfm', 'inputnode.joint_std2anat_xfm'),
-              # Undefined if --no-freesurfer, but this is safe
+              # Undefined if --fs-no-reconall, but this is safe
               ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
               ('outputnode.subject_id', 'inputnode.subject_id'),
               ('outputnode.t1w2fsnative_xfm', 'inputnode.t1w2fsnative_xfm'),

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -589,7 +589,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         (inputnode, bold_reg_wf, [
             ('t1w_brain', 'inputnode.t1w_brain'),
             ('t1w_dseg', 'inputnode.t1w_dseg'),
-            # Undefined if --no-freesurfer, but this is safe
+            # Undefined if --fs-no-reconall, but this is safe
             ('subjects_dir', 'inputnode.subjects_dir'),
             ('subject_id', 'inputnode.subject_id'),
             ('fsnative2t1w_xfm', 'inputnode.fsnative2t1w_xfm')]),

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -18,7 +18,6 @@ import sys
 import os
 import re
 import subprocess
-from warnings import warn
 
 __version__ = '99.99.99'
 __copyright__ = 'Copyright 2019, Center for Reproducible Neuroscience, Stanford University'
@@ -260,8 +259,8 @@ may be followed by optional, colon-separated parameters. \
 Non-standard spaces (valid keywords: %s) imply specific orientations and sampling \
 grids. \
 Important to note, the ``res-*`` modifier does not define the resolution used for \
-the spatial normalization.""" % (
-        ', '.join('"%s"' % s for s in TF_TEMPLATES), ', '.join(NONSTANDARD_REFERENCES)))
+the spatial normalization.""" % (', '.join('"%s"' % s for s in TF_TEMPLATES),
+                                 ', '.join(NONSTANDARD_REFERENCES)))
 
     g_wrap.add_argument(
         '--fs-license-file', metavar='PATH', type=os.path.abspath,

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -226,9 +226,6 @@ def get_parser():
     g_wrap.add_argument('-w', '--work-dir', action='store', type=os.path.abspath,
                         help='path where intermediate results should be stored')
     g_wrap.add_argument(
-        '--output-grid-reference', required=False, action='store', type=os.path.abspath,
-        help='Deprecated after FMRIPREP 1.0.8. Please use --template-resampling-grid instead.')
-    g_wrap.add_argument(
         '--template-resampling-grid', required=False, action='store', type=str,
         help='Keyword ("native", "1mm", or "2mm") or path to an existing file. '
              'Allows to define a reference grid for the resampling of BOLD images in template '
@@ -395,11 +392,7 @@ def main():
                                         'ro'))])
         unknown_args.extend(['--use-plugin', '/tmp/plugin.yml'])
 
-    template_target = opts.template_resampling_grid or opts.output_grid_reference
-    if template_target is not None:
-        if opts.output_grid_reference is not None:
-            warn('Option --output-grid-reference is deprecated, please use '
-                 '--template-resampling-grid', DeprecationWarning)
+    if opts.template_resampling_grid is not None:
         if template_target not in ['native', '2mm' '1mm']:
             target = '/imports/' + os.path.basename(template_target)
             command.extend(['-v', ':'.join((os.path.abspath(

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -429,7 +429,7 @@ def main():
                 spaces.append(target)
             else:
                 spaces.append(space)
-        unknown_args.extend(['--output-spaces', " ".join(spaces)])
+        unknown_args.extend(['--output-spaces'] + spaces)
 
     if opts.shell:
         command.append('--entrypoint=bash')

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -31,6 +31,30 @@ MISSING = """
 Image '{}' is missing
 Would you like to download? [Y/n] """
 PKG_PATH = '/usr/local/miniconda/lib/python3.7/site-packages'
+TF_TEMPLATES = (
+    'MNI152Lin',
+    'MNI152NLin2009cAsym',
+    'MNI152NLin6Asym',
+    'MNI152NLin6Sym',
+    'MNIInfant',
+    'MNIPediatricAsym',
+    'NKI',
+    'OASIS30ANTs',
+    'PNC',
+    'UNCInfant',
+    'fsLR',
+    'fsaverage',
+    'fsaverage5',
+    'fsaverage6',
+)
+NONSTANDARD_REFERENCES = (
+    'anat',
+    'T1w',
+    'run',
+    'func',
+    'sbref',
+    'fsnative'
+)
 
 # Monkey-patch Py2 subprocess
 if not hasattr(subprocess, 'DEVNULL'):
@@ -141,7 +165,7 @@ def merge_help(wrapper_help, target_help):
 
     # Make sure we're not clobbering options we don't mean to
     overlap = set(w_flags).intersection(t_flags)
-    expected_overlap = set(['h', 'version', 'w', 'template-resampling-grid',
+    expected_overlap = set(['h', 'version', 'w', 'output-spaces',
                             'fs-license-file', 'fs-subjects-dir', 'use-plugin'])
 
     assert overlap == expected_overlap, "Clobbering options: {}".format(
@@ -226,14 +250,19 @@ def get_parser():
     g_wrap.add_argument('-w', '--work-dir', action='store', type=os.path.abspath,
                         help='path where intermediate results should be stored')
     g_wrap.add_argument(
-        '--template-resampling-grid', required=False, action='store', type=str,
-        help='Keyword ("native", "1mm", or "2mm") or path to an existing file. '
-             'Allows to define a reference grid for the resampling of BOLD images in template '
-             'space. Keyword "native" will use the original BOLD grid as reference. '
-             'Keywords "1mm" and "2mm" will use the corresponding isotropic template '
-             'resolutions. If a path is given, the grid of that image will be used. '
-             'It determines the field of view and resolution of the output images, '
-             'but is not used in normalization.')
+        '--output-spaces', nargs="+",
+        help="""\
+Standard and non-standard spaces to resample anatomical and functional images to. \
+Standard spaces may be specified by the form \
+``<TEMPLATE>[:res-<resolution>][:cohort-<label>][...]``, where ``<TEMPLATE>`` is \
+a keyword (valid keywords: %s) or path pointing to a user-supplied template, and \
+may be followed by optional, colon-separated parameters. \
+Non-standard spaces (valid keywords: %s) imply specific orientations and sampling \
+grids. \
+Important to note, the ``res-*`` modifier does not define the resolution used for \
+the spatial normalization.""" % (
+        ', '.join('"%s"' % s for s in TF_TEMPLATES), ', '.join(NONSTANDARD_REFERENCES)))
+
     g_wrap.add_argument(
         '--fs-license-file', metavar='PATH', type=os.path.abspath,
         default=os.getenv('FS_LICENSE', None),
@@ -392,12 +421,16 @@ def main():
                                         'ro'))])
         unknown_args.extend(['--use-plugin', '/tmp/plugin.yml'])
 
-    if opts.template_resampling_grid is not None:
-        if template_target not in ['native', '2mm' '1mm']:
-            target = '/imports/' + os.path.basename(template_target)
-            command.extend(['-v', ':'.join((os.path.abspath(
-                template_target), target, 'ro'))])
-        unknown_args.extend(['--template-resampling-grid', template_target])
+    if opts.output_spaces:
+        spaces = []
+        for space in opts.output_spaces:
+            if space.split(':')[0] not in (TF_TEMPLATES + NONSTANDARD_REFERENCES):
+                target = '/imports/' + os.path.basename(space)
+                command.extend(['-v', ':'.join((os.path.abspath(space), target, 'ro'))])
+                spaces.append(target)
+            else:
+                spaces.append(space)
+        unknown_args.extend(['--output-spaces', " ".join(spaces)])
 
     if opts.shell:
         command.append('--entrypoint=bash')


### PR DESCRIPTION
Closes #1898 
## Changes proposed in this pull request

- removes deprecated `fmriprep` arguments:
```
--ignore-aroma-denoising-errors
--debug
--output-space
--template
--template-resampling-grid
--no-freesurfer
```
- removes deprecated `fmriprep-docker` arguments:
```
--template-resampling-grid
--output-grid-reference
```
- adds `--output-spaces` argument to `fmriprep-docker` to allow custom template usage