### PR TITLE
ENH: Add fmriprep.__main__ to allow python -m fmriprep

### DIFF
--- a/fmriprep/__main__.py
+++ b/fmriprep/__main__.py
@@ -1,0 +1,9 @@
+from .cli.run import main
+
+if __name__ == '__main__':
+    import sys
+    from . import __name__ as module
+    # `python -m <module>` typically displays the command as __main__.py
+    if '__main__.py' in sys.argv[0]:
+        sys.argv[0] = '%s -m %s' % (sys.executable, module)
+    main()


### PR DESCRIPTION
## Changes proposed in this pull request

This helps in confused environment situations, as `python -m fmriprep` uses Python module loading to locate the executable instead of the shell's `$PATH`. Also for cases like `coverage run -m fmriprep` on an installed copy instead of a source directory.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
