### PR TITLE
REL: 1.5.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+1.5.7 (January 23, 2020)
+========================
+Bug-fix release in the 1.5.x series.
+
+This release fixes a bug specifically for T1w images with dimensions ≤256 voxels
+but a field-of-view >256mm.
+
+  * FIX: Calculate FoV with shape and zooms (poldracklab/smriprep#161)
+
 1.5.6 (January 22, 2020)
 ========================
 Bug-fix release in the 1.5.x series.

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     pybids ~= 0.9.4
     pyyaml
     sdcflows ~= 1.0.3
-    smriprep ~= 0.4.0
+    smriprep ~= 0.4.2
     tedana >=0.0.5
     templateflow ~= 0.4.1
 test_requires =


### PR DESCRIPTION
The plan is to just push this commit to `maint/1.5.x` and release once sMRIPrep gets pushed to PyPI. Probably in the morning (hence the date).

Opening this PR just to give a chance to object or suggest other bug fixes we should hold off for.