### PR TITLE
DOC/FIX: Remove unusable scale option to SVG figures

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -133,7 +133,6 @@ Below are some benchmark data that have been computed on a high performance clus
 CPUs and 64 GB of physical memory:
 
 .. figure:: _static/fmriprep_benchmark.svg
-    :scale: 100%
 
 **Compute Time**: time in hours to complete the preprocessing for all subjects. **Physical Memory**: the maximum of RAM usage
 used across all fMRIPrep processes as reported by the HCP job manager. **Virtual Memory**: the maximum of virtual memory used

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -453,7 +453,6 @@ Some of the estimated confounds are plotted with a "carpet" visualization of the
 An example of these plots follows:
 
 .. figure:: _static/sub-01_task-mixedgamblestask_run-01_bold_carpetplot.svg
-    :scale: 100%
 
     The figure shows on top several confounds estimated for the BOLD series:
     global signals ('GlobalSignal', 'WM', 'GM'), standardized DVARS ('stdDVARS'),
@@ -474,7 +473,6 @@ option ``--return-all-components``.
 component, ordered by descending singular value.
 
 .. figure:: _static/sub-01_task-rest_compcor.svg
-    :scale: 100%
 
     The figure displays the cumulative variance explained by components for each
     of four CompCor decompositions (left to right: anatomical CSF mask, anatomical
@@ -491,7 +489,6 @@ This can be used to guide selection of a confound model or to assess the extent
 to which tissue-specific regressors correlate with global signal.
 
 .. figure:: _static/sub-01_task-mixedgamblestask_run-01_confounds_correlation.svg
-    :scale: 100%
 
     The left-hand panel shows the matrix of correlations among selected confound
     time series as a heat-map.

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -118,7 +118,6 @@ brain extraction workflow:
 An example of brain extraction is shown below:
 
 .. figure:: _static/brainextraction_t1.svg
-    :scale: 100%
 
     Brain extraction
 
@@ -126,7 +125,6 @@ An example of brain extraction is shown below:
 Once the brain mask is computed, FSL ``fast`` is utilized for brain tissue segmentation.
 
 .. figure:: _static/segmentation.svg
-    :scale: 100%
 
     Brain tissue segmentation.
 
@@ -138,7 +136,6 @@ be set to resample the preprocessed data onto the final output spaces.
 
 
 .. figure:: _static/T1MNINormalization.svg
-    :scale: 100%
 
     Animation showing spatial normalization of T1w onto the ``MNI152NLin2009cAsym`` template.
 
@@ -244,7 +241,6 @@ details.
 Reconstructed white and pial surfaces are included in the report.
 
 .. figure:: _static/reconall.svg
-    :scale: 100%
 
     Surface reconstruction (FreeSurfer)
 
@@ -360,7 +356,6 @@ workflow <bold_hmc>` and the :ref:`registration workflow to map
 BOLD series into the T1w image of the same subject <bold_reg>`.
 
 .. figure:: _static/brainextraction.svg
-    :scale: 100%
 
     Calculation of a brain mask from the BOLD series.
 
@@ -425,7 +420,6 @@ Susceptibility Distortion Correction (SDC)
 :mod:`fmriprep.workflows.fieldmap.base.init_sdc_wf`
 
 .. figure:: _static/unwarping.svg
-    :scale: 100%
 
     Applying susceptibility-derived distortion correction, based on
     fieldmap estimation.
@@ -482,7 +476,6 @@ of each run and the reconstructed subject using the gray/white matter boundary
 (FreeSurfer's ``?h.white`` surfaces) is calculated by the ``bbregister`` routine.
 
 .. figure:: _static/EPIT1Normalization.svg
-    :scale: 100%
 
     Animation showing :abbr:`EPI (echo-planar imaging)` to T1w registration (FreeSurfer ``bbregister``)
 
@@ -630,7 +623,6 @@ melodic's estimation of components.
 A visualization of the AROMA component classification is also included in the HTML reports.
 
 .. figure:: _static/aroma.svg
-    :scale: 100%
 
     Maps created with maximum intensity projection (glass brain) with a black
     brain outline.


### PR DESCRIPTION
Build docs is breaking with 

```
Warning, treated as error:
/tmp/src/fmriprep/docs/faq.rst::Could not obtain image size. :scale: option is ignored.
```

Warning introduced in https://github.com/sphinx-doc/sphinx/pull/6985. Unclear whether it's supposed to work or the warning is just added. Either way, if it wasn't working before, removing it shouldn't cause new problems.

Affected files:

* [FAQ](https://11700-53175327-gh.circle-artifacts.com/0/tmp/src/fmriprep/docs/_build/html/faq.html)
* [Outputs](https://11700-53175327-gh.circle-artifacts.com/0/tmp/src/fmriprep/docs/_build/html/outputs.html)
* [Workflows](https://11700-53175327-gh.circle-artifacts.com/0/tmp/src/fmriprep/docs/_build/html/workflows.html)