### PR TITLE
FIX: Ensure logs are properly displayed

### DIFF
--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -326,6 +326,7 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
     log_level = int(max(25 - 5 * opts.verbose_count, logging.DEBUG))
     # Set logging
     logger.setLevel(log_level)
+    logger.addHandler(logging.StreamHandler())
     nlogging.getLogger('nipype.workflow').setLevel(log_level)
     nlogging.getLogger('nipype.interface').setLevel(log_level)
     nlogging.getLogger('nipype.utils').setLevel(log_level)
@@ -502,7 +503,7 @@ def build_workflow(opts, retval):
 
     if opts.clean_workdir:
         from niworkflows.utils.misc import clean_directory
-        build_log.log("Clearing previous fMRIPrep working directory: %s" % work_dir)
+        build_log.info("Clearing previous fMRIPrep working directory: %s" % work_dir)
         if not clean_directory(work_dir):
             build_log.warning("Could not clear all contents of working directory: %s" % work_dir)
 


### PR DESCRIPTION
Closes #1763 

The `cli` logger did not have an attached `Handler`, so logs that should have been displayed were not.