### PR TITLE
ENH: Add t2w/flair as potential --ignore targets

### DIFF
--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -116,7 +116,7 @@ def get_parser():
     g_conf = parser.add_argument_group('Workflow configuration')
     g_conf.add_argument(
         '--ignore', required=False, action='store', nargs="+", default=[],
-        choices=['fieldmaps', 'slicetiming', 'sbref'],
+        choices=['fieldmaps', 'slicetiming', 'sbref', 't2w', 'flair'],
         help='ignore selected aspects of the input dataset to disable corresponding '
              'parts of the workflow (a space delimited list)')
     g_conf.add_argument(

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -491,6 +491,10 @@ def init_single_subject_wf(
     else:
         subject_data = collect_data(layout, subject_id, task_id, echo_idx,
                                     bids_filters=bids_filters)[0]
+        if 'flair' in ignore and subject_data['flair']:
+            subject_data['flair'] = []
+        if 't2w' in ignore and subject_data['t2w']:
+            subject_data['t2w'] = []
 
     # Make sure we always go through these two checks
     if not anat_only and subject_data['bold'] == []:

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -491,9 +491,9 @@ def init_single_subject_wf(
     else:
         subject_data = collect_data(layout, subject_id, task_id, echo_idx,
                                     bids_filters=bids_filters)[0]
-        if 'flair' in ignore and subject_data['flair']:
+        if 'flair' in ignore:
             subject_data['flair'] = []
-        if 't2w' in ignore and subject_data['t2w']:
+        if 't2w' in ignore:
             subject_data['t2w'] = []
 
     # Make sure we always go through these two checks


### PR DESCRIPTION
Closes #2011 
This adds new options to the `--ignore` flag, allowing users to avoid using T2w/FLAIR images during FreeSurfer processing.