### PR TITLE
MAINT: Bump to 3.7+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,19 @@ jobs:
               /src/fmriprep/fmriprep -svx --doctest-modules
 
       - run:
+          name: Test fmriprep-wrapper (Python 2)
+          command: |
+            export PY2=$(pyenv versions | grep '2\.' |
+                         sed -e 's/.* 2\./2./' -e 's/ .*//')
+            pyenv local $PY2
+            echo -n "Python version: "
+            python --version
+            pip install --upgrade pip setuptools
+            pip install --upgrade wrapper/
+            which fmriprep-docker
+            fmriprep-docker -i poldracklab/fmriprep:latest --help
+            fmriprep-docker -i poldracklab/fmriprep:latest --version
+      - run:
           name: Test fmriprep-wrapper (Python 3)
           command: |
             export PY3=$(pyenv versions | grep '3\.' |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,19 +233,6 @@ jobs:
               /src/fmriprep/fmriprep -svx --doctest-modules
 
       - run:
-          name: Test fmriprep-wrapper (Python 2)
-          command: |
-            export PY2=$(pyenv versions | grep '2\.' |
-                         sed -e 's/.* 2\./2./' -e 's/ .*//')
-            pyenv local $PY2
-            echo -n "Python version: "
-            python --version
-            pip install --upgrade pip setuptools
-            pip install --upgrade wrapper/
-            which fmriprep-docker
-            fmriprep-docker -i poldracklab/fmriprep:latest --help
-            fmriprep-docker -i poldracklab/fmriprep:latest --version
-      - run:
           name: Test fmriprep-wrapper (Python 3)
           command: |
             export PY3=$(pyenv versions | grep '3\.' |

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - $HOME/.cache/pip
 
 python:
-  - 3.6
+  - 3.7
 
 before_install:
   - python -m pip install --upgrade pip

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ Installation
 
 There are two ways to get *fMRIPrep* installed:
 
-* within a `Manually Prepared Environment (Python 3.5+)`_, also known as
+* within a `Manually Prepared Environment (Python 3.7+)`_, also known as
   *bare-metal installation*; or
 * using container technologies (RECOMMENDED), such as :ref:`run_docker`
   or :ref:`run_singularity`.
@@ -55,10 +55,10 @@ You can check your `Docker Engine`_ installation running their ``hello-world`` i
     $ docker run --rm hello-world
 
 If you have a functional installation, then you should obtain the following output. ::
-    
+
     Hello from Docker!
     This message shows that your installation appears to be working correctly.
-    
+
     To generate this message, Docker took the following steps:
      1. The Docker client contacted the Docker daemon.
      1. The Docker daemon pulled the "hello-world" image from the Docker Hub.
@@ -67,19 +67,19 @@ If you have a functional installation, then you should obtain the following outp
         executable that produces the output you are currently reading.
      1. The Docker daemon streamed that output to the Docker client, which sent it
         to your terminal.
-    
+
     To try something more ambitious, you can run an Ubuntu container with:
      $ docker run -it ubuntu bash
-    
+
     Share images, automate workflows, and more with a free Docker ID:
      https://hub.docker.com/
-    
+
     For more examples and ideas, visit:
      https://docs.docker.com/get-started/
 
 After checking your Docker Engine is capable of running Docker images, then go ahead
 and `check out our documentation <docker.html>`_ to run the *fMRIPrep* image.
-The list of Docker images ready to use is found at the `Docker Hub`_, 
+The list of Docker images ready to use is found at the `Docker Hub`_,
 under the ``poldracklab/fmriprep`` identifier.
 
 The ``fmriprep-docker`` wrapper
@@ -106,7 +106,7 @@ Please make sure you `follow our tips and tricks to run fMRIPrep's Singularity i
 <singularity.html>`_.
 
 
-Manually Prepared Environment (Python 3.5+)
+Manually Prepared Environment (Python 3.7+)
 ===========================================
 
 .. warning::
@@ -121,7 +121,7 @@ A relatively interpretable description of how your environment can be set-up
 is found in the `Dockerfile <https://github.com/poldracklab/fmriprep/blob/master/Dockerfile>`_.
 As an additional installation setting, FreeSurfer requires a license file (see :ref:`fs_license`).
 
-On a functional Python 3.5 (or above) environment with ``pip`` installed,
+On a functional Python 3.7 (or above) environment with ``pip`` installed,
 *fMRIPRep* can be installed using the habitual command ::
 
     $ python -m pip install fmriprep
@@ -134,7 +134,7 @@ Check your installation with the ``--version`` argument ::
 External Dependencies
 ---------------------
 
-*fMRIPRep* is written using Python 3.5 (or above), and is based on
+*fMRIPRep* is written using Python 3.7 (or above), and is based on
 nipype_.
 
 *fMRIPRep* requires some other neuroimaging software tools that are

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -7,5 +7,5 @@ in the *fMRIPrep* distribution.
 
 All trademarks referenced herein are property of their respective holders.
 
-Copyright (c) 2015-2019, the *fMRIPrep* developers and the CRN.
+Copyright (c) 2015-2020, the *fMRIPrep* developers and the CRN.
 All rights reserved.

--- a/fmriprep/__about__.py
+++ b/fmriprep/__about__.py
@@ -8,7 +8,7 @@ __version__ = get_versions()['version']
 del get_versions
 
 __packagename__ = 'fmriprep'
-__copyright__ = 'Copyright 2019, Center for Reproducible Neuroscience, Stanford University'
+__copyright__ = 'Copyright 2020, Center for Reproducible Neuroscience, Stanford University'
 __credits__ = ('Contributors: please check the ``.zenodo.json`` file at the top-level folder'
                'of the repository')
 __url__ = 'https://github.com/poldracklab/fmriprep'

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,12 +13,11 @@ classifiers =
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering :: Image Recognition
     License :: OSI Approved :: BSD License
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.5
+python_requires = >=3.7
 install_requires =
     indexed_gzip >= 0.8.8
     nibabel >= 3.0.1

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -20,7 +20,7 @@ import re
 import subprocess
 
 __version__ = '99.99.99'
-__copyright__ = 'Copyright 2019, Center for Reproducible Neuroscience, Stanford University'
+__copyright__ = 'Copyright 2020, Center for Reproducible Neuroscience, Stanford University'
 __credits__ = ['Craig Moodie', 'Ross Blair', 'Oscar Esteban', 'Chris Gorgolewski',
                'Shoshana Berleant', 'Christopher J. Markiewicz', 'Russell A. Poldrack']
 __bugreports__ = 'https://github.com/poldracklab/fmriprep/issues'


### PR DESCRIPTION
also removes a python 2 test of the docker wrapper, and bumps licenses up a year