### PR TITLE
FIX: Properly mount local templates

### DIFF
--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -428,6 +428,8 @@ def main():
         for space in opts.output_spaces:
             if space.split(':')[0] not in (TF_TEMPLATES + NONSTANDARD_REFERENCES):
                 tpl = os.path.basename(space)
+                if not tpl.startswith('tpl-'):
+                    raise RuntimeError("Custom template %s requires a `tpl-` prefix" % tpl)
                 target = '/home/fmriprep/.cache/templateflow/' + tpl
                 command.extend(['-v', ':'.join((os.path.abspath(space), target, 'ro'))])
                 spaces.append(tpl[4:])

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -427,9 +427,10 @@ def main():
         spaces = []
         for space in opts.output_spaces:
             if space.split(':')[0] not in (TF_TEMPLATES + NONSTANDARD_REFERENCES):
-                target = '/imports/' + os.path.basename(space)
+                tpl = os.path.basename(space)
+                target = '/home/fmriprep/.cache/templateflow/' + tpl
                 command.extend(['-v', ':'.join((os.path.abspath(space), target, 'ro'))])
-                spaces.append(target)
+                spaces.append(tpl[4:])
             else:
                 spaces.append(space)
         unknown_args.extend(['--output-spaces'] + spaces)


### PR DESCRIPTION
This PR re-enables use of custom templates after the output spaces refactoring.

The local directory where the custom template exists is now mounted to the TemplateFlow home within the container.

Related issue: https://neurostars.org/t/custom-template-fmriprep-20-0-1/6232