### PR TITLE
MNT: Pin minor series of nipype, major of nibabel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,8 @@ classifiers =
 python_requires = >=3.5
 install_requires =
     indexed_gzip >= 0.8.8
-    nibabel >= 3.0.1
-    nipype >= 1.3.1
+    nibabel ~= 3.0
+    nipype ~= 1.4.0
     nitime
     niworkflows ~= 1.1.8
     numpy


### PR DESCRIPTION
Based on a conversation in https://github.com/nipy/nipype/pull/3180, it seems prudent to pin to minor series of nipype. Nipype is on bug-fix-only patch releases. This fits well with our proposed rules for minor release series. Upgrading the nipype pin to a new minor release series would only be valid in minor releases of fMRIPrep.

I also pinned nibabel 3.0. Nibabel has very strict backwards-compatibility constraints within a major version series, so upgrading to a new minor release should not introduce any concerns even in bug-fix releases.

We might want to consider assessing other dependencies. With the prospect of long-term releases, unpinned dependencies become riskier.