### PR TITLE
ENH: Adapt fMRIPrep to upcoming sMRIPrep API changes

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -40,9 +40,9 @@ single reference template (see `Longitudinal processing`_).
         freesurfer=True,
         hires=True,
         longitudinal=False,
-        num_t1w=1,
         omp_nthreads=1,
         output_dir='.',
+        skull_strip_mode='force',
         skull_strip_template=Reference('MNI152NLin2009cAsym'),
         spaces=SpatialReferences([
             ('MNI152Lin', {}),
@@ -52,6 +52,7 @@ single reference template (see `Longitudinal processing`_).
         ]),
         reportlets_dir='.',
         skull_strip_fixed_seed=False,
+        t1w=['sub-01/anat/sub-01_T1w.nii.gz'],
     )
 
 See also *sMRIPrep*'s

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -222,16 +222,15 @@ It is released under the [CC0]\
         freesurfer=config.workflow.run_reconall,
         hires=config.workflow.hires,
         longitudinal=config.workflow.longitudinal,
-        num_t1w=len(subject_data['t1w']),
         omp_nthreads=config.nipype.omp_nthreads,
         output_dir=str(config.execution.output_dir),
         reportlets_dir=reportlets_dir,
         skull_strip_fixed_seed=config.workflow.skull_strip_fixed_seed,
-        # skull_strip_mode='force',
+        skull_strip_mode='force',
         skull_strip_template=Reference.from_string(
             config.workflow.skull_strip_template)[0],
         spaces=spaces,
-        # t1w=subject_data['t1w'],
+        t1w=subject_data['t1w'],
     )
 
     workflow.connect([
@@ -277,18 +276,14 @@ tasks and sessions), the following preprocessing was performed.
         workflow.connect([
             (anat_preproc_wf, func_preproc_wf,
              [(('outputnode.t1w_preproc', _pop), 'inputnode.t1w_preproc'),
-              ('outputnode.t1w_brain', 'inputnode.t1w_brain'),
               ('outputnode.t1w_mask', 'inputnode.t1w_mask'),
               ('outputnode.t1w_dseg', 'inputnode.t1w_dseg'),
               ('outputnode.t1w_aseg', 'inputnode.t1w_aseg'),
               ('outputnode.t1w_aparc', 'inputnode.t1w_aparc'),
               ('outputnode.t1w_tpms', 'inputnode.t1w_tpms'),
-              ('outputnode.template', 'inputnode.template'),
-              ('outputnode.anat2std_xfm', 'inputnode.anat2std_xfm'),
-              ('outputnode.std2anat_xfm', 'inputnode.std2anat_xfm'),
-              ('outputnode.joint_template', 'inputnode.joint_template'),
-              ('outputnode.joint_anat2std_xfm', 'inputnode.joint_anat2std_xfm'),
-              ('outputnode.joint_std2anat_xfm', 'inputnode.joint_std2anat_xfm'),
+              ('outputnode.joint_template', 'inputnode.template'),
+              ('outputnode.joint_anat2std_xfm', 'inputnode.anat2std_xfm'),
+              ('outputnode.joint_std2anat_xfm', 'inputnode.std2anat_xfm'),
               # Undefined if --fs-no-reconall, but this is safe
               ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
               ('outputnode.subject_id', 'inputnode.subject_id'),

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,16 +21,16 @@ python_requires = >=3.7
 install_requires =
     indexed_gzip >= 0.8.8
     nibabel ~= 3.0
-    nipype ~= 1.4.0
+    nipype ~= 1.4
     nitime
-    niworkflows @ git+https://github.com/nipreps/niworkflows.git@76f831f1f8fbf6c277fdf92535639bbf11d84527
+    niworkflows ~= 1.1.9
     numpy
     pandas
     psutil >= 5.4
     pybids >= 0.10.0
     pyyaml
     sdcflows ~= 1.2.0
-    smriprep ~= 0.5.2
+    smriprep >= 0.6.0rc1
     tedana >= 0.0.5
     templateflow >= 0.5.1rc1
     toml

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     pybids >= 0.10.0
     pyyaml
     sdcflows ~= 1.2.0
-    smriprep >= 0.6.0rc1
+    smriprep >= 0.6.0rc1,<0.7
     tedana >= 0.0.5
     templateflow >= 0.5.1rc1
     toml


### PR DESCRIPTION
In particular, poldracklab/fmriprep#167 introduces a few changes that need to be considered before #1829 is merged:

  - The new `skull_strip_mode` argument for the anatomical workflow (poldracklab/smriprep#167)
  - The functional workflow does not require parameterized inputs
  - The anatomical workflow no longer produces a brain-masked conversion of the T1w.