### PR TITLE
ENH: Use CIFTI for carpetplot when available

### DIFF
--- a/fmriprep/data/reports-spec.yml
+++ b/fmriprep/data/reports-spec.yml
@@ -108,10 +108,10 @@ sections:
       the white-matter (WM) and within cerebro-spinal fluid (CSF) show the mean BOLD
       signal in their corresponding masks. DVARS and FD show the standardized DVARS
       and framewise-displacement measures for each time point.<br />A carpet plot
-      shows the time series for all voxels within the brain mask. Voxels are grouped
-      into cortical (blue), and subcortical (orange) gray matter, cerebellum (green)
-      and white matter and CSF (red), indicated by the color map on the left-hand
-      side.
+      shows the time series for all voxels within the brain mask, or if CIFTI output
+      was enabled, all grayordinates. Voxels are grouped into cortical (dark/light blue),
+      and subcortical (orange) gray matter, cerebellum (green) and white matter and CSF
+      (red), indicated by the color map on the left-hand side.
     subtitle: BOLD Summary
   - bids: {datatype: func, desc: 'confoundcorr', suffix: bold}
     caption: |

--- a/fmriprep/data/reports-spec.yml
+++ b/fmriprep/data/reports-spec.yml
@@ -108,7 +108,7 @@ sections:
       the white-matter (WM) and within cerebro-spinal fluid (CSF) show the mean BOLD
       signal in their corresponding masks. DVARS and FD show the standardized DVARS
       and framewise-displacement measures for each time point.<br />A carpet plot
-      shows the time series for all voxels within the brain mask, or if CIFTI output
+      shows the time series for all voxels within the brain mask, or if ``--cifti-output``
       was enabled, all grayordinates. Voxels are grouped into cortical (dark/light blue),
       and subcortical (orange) gray matter, cerebellum (green) and white matter and CSF
       (red), indicated by the color map on the left-hand side.

--- a/fmriprep/interfaces/confounds.py
+++ b/fmriprep/interfaces/confounds.py
@@ -282,8 +282,8 @@ def _get_ica_confounds(ica_out_dir, skip_vols, newpath=None):
 
 class FMRISummaryInputSpec(BaseInterfaceInputSpec):
     in_func = File(exists=True, mandatory=True,
-                   desc='input BOLD time-series (4D file)')
-    in_mask = File(exists=True, mandatory=True,
+                   desc='input BOLD time-series (4D file) or dense timeseries CIFTI')
+    in_mask = File(exists=True,
                    desc='3D brain mask')
     in_segm = File(exists=True, desc='resampled segmentation')
     confounds_file = File(exists=True,
@@ -353,7 +353,7 @@ class FMRISummary(SimpleInterface):
 
         fig = fMRIPlot(
             self.inputs.in_func,
-            mask_file=self.inputs.in_mask,
+            mask_file=self.inputs.in_mask if isdefined(self.inputs.in_mask) else None,
             seg_file=(self.inputs.in_segm
                       if isdefined(self.inputs.in_segm) else None),
             tr=self.inputs.tr,


### PR DESCRIPTION
Closes #2026 

Uses BOLD CIFTI file to generate carpetplot when available
Depends on nipreps/niworkflows#491