### PR TITLE
FIX: Restore omp-nthreads calculation

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -316,7 +316,6 @@ def parse_args(args=None, namespace=None):
     opts = parser.parse_args(args, namespace)
     config.execution.log_level = int(max(25 - 5 * opts.verbose_count, logging.DEBUG))
     config.from_dict(vars(opts))
-    config.loggers.init()
 
     # Initialize --output-spaces if not defined
     if config.execution.output_spaces is None:

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -102,7 +102,7 @@ def _build_parser():
 
     g_perfm = parser.add_argument_group('Options to handle performance')
     g_perfm.add_argument(
-        '--nprocs', '--nthreads', '--n_cpus', '-n-cpus', action='store', type=PositiveInt,
+        '--nprocs', '--nthreads', '--n_cpus', '--n-cpus', action='store', type=PositiveInt,
         help='maximum number of threads across all processes')
     g_perfm.add_argument('--omp-nthreads', action='store', type=PositiveInt,
                          help='maximum number of threads per-process')

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -251,7 +251,7 @@ class nipype(_Config):
     """Estimation in GB of the RAM this workflow can allocate at any given time."""
     nprocs = os.cpu_count()
     """Number of processes (compute tasks) that can be run in parallel (multiprocessing only)."""
-    omp_nthreads = os.cpu_count()
+    omp_nthreads = None
     """Number of CPUs a single process can access for multithreaded execution."""
     plugin = 'MultiProc'
     """NiPype's execution plugin."""
@@ -303,6 +303,9 @@ class nipype(_Config):
                 'stop_on_first_crash': cls.stop_on_first_crash,
             }
         })
+
+        if cls.omp_nthreads is None:
+            cls.omp_nthreads = min(cls.nprocs - 1 if cls.nprocs > 1 else os.cpu_count(), 8)
 
 
 class execution(_Config):


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

This restores the default value of` omp-nthreads` based on `n-cpus` established in #500 and removed in #2018.

Fixes #2070.


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
