### PR TITLE
ENH: Keep track and allow reuse of random seeds with the config module

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -8,7 +8,6 @@ from .. import config
 
 def _build_parser():
     """Build parser object."""
-    from datetime import datetime
     from functools import partial
     from pathlib import Path
     from argparse import (
@@ -46,8 +45,6 @@ def _build_parser():
         from json import loads
         if value and Path(value).exists():
             return loads(Path(value).read_text())
-
-    _date_to_num = datetime.now().strftime('%Y%M%d')
 
     verstr = f'fMRIPrep v{config.environment.version}'
     currentv = Version(config.environment.version)
@@ -177,6 +174,10 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html""" % (currentv.base_version
     g_conf.add_argument(
         '--dummy-scans', required=False, action='store', default=None, type=int,
         help='Number of non steady state volumes.')
+    g_conf.add_argument(
+        '--random-seed', action='store', type=int, default=None,
+        help='Initialize the random seed for the workflow'
+    )
 
     # ICA_AROMA options
     g_aroma = parser.add_argument_group('Specific options for running ICA_AROMA')
@@ -214,9 +215,7 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html""" % (currentv.base_version
     g_ants.add_argument('--skull-strip-fixed-seed', action='store_true',
                         help='do not use a random seed for skull-stripping - will ensure '
                              'run-to-run replicability when used with --omp-nthreads 1 and '
-                             '--ants-fixed-seed <int>')
-    g_ants.add_argument('--ants-fixed-seed', action='store', default=_date_to_num,
-                        help='Seed to use for antsRegistration')
+                             'matching --master-random-seed <int>')
     g_ants.add_argument(
         '--skull-strip-t1w', action='store', choices=('auto', 'skip', 'force'), default='force',
         help="determiner for T1-weighted skull stripping ('force' ensures skull "

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -215,7 +215,7 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html""" % (currentv.base_version
     g_ants.add_argument('--skull-strip-fixed-seed', action='store_true',
                         help='do not use a random seed for skull-stripping - will ensure '
                              'run-to-run replicability when used with --omp-nthreads 1 and '
-                             'matching --master-random-seed <int>')
+                             'matching --random-seed <int>')
     g_ants.add_argument(
         '--skull-strip-t1w', action='store', choices=('auto', 'skip', 'force'), default='force',
         help="determiner for T1-weighted skull stripping ('force' ensures skull "

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -8,6 +8,7 @@ from .. import config
 
 def _build_parser():
     """Build parser object."""
+    from datetime import datetime
     from functools import partial
     from pathlib import Path
     from argparse import (
@@ -45,6 +46,8 @@ def _build_parser():
         from json import loads
         if value and Path(value).exists():
             return loads(Path(value).read_text())
+
+    _date_to_num = datetime.now().strftime('%Y%M%d')
 
     verstr = f'fMRIPrep v{config.environment.version}'
     currentv = Version(config.environment.version)
@@ -210,7 +213,10 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html""" % (currentv.base_version
         help='select a template for skull-stripping with antsBrainExtraction')
     g_ants.add_argument('--skull-strip-fixed-seed', action='store_true',
                         help='do not use a random seed for skull-stripping - will ensure '
-                             'run-to-run replicability when used with --omp-nthreads 1')
+                             'run-to-run replicability when used with --omp-nthreads 1 and '
+                             '--ants-fixed-seed <int>')
+    g_ants.add_argument('--ants-fixed-seed', action='store', default=_date_to_num,
+                        help='Seed to use for antsRegistration')
     g_ants.add_argument(
         '--skull-strip-t1w', action='store', choices=('auto', 'skip', 'force'), default='force',
         help="determiner for T1-weighted skull stripping ('force' ensures skull "

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -45,9 +45,6 @@ def main():
     # state of fMRIPrep).
     config.load(config_file)
 
-    if config.workflow.ants_fixed_seed:
-        os.environ['ANTS_RANDOM_SEED'] = config.workflow.ants_fixed_seed
-
     if config.execution.reports_only:
         sys.exit(int(retcode > 0))
 

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -45,6 +45,9 @@ def main():
     # state of fMRIPrep).
     config.load(config_file)
 
+    if config.workflow.ants_fixed_seed:
+        os.environ['ANTS_RANDOM_SEED'] = config.workflow.ants_fixed_seed
+
     if config.execution.reports_only:
         sys.exit(int(retcode > 0))
 

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -402,8 +402,6 @@ del _oc_policy
 class workflow(_Config):
     """Configure the particular execution graph of this workflow."""
 
-    ants_fixed_seed = None
-    """Fix random seed for antsRegistration, antsAI, antsMotionCorr"""
     anat_only = False
     """Execute the anatomical preprocessing only."""
     aroma_err_on_warn = None
@@ -429,8 +427,8 @@ class workflow(_Config):
     """Ignore particular steps for *fMRIPrep*."""
     longitudinal = False
     """Run FreeSurfer ``recon-all`` with the ``-logitudinal`` flag."""
-    master_seed = None
-    """Master seed to initialize the Pseudorandom Number Generator (PRNG)"""
+    random_seed = None
+    """Master random seed to initialize the Pseudorandom Number Generator (PRNG)"""
     medial_surface_nan = None
     """Fill medial surface with :abbr:`NaNs (not-a-number)` when sampling."""
     regressors_all_comps = None
@@ -519,7 +517,7 @@ class seeds(_Config):
 
     @classmethod
     def init(cls):
-        cls.master = workflow.master_seed
+        cls.master = workflow.random_seed
         if cls.master is None:
             cls.master = random.randint(1, 65536)
         random.seed(cls.master)  # initialize the PRNG

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -401,6 +401,8 @@ del _oc_policy
 class workflow(_Config):
     """Configure the particular execution graph of this workflow."""
 
+    ants_fixed_seed = None
+    """Fix random seed for antsRegistration, antsAI, antsMotionCorr"""
     anat_only = False
     """Execute the anatomical preprocessing only."""
     aroma_err_on_warn = None


### PR DESCRIPTION
~~This PR sets and tracks `ANTS_RANDOM_SEED` environmental for increased run-to-run reproducibility. By default, this value is set to a string representation of the current date in `YYYYMMDD` format. Additionally, a parser option `--ants-fixed-seed` is added to allow manually setting this option.~~

This PR adds a new section to the config, *seeds*, that tracks and sets random seeds. Firstly, a master seed is generated, or can be passed in via the new `--random-seed` argument. This seed initiates the PRNG and reproducibly generates program specific seeds. ANTs is the only seed currently tracked.

NOTE: `ANTS_RANDOM_SEED` is only used for some ANTs interfaces (https://github.com/ANTsX/ANTsR/issues/210#issuecomment-538812296)