### PR TITLE
(enh) add fraction of variance explained by ICA-AROMA components to metadata

### DIFF
--- a/fmriprep/interfaces/confounds.py
+++ b/fmriprep/interfaces/confounds.py
@@ -224,6 +224,7 @@ def _get_ica_confounds(ica_out_dir, skip_vols, newpath=None):
     melodic_mix = os.path.join(ica_out_dir, 'melodic.ica/melodic_mix')
     motion_ics = os.path.join(ica_out_dir, 'classified_motion_ICs.txt')
     aroma_metadata = os.path.join(ica_out_dir, 'classification_overview.txt')
+    aroma_icstats = os.path.join(ica_out_dir, 'melodic.ica/melodic_ICstats')
 
     # Change names of motion_ics and melodic_mix for output
     melodic_mix_out = os.path.join(newpath, 'MELODICmix.tsv')
@@ -252,9 +253,17 @@ def _get_ica_confounds(ica_out_dir, skip_vols, newpath=None):
         'aroma_motion_{}'.format(name) for name in aroma_metadata['IC']]
     aroma_metadata.columns = [
         re.sub(r'[ |\-|\/]', '_', c) for c in aroma_metadata.columns]
+
+    # Add variance statistics to metadata
+    aroma_icstats = pd.read_csv(
+        aroma_icstats, header=None, sep='  ')[[0, 1]] / 100
+    aroma_icstats.columns = [
+        'model_variance_explained', 'total_variance_explained']
+    aroma_metadata = pd.concat([aroma_metadata, aroma_icstats], axis=1)
+
     aroma_metadata.to_csv(aroma_metadata_out, sep='\t', index=False)
 
-    # Return dummy list of ones if no noise compnents were found
+    # Return dummy list of ones if no noise components were found
     if motion_ic_indices.size == 0:
         LOGGER.warning('No noise components were classified')
         return None, motion_ics_out, melodic_mix_out, aroma_metadata_out


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

* Resolves #2062 .
  * Using example MELODIC reports, I was able to figure out that the first column of the `melodic_ICstats` file records the fraction of the model variance explained.
  * The second column records the fraction of the total variance explained.
  * I am not able to discern what the third and fourth columns record, but adding those metadata should be an easy change if we can figure this out.

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
