### PR TITLE
ENH: add options to patch in other dependencies

### DIFF
--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -375,10 +375,9 @@ def main():
     # Patch working repositories into installed package directories
     if opts.patch:
         for pkg, repo_path in opts.patch.items():
-            if repo_path is not None:
-                command.extend(
-                    ['-v', '{}:{}/{}:ro'.format(repo_path, PKG_PATH, pkg)]
-                )
+            command.extend(
+                ['-v', '{}:{}/{}:ro'.format(repo_path, PKG_PATH, pkg)]
+            )
 
     if opts.env:
         for envvar in opts.env:

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -288,6 +288,10 @@ the spatial normalization.""" % (', '.join('"%s"' % s for s in TF_TEMPLATES),
     g_dev.add_argument('-p', '--patch-nipype', metavar='PATH',
                        type=os.path.abspath,
                        help='working nipype repository')
+    g_dev.add_argument('--patch-smriprep', metavar='PATH', type=os.path.abspath,
+                       help='working smriprep repository')
+    g_dev.add_argument('--patch-sdcflows', metavar='PATH', type=os.path.abspath,
+                       help='working sdcflows repository')
     g_dev.add_argument('--shell', action='store_true',
                        help='open shell in image instead of running FMRIPREP')
     g_dev.add_argument('--config', metavar='PATH', action='store',
@@ -371,7 +375,7 @@ def main():
                'DOCKER_VERSION_8395080871=%s' % docker_version]
 
     # Patch working repositories into installed package directories
-    for pkg in ('fmriprep', 'niworkflows', 'nipype'):
+    for pkg in ('fmriprep', 'niworkflows', 'nipype', 'smriprep', 'sdcflows'):
         repo_path = getattr(opts, 'patch_' + pkg)
         if repo_path is not None:
             command.extend(['-v',


### PR DESCRIPTION
While testing the wrapper, I realize we don't make it easy to patch all our "in-house" dependencies.

This PR removes package specific `--patch-x` calls and instead adds a new argument, `--patch`, which supports one or more key value pairs of package, package path.

For example:
```
fmriprep-docker ... --patch fmriprep=/code/fmriprep/fmriprep smriprep=/code/smriprep/smriprep
```