### PR TITLE
ENH: ability to reuse existing config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -660,7 +660,7 @@ jobs:
                 /tmp/data/${DATASET} /tmp/${DATASET}/derivatives participant \
                 --fs-no-reconall --sloppy --write-graph \
                 --output-spaces MNI152NLin2009cAsym:res-2 anat func \
-                --reports-only --run-uuid $UUID
+                --reports-only
             RET=$?
             set -e
             [[ "$RET" -eq "1" ]]

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -289,6 +289,7 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html"""
     )
     g_conf.add_argument(
         "--random-seed",
+        dest="_random_seed",
         action="store",
         type=int,
         default=None,

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -543,10 +543,15 @@ def parse_args(args=None, namespace=None):
     parser = _build_parser()
     opts = parser.parse_args(args, namespace)
 
-    new_config = os.getenv('FMRIPREP_NO_REUSE_CONFIG') or opts.reports_only
+    new_config = os.getenv('FMRIPREP_NO_REUSE_CONFIG')
     if not new_config:
         # attempt to reuse previous config
-        config.load_previous_config(opts.output_dir, opts.work_dir, opts.participant_label)
+        config.load_previous_config(
+            opts.output_dir,
+            opts.work_dir,
+            participant=opts.participant_label,
+            new_uuid=not opts.reports_only,
+        )
 
     config.execution.log_level = int(max(25 - 5 * opts.verbose_count, logging.DEBUG))
     config.from_dict(vars(opts))

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -476,13 +476,6 @@ https://fmriprep.readthedocs.io/en/%s/spaces.html"""
         "aggregation, not reportlet generation for specific nodes.",
     )
     g_other.add_argument(
-        "--run-uuid",
-        action="store",
-        default=None,
-        help="Specify UUID of previous run, to include error logs in report. "
-        "No effect without --reports-only.",
-    )
-    g_other.add_argument(
         "--write-graph",
         action="store_true",
         default=False,
@@ -541,12 +534,19 @@ discourage its usage."""
 
 def parse_args(args=None, namespace=None):
     """Parse args and run further checks on the command line."""
+    import os
     import logging
     from niworkflows.utils.spaces import Reference, SpatialReferences
     from niworkflows.utils.misc import check_valid_fs_license
 
     parser = _build_parser()
     opts = parser.parse_args(args, namespace)
+
+    new_config = os.getenv('FMRIPREP_NO_REUSE_CONFIG') or opts.reports_only
+    if not new_config:
+        # attempt to reuse previous config
+        config.load_previous_config(opts.output_dir, opts.work_dir, opts.participant_label)
+
     config.execution.log_level = int(max(25 - 5 * opts.verbose_count, logging.DEBUG))
     config.from_dict(vars(opts))
 

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -630,7 +630,7 @@ def init_spaces(checkpoint=True):
     workflow.spaces = spaces
 
 
-def load_previous_config(output_dir, work_dir, participant=None):
+def load_previous_config(output_dir, work_dir, participant=None, new_uuid=True):
     """
     Search for existing config file, and carry over previous options.
     If a participant label is specified, the output directory is searched for
@@ -642,10 +642,6 @@ def load_previous_config(output_dir, work_dir, participant=None):
         Existing config found and loaded
 
     """
-    # settings to avoid reusing
-    skip = {
-        'execution': ('run_uuid',)
-    }
     conf = None
     if participant:
         # output directory
@@ -663,6 +659,8 @@ def load_previous_config(output_dir, work_dir, participant=None):
 
     # load existing config
     if conf is not None:
+        # settings to avoid reusing
+        skip = {} if new_uuid else {'execution': ('run_uuid',)}
         print(f"Reusing config file {conf}")
         load(conf, skip=skip)
         return True

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -433,8 +433,6 @@ class workflow(_Config):
     """Ignore particular steps for *fMRIPrep*."""
     longitudinal = False
     """Run FreeSurfer ``recon-all`` with the ``-logitudinal`` flag."""
-    random_seed = None
-    """Master random seed to initialize the Pseudorandom Number Generator (PRNG)"""
     medial_surface_nan = None
     """Fill medial surface with :abbr:`NaNs (not-a-number)` when sampling."""
     regressors_all_comps = None
@@ -513,18 +511,19 @@ class loggers:
 class seeds(_Config):
     """Initialize the PRNG and track random seed assignments"""
 
+    _random_seed = None
     master = None
-    """Master seed used to generate all other tracked seeds"""
+    """Master random seed to initialize the Pseudorandom Number Generator (PRNG)"""
     ants = None
     """Seed used for antsRegistration, antsAI, antsMotionCorr"""
 
     @classmethod
     def init(cls):
-        cls.master = workflow.random_seed
+        if cls._random_seed is not None:
+            cls.master = cls._random_seed
         if cls.master is None:
             cls.master = random.randint(1, 65536)
         random.seed(cls.master)  # initialize the PRNG
-
         # functions to set program specific seeds
         cls.ants = _set_ants_seed()
 
@@ -541,7 +540,7 @@ def from_dict(settings):
     nipype.load(settings)
     execution.load(settings)
     workflow.load(settings)
-    seeds.init()
+    seeds.load(settings)
     loggers.init()
 
 

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -86,7 +86,7 @@ finally:
     from time import strftime
 
     from pathlib import Path
-    from nipype import logging as nlogging, __version__ as _nipype_ver
+    from nipype import __version__ as _nipype_ver
     from templateflow import __version__ as _tf_ver
     from . import __version__
 
@@ -171,10 +171,9 @@ class _Config:
     @classmethod
     def load(cls, settings, init=True, ignore=None):
         """Store settings from a dictionary."""
+        ignore = ignore or {}
         for k, v in settings.items():
-            if ignore and k in ignore:
-                continue
-            if v is None:
+            if k in ignore or v is None:
                 continue
             if k in cls._paths:
                 setattr(cls, k, Path(v).absolute())
@@ -472,11 +471,11 @@ class loggers:
     """The root logger."""
     cli = logging.getLogger('cli')
     """Command-line interface logging."""
-    workflow = nlogging.getLogger('nipype.workflow')
+    workflow = logging.getLogger('nipype.workflow')
     """NiPype's workflow logger."""
-    interface = nlogging.getLogger('nipype.interface')
+    interface = logging.getLogger('nipype.interface')
     """NiPype's interface logger."""
-    utils = nlogging.getLogger('nipype.utils')
+    utils = logging.getLogger('nipype.utils')
     """NiPype's utils logger."""
 
     @classmethod
@@ -661,8 +660,8 @@ def load_previous_config(output_dir, work_dir, participant=None, new_uuid=True):
     if conf is not None:
         # settings to avoid reusing
         skip = {} if new_uuid else {'execution': ('run_uuid',)}
-        print(f"Reusing config file {conf}")
         load(conf, skip=skip)
+        loggers.cli.warning(f"Loaded previous configuration file {conf}")
         return True
 
     return False


### PR DESCRIPTION
Allows loading configuration files from previous fmriprep runs.

By default, all fields besides `run_uuid` are copied. Most options can be overwritten by CLI options.