### PR TITLE
MAINT: bump templateflow to auto-update skeleton

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,10 +30,10 @@ install_requires =
     psutil >= 5.4
     pybids >= 0.9.4
     pyyaml
-    sdcflows ~= 1.2.2
+    sdcflows ~= 1.2.2, != 1.2.3
     smriprep ~= 0.5.2
     tedana >= 0.0.5
-    templateflow >= 0.5.1rc1
+    templateflow >= 0.6.0
 test_requires =
     coverage
     codecov


### PR DESCRIPTION
This bumps the minimum templateflow to [0.6.0](https://github.com/templateflow/python-client/releases/tag/0.6.0), which includes an automatic update mechanism to update the local template skeleton.

This should reduce the burden of having to update the python templateflow client every time a change has been made to the skeleton.