### PR TITLE
MAINT: Stop printing full boilerplate, ``black fmriprep/cli``

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -31,118 +31,204 @@ def _build_parser():
         return value
 
     def _to_gb(value):
-        scale = {"G": 1, "T": 10**3, "M": 1e-3, "K": 1e-6, "B": 1e-9}
-        digits = ''.join([c for c in value if c.isdigit()])
+        scale = {"G": 1, "T": 10 ** 3, "M": 1e-3, "K": 1e-6, "B": 1e-9}
+        digits = "".join([c for c in value if c.isdigit()])
         units = value[len(digits):] or "M"
         return int(digits) * scale[units[0]]
 
     def _drop_sub(value):
         value = str(value)
-        return value.lstrip('sub-')
+        return value.lstrip("sub-")
 
     def _bids_filter(value):
         from json import loads
+
         if value and Path(value).exists():
             return loads(Path(value).read_text())
 
-    verstr = f'fMRIPrep v{config.environment.version}'
+    verstr = f"fMRIPrep v{config.environment.version}"
     currentv = Version(config.environment.version)
-    is_release = not any((currentv.is_devrelease, currentv.is_prerelease, currentv.is_postrelease))
+    is_release = not any(
+        (currentv.is_devrelease, currentv.is_prerelease, currentv.is_postrelease)
+    )
 
     parser = ArgumentParser(
-        description='fMRIPrep: fMRI PREProcessing workflows v{}'.format(
-            config.environment.version),
-        formatter_class=ArgumentDefaultsHelpFormatter)
+        description="fMRIPrep: fMRI PREProcessing workflows v{}".format(
+            config.environment.version
+        ),
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
     PathExists = partial(_path_exists, parser=parser)
     PositiveInt = partial(_min_one, parser=parser)
 
     # Arguments as specified by BIDS-Apps
     # required, positional arguments
     # IMPORTANT: they must go directly with the parser object
-    parser.add_argument('bids_dir', action='store', type=PathExists,
-                        help='the root folder of a BIDS valid dataset (sub-XXXXX folders should '
-                             'be found at the top level in this folder).')
-    parser.add_argument('output_dir', action='store', type=Path,
-                        help='the output path for the outcomes of preprocessing and visual '
-                             'reports')
-    parser.add_argument('analysis_level', choices=['participant'],
-                        help='processing stage to be run, only "participant" in the case of '
-                             'fMRIPrep (see BIDS-Apps specification).')
+    parser.add_argument(
+        "bids_dir",
+        action="store",
+        type=PathExists,
+        help="the root folder of a BIDS valid dataset (sub-XXXXX folders should "
+        "be found at the top level in this folder).",
+    )
+    parser.add_argument(
+        "output_dir",
+        action="store",
+        type=Path,
+        help="the output path for the outcomes of preprocessing and visual " "reports",
+    )
+    parser.add_argument(
+        "analysis_level",
+        choices=["participant"],
+        help='processing stage to be run, only "participant" in the case of '
+        "fMRIPrep (see BIDS-Apps specification).",
+    )
 
     # optional arguments
-    parser.add_argument('--version', action='version', version=verstr)
+    parser.add_argument("--version", action="version", version=verstr)
 
-    g_bids = parser.add_argument_group('Options for filtering BIDS queries')
-    g_bids.add_argument('--skip_bids_validation', '--skip-bids-validation', action='store_true',
-                        default=False,
-                        help='assume the input dataset is BIDS compliant and skip the validation')
+    g_bids = parser.add_argument_group("Options for filtering BIDS queries")
     g_bids.add_argument(
-        '--participant-label', '--participant_label', action='store', nargs='+', type=_drop_sub,
-        help='a space delimited list of participant identifiers or a single '
-             'identifier (the sub- prefix can be removed)')
+        "--skip_bids_validation",
+        "--skip-bids-validation",
+        action="store_true",
+        default=False,
+        help="assume the input dataset is BIDS compliant and skip the validation",
+    )
+    g_bids.add_argument(
+        "--participant-label",
+        "--participant_label",
+        action="store",
+        nargs="+",
+        type=_drop_sub,
+        help="a space delimited list of participant identifiers or a single "
+        "identifier (the sub- prefix can be removed)",
+    )
     # Re-enable when option is actually implemented
     # g_bids.add_argument('-s', '--session-id', action='store', default='single_session',
     #                     help='select a specific session to be processed')
     # Re-enable when option is actually implemented
     # g_bids.add_argument('-r', '--run-id', action='store', default='single_run',
     #                     help='select a specific run to be processed')
-    g_bids.add_argument('-t', '--task-id', action='store',
-                        help='select a specific task to be processed')
-    g_bids.add_argument('--echo-idx', action='store', type=int,
-                        help='select a specific echo to be processed in a multiecho series')
     g_bids.add_argument(
-        '--bids-filter-file', dest='bids_filters', action='store',
-        type=_bids_filter, metavar='PATH',
+        "-t", "--task-id", action="store", help="select a specific task to be processed"
+    )
+    g_bids.add_argument(
+        "--echo-idx",
+        action="store",
+        type=int,
+        help="select a specific echo to be processed in a multiecho series",
+    )
+    g_bids.add_argument(
+        "--bids-filter-file",
+        dest="bids_filters",
+        action="store",
+        type=_bids_filter,
+        metavar="PATH",
         help="a JSON file describing custom BIDS input filters using PyBIDS. "
-             "For further details, please check out "
-             "https://fmriprep.readthedocs.io/en/%s/faq.html#"
-             "how-do-I-select-only-certain-files-to-be-input-to-fMRIPrep" % (
-                 currentv.base_version if is_release else 'latest'))
+        "For further details, please check out "
+        "https://fmriprep.readthedocs.io/en/%s/faq.html#"
+        "how-do-I-select-only-certain-files-to-be-input-to-fMRIPrep"
+        % (currentv.base_version if is_release else "latest"),
+    )
     g_bids.add_argument(
-        "--anat-derivatives", action='store', metavar="PATH", type=PathExists,
+        "--anat-derivatives",
+        action="store",
+        metavar="PATH",
+        type=PathExists,
         help="Reuse the anatomical derivatives from another fMRIPrep run or calculated "
-             "with an alternative processing tool (NOT RECOMMENDED)."
+        "with an alternative processing tool (NOT RECOMMENDED).",
     )
 
-    g_perfm = parser.add_argument_group('Options to handle performance')
+    g_perfm = parser.add_argument_group("Options to handle performance")
     g_perfm.add_argument(
-        '--nprocs', '--nthreads', '--n_cpus', '--n-cpus', action='store', type=PositiveInt,
-        help='maximum number of threads across all processes')
-    g_perfm.add_argument('--omp-nthreads', action='store', type=PositiveInt,
-                         help='maximum number of threads per-process')
-    g_perfm.add_argument('--mem', '--mem_mb', '--mem-mb', dest='memory_gb',
-                         action='store', type=_to_gb,
-                         help='upper bound memory limit for fMRIPrep processes')
-    g_perfm.add_argument('--low-mem', action='store_true',
-                         help='attempt to reduce memory usage (will increase disk usage '
-                              'in working directory)')
-    g_perfm.add_argument('--use-plugin', action='store', default=None,
-                         help='nipype plugin configuration file')
-    g_perfm.add_argument('--anat-only', action='store_true',
-                         help='run anatomical workflows only')
-    g_perfm.add_argument('--boilerplate_only', action='store_true', default=False,
-                         help='generate boilerplate only')
-    g_perfm.add_argument('--md-only-boilerplate', action='store_true',
-                         default=False,
-                         help='skip generation of HTML and LaTeX formatted citation with pandoc')
-    g_perfm.add_argument('--error-on-aroma-warnings', action='store_true',
-                         dest='aroma_err_on_warn', default=False,
-                         help='Raise an error if ICA_AROMA does not produce sensible output '
-                              '(e.g., if all the components are classified as signal or noise)')
-    g_perfm.add_argument("-v", "--verbose", dest="verbose_count", action="count", default=0,
-                         help="increases log verbosity for each occurence, debug level is -vvv")
+        "--nprocs",
+        "--nthreads",
+        "--n_cpus",
+        "--n-cpus",
+        action="store",
+        type=PositiveInt,
+        help="maximum number of threads across all processes",
+    )
+    g_perfm.add_argument(
+        "--omp-nthreads",
+        action="store",
+        type=PositiveInt,
+        help="maximum number of threads per-process",
+    )
+    g_perfm.add_argument(
+        "--mem",
+        "--mem_mb",
+        "--mem-mb",
+        dest="memory_gb",
+        action="store",
+        type=_to_gb,
+        help="upper bound memory limit for fMRIPrep processes",
+    )
+    g_perfm.add_argument(
+        "--low-mem",
+        action="store_true",
+        help="attempt to reduce memory usage (will increase disk usage "
+        "in working directory)",
+    )
+    g_perfm.add_argument(
+        "--use-plugin",
+        action="store",
+        default=None,
+        help="nipype plugin configuration file",
+    )
+    g_perfm.add_argument(
+        "--anat-only", action="store_true", help="run anatomical workflows only"
+    )
+    g_perfm.add_argument(
+        "--boilerplate_only",
+        action="store_true",
+        default=False,
+        help="generate boilerplate only",
+    )
+    g_perfm.add_argument(
+        "--md-only-boilerplate",
+        action="store_true",
+        default=False,
+        help="skip generation of HTML and LaTeX formatted citation with pandoc",
+    )
+    g_perfm.add_argument(
+        "--error-on-aroma-warnings",
+        action="store_true",
+        dest="aroma_err_on_warn",
+        default=False,
+        help="Raise an error if ICA_AROMA does not produce sensible output "
+        "(e.g., if all the components are classified as signal or noise)",
+    )
+    g_perfm.add_argument(
+        "-v",
+        "--verbose",
+        dest="verbose_count",
+        action="count",
+        default=0,
+        help="increases log verbosity for each occurence, debug level is -vvv",
+    )
 
-    g_conf = parser.add_argument_group('Workflow configuration')
+    g_conf = parser.add_argument_group("Workflow configuration")
     g_conf.add_argument(
-        '--ignore', required=False, action='store', nargs="+", default=[],
-        choices=['fieldmaps', 'slicetiming', 'sbref'],
-        help='ignore selected aspects of the input dataset to disable corresponding '
-             'parts of the workflow (a space delimited list)')
+        "--ignore",
+        required=False,
+        action="store",
+        nargs="+",
+        default=[],
+        choices=["fieldmaps", "slicetiming", "sbref"],
+        help="ignore selected aspects of the input dataset to disable corresponding "
+        "parts of the workflow (a space delimited list)",
+    )
     g_conf.add_argument(
-        '--longitudinal', action='store_true',
-        help='treat dataset as longitudinal - may increase runtime')
+        "--longitudinal",
+        action="store_true",
+        help="treat dataset as longitudinal - may increase runtime",
+    )
     g_conf.add_argument(
-        '--output-spaces', nargs='*', action=OutputReferencesAction,
+        "--output-spaces",
+        nargs="*",
+        action=OutputReferencesAction,
         help="""\
 Standard and non-standard spaces to resample anatomical and functional images to. \
 Standard spaces may be specified by the form \
@@ -153,160 +239,297 @@ Non-standard spaces imply specific orientations and sampling grids. \
 Important to note, the ``res-*`` modifier does not define the resolution used for \
 the spatial normalization. To generate no BOLD outputs, use this option without specifying \
 any spatial references. For further details, please check out \
-https://fmriprep.readthedocs.io/en/%s/spaces.html""" % (currentv.base_version
-                                                        if is_release else 'latest'))
+https://fmriprep.readthedocs.io/en/%s/spaces.html"""
+        % (currentv.base_version if is_release else "latest"),
+    )
 
-    g_conf.add_argument('--bold2t1w-dof', action='store', default=6, choices=[6, 9, 12], type=int,
-                        help='Degrees of freedom when registering BOLD to T1w images. '
-                             '6 degrees (rotation and translation) are used by default.')
     g_conf.add_argument(
-        '--force-bbr', action='store_true', dest='use_bbr', default=None,
-        help='Always use boundary-based registration (no goodness-of-fit checks)')
+        "--bold2t1w-dof",
+        action="store",
+        default=6,
+        choices=[6, 9, 12],
+        type=int,
+        help="Degrees of freedom when registering BOLD to T1w images. "
+        "6 degrees (rotation and translation) are used by default.",
+    )
     g_conf.add_argument(
-        '--force-no-bbr', action='store_false', dest='use_bbr', default=None,
-        help='Do not use boundary-based registration (no goodness-of-fit checks)')
+        "--force-bbr",
+        action="store_true",
+        dest="use_bbr",
+        default=None,
+        help="Always use boundary-based registration (no goodness-of-fit checks)",
+    )
     g_conf.add_argument(
-        '--medial-surface-nan', required=False, action='store_true', default=False,
-        help='Replace medial wall values with NaNs on functional GIFTI files. Only '
-        'performed for GIFTI files mapped to a freesurfer subject (fsaverage or fsnative).')
+        "--force-no-bbr",
+        action="store_false",
+        dest="use_bbr",
+        default=None,
+        help="Do not use boundary-based registration (no goodness-of-fit checks)",
+    )
     g_conf.add_argument(
-        '--dummy-scans', required=False, action='store', default=None, type=int,
-        help='Number of non steady state volumes.')
+        "--medial-surface-nan",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Replace medial wall values with NaNs on functional GIFTI files. Only "
+        "performed for GIFTI files mapped to a freesurfer subject (fsaverage or fsnative).",
+    )
     g_conf.add_argument(
-        '--random-seed', action='store', type=int, default=None,
-        help='Initialize the random seed for the workflow'
+        "--dummy-scans",
+        required=False,
+        action="store",
+        default=None,
+        type=int,
+        help="Number of non steady state volumes.",
+    )
+    g_conf.add_argument(
+        "--random-seed",
+        action="store",
+        type=int,
+        default=None,
+        help="Initialize the random seed for the workflow",
     )
 
     # ICA_AROMA options
-    g_aroma = parser.add_argument_group('Specific options for running ICA_AROMA')
-    g_aroma.add_argument('--use-aroma', action='store_true', default=False,
-                         help='add ICA_AROMA to your preprocessing stream')
-    g_aroma.add_argument('--aroma-melodic-dimensionality', dest='aroma_melodic_dim',
-                         action='store', default=-200, type=int,
-                         help='Exact or maximum number of MELODIC components to estimate '
-                         '(positive = exact, negative = maximum)')
+    g_aroma = parser.add_argument_group("Specific options for running ICA_AROMA")
+    g_aroma.add_argument(
+        "--use-aroma",
+        action="store_true",
+        default=False,
+        help="add ICA_AROMA to your preprocessing stream",
+    )
+    g_aroma.add_argument(
+        "--aroma-melodic-dimensionality",
+        dest="aroma_melodic_dim",
+        action="store",
+        default=-200,
+        type=int,
+        help="Exact or maximum number of MELODIC components to estimate "
+        "(positive = exact, negative = maximum)",
+    )
 
     # Confounds options
-    g_confounds = parser.add_argument_group('Specific options for estimating confounds')
+    g_confounds = parser.add_argument_group("Specific options for estimating confounds")
     g_confounds.add_argument(
-        '--return-all-components', dest='regressors_all_comps', required=False,
-        action='store_true', default=False,
-        help='Include all components estimated in CompCor decomposition in the confounds '
-             'file instead of only the components sufficient to explain 50 percent of '
-             'BOLD variance in each CompCor mask')
+        "--return-all-components",
+        dest="regressors_all_comps",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Include all components estimated in CompCor decomposition in the confounds "
+        "file instead of only the components sufficient to explain 50 percent of "
+        "BOLD variance in each CompCor mask",
+    )
     g_confounds.add_argument(
-        '--fd-spike-threshold', dest='regressors_fd_th', required=False,
-        action='store', default=0.5, type=float,
-        help='Threshold for flagging a frame as an outlier on the basis of framewise '
-             'displacement')
+        "--fd-spike-threshold",
+        dest="regressors_fd_th",
+        required=False,
+        action="store",
+        default=0.5,
+        type=float,
+        help="Threshold for flagging a frame as an outlier on the basis of framewise "
+        "displacement",
+    )
     g_confounds.add_argument(
-        '--dvars-spike-threshold', dest='regressors_dvars_th', required=False,
-        action='store', default=1.5, type=float,
-        help='Threshold for flagging a frame as an outlier on the basis of standardised '
-             'DVARS')
+        "--dvars-spike-threshold",
+        dest="regressors_dvars_th",
+        required=False,
+        action="store",
+        default=1.5,
+        type=float,
+        help="Threshold for flagging a frame as an outlier on the basis of standardised "
+        "DVARS",
+    )
 
     #  ANTs options
-    g_ants = parser.add_argument_group('Specific options for ANTs registrations')
+    g_ants = parser.add_argument_group("Specific options for ANTs registrations")
     g_ants.add_argument(
-        '--skull-strip-template', default='OASIS30ANTs', type=Reference.from_string,
-        help='select a template for skull-stripping with antsBrainExtraction')
-    g_ants.add_argument('--skull-strip-fixed-seed', action='store_true',
-                        help='do not use a random seed for skull-stripping - will ensure '
-                             'run-to-run replicability when used with --omp-nthreads 1 and '
-                             'matching --random-seed <int>')
+        "--skull-strip-template",
+        default="OASIS30ANTs",
+        type=Reference.from_string,
+        help="select a template for skull-stripping with antsBrainExtraction",
+    )
     g_ants.add_argument(
-        '--skull-strip-t1w', action='store', choices=('auto', 'skip', 'force'), default='force',
+        "--skull-strip-fixed-seed",
+        action="store_true",
+        help="do not use a random seed for skull-stripping - will ensure "
+        "run-to-run replicability when used with --omp-nthreads 1 and "
+        "matching --random-seed <int>",
+    )
+    g_ants.add_argument(
+        "--skull-strip-t1w",
+        action="store",
+        choices=("auto", "skip", "force"),
+        default="force",
         help="determiner for T1-weighted skull stripping ('force' ensures skull "
-             "stripping, 'skip' ignores skull stripping, and 'auto' applies brain extraction "
-             "based on the outcome of a heuristic to check whether the brain is already masked).")
+        "stripping, 'skip' ignores skull stripping, and 'auto' applies brain extraction "
+        "based on the outcome of a heuristic to check whether the brain is already masked).",
+    )
 
     # Fieldmap options
-    g_fmap = parser.add_argument_group('Specific options for handling fieldmaps')
-    g_fmap.add_argument('--fmap-bspline', action='store_true', default=False,
-                        help='fit a B-Spline field using least-squares (experimental)')
-    g_fmap.add_argument('--fmap-no-demean', action='store_false', default=True,
-                        help='do not remove median (within mask) from fieldmap')
+    g_fmap = parser.add_argument_group("Specific options for handling fieldmaps")
+    g_fmap.add_argument(
+        "--fmap-bspline",
+        action="store_true",
+        default=False,
+        help="fit a B-Spline field using least-squares (experimental)",
+    )
+    g_fmap.add_argument(
+        "--fmap-no-demean",
+        action="store_false",
+        default=True,
+        help="do not remove median (within mask) from fieldmap",
+    )
 
     # SyN-unwarp options
-    g_syn = parser.add_argument_group('Specific options for SyN distortion correction')
-    g_syn.add_argument('--use-syn-sdc', action='store_true', default=False,
-                       help='EXPERIMENTAL: Use fieldmap-free distortion correction')
-    g_syn.add_argument('--force-syn', action='store_true', default=False,
-                       help='EXPERIMENTAL/TEMPORARY: Use SyN correction in addition to '
-                       'fieldmap correction, if available')
+    g_syn = parser.add_argument_group("Specific options for SyN distortion correction")
+    g_syn.add_argument(
+        "--use-syn-sdc",
+        action="store_true",
+        default=False,
+        help="EXPERIMENTAL: Use fieldmap-free distortion correction",
+    )
+    g_syn.add_argument(
+        "--force-syn",
+        action="store_true",
+        default=False,
+        help="EXPERIMENTAL/TEMPORARY: Use SyN correction in addition to "
+        "fieldmap correction, if available",
+    )
 
     # FreeSurfer options
-    g_fs = parser.add_argument_group('Specific options for FreeSurfer preprocessing')
+    g_fs = parser.add_argument_group("Specific options for FreeSurfer preprocessing")
     g_fs.add_argument(
-        '--fs-license-file', metavar='PATH', type=PathExists,
-        help='Path to FreeSurfer license key file. Get it (for free) by registering'
-             ' at https://surfer.nmr.mgh.harvard.edu/registration.html')
+        "--fs-license-file",
+        metavar="PATH",
+        type=PathExists,
+        help="Path to FreeSurfer license key file. Get it (for free) by registering"
+        " at https://surfer.nmr.mgh.harvard.edu/registration.html",
+    )
     g_fs.add_argument(
-        '--fs-subjects-dir', metavar='PATH', type=Path,
-        help='Path to existing FreeSurfer subjects directory to reuse. '
-             '(default: OUTPUT_DIR/freesurfer)')
+        "--fs-subjects-dir",
+        metavar="PATH",
+        type=Path,
+        help="Path to existing FreeSurfer subjects directory to reuse. "
+        "(default: OUTPUT_DIR/freesurfer)",
+    )
 
     # Surface generation xor
-    g_surfs = parser.add_argument_group('Surface preprocessing options')
-    g_surfs.add_argument('--no-submm-recon', action='store_false', dest='hires',
-                         help='disable sub-millimeter (hires) reconstruction')
+    g_surfs = parser.add_argument_group("Surface preprocessing options")
+    g_surfs.add_argument(
+        "--no-submm-recon",
+        action="store_false",
+        dest="hires",
+        help="disable sub-millimeter (hires) reconstruction",
+    )
     g_surfs_xor = g_surfs.add_mutually_exclusive_group()
-    g_surfs_xor.add_argument('--cifti-output', nargs='?', const='91k', default=False,
-                             choices=('91k', '170k'), type=str,
-                             help='output preprocessed BOLD as a CIFTI dense timeseries. '
-                             'Optionally, the number of grayordinate can be specified '
-                             '(default is 91k, which equates to 2mm resolution)')
-    g_surfs_xor.add_argument('--fs-no-reconall',
-                             action='store_false', dest='run_reconall',
-                             help='disable FreeSurfer surface preprocessing.')
+    g_surfs_xor.add_argument(
+        "--cifti-output",
+        nargs="?",
+        const="91k",
+        default=False,
+        choices=("91k", "170k"),
+        type=str,
+        help="output preprocessed BOLD as a CIFTI dense timeseries. "
+        "Optionally, the number of grayordinate can be specified "
+        "(default is 91k, which equates to 2mm resolution)",
+    )
+    g_surfs_xor.add_argument(
+        "--fs-no-reconall",
+        action="store_false",
+        dest="run_reconall",
+        help="disable FreeSurfer surface preprocessing.",
+    )
 
-    g_other = parser.add_argument_group('Other options')
+    g_other = parser.add_argument_group("Other options")
     g_other.add_argument(
-        '-w', '--work-dir', action='store', type=Path, default=Path('work').absolute(),
-        help='path where intermediate results should be stored')
-    g_other.add_argument('--clean-workdir', action='store_true', default=False,
-                         help='Clears working directory of contents. Use of this flag is not'
-                              'recommended when running concurrent processes of fMRIPrep.')
+        "-w",
+        "--work-dir",
+        action="store",
+        type=Path,
+        default=Path("work").absolute(),
+        help="path where intermediate results should be stored",
+    )
     g_other.add_argument(
-        '--resource-monitor', action='store_true', default=False,
-        help='enable Nipype\'s resource monitoring to keep track of memory and CPU usage')
+        "--clean-workdir",
+        action="store_true",
+        default=False,
+        help="Clears working directory of contents. Use of this flag is not"
+        "recommended when running concurrent processes of fMRIPrep.",
+    )
     g_other.add_argument(
-        '--reports-only', action='store_true', default=False,
-        help='only generate reports, don\'t run workflows. This will only rerun report '
-             'aggregation, not reportlet generation for specific nodes.')
+        "--resource-monitor",
+        action="store_true",
+        default=False,
+        help="enable Nipype's resource monitoring to keep track of memory and CPU usage",
+    )
     g_other.add_argument(
-        '--run-uuid', action='store', default=None,
-        help='Specify UUID of previous run, to include error logs in report. '
-             'No effect without --reports-only.')
-    g_other.add_argument('--write-graph', action='store_true', default=False,
-                         help='Write workflow graph.')
-    g_other.add_argument('--stop-on-first-crash', action='store_true', default=False,
-                         help='Force stopping on first crash, even if a work directory'
-                              ' was specified.')
-    g_other.add_argument('--notrack', action='store_true', default=False,
-                         help='Opt-out of sending tracking information of this run to '
-                              'the FMRIPREP developers. This information helps to '
-                              'improve FMRIPREP and provides an indicator of real '
-                              'world usage crucial for obtaining funding.')
-    g_other.add_argument('--sloppy', dest='debug', action='store_true', default=False,
-                         help='Use low-quality tools for speed - TESTING ONLY')
+        "--reports-only",
+        action="store_true",
+        default=False,
+        help="only generate reports, don't run workflows. This will only rerun report "
+        "aggregation, not reportlet generation for specific nodes.",
+    )
+    g_other.add_argument(
+        "--run-uuid",
+        action="store",
+        default=None,
+        help="Specify UUID of previous run, to include error logs in report. "
+        "No effect without --reports-only.",
+    )
+    g_other.add_argument(
+        "--write-graph",
+        action="store_true",
+        default=False,
+        help="Write workflow graph.",
+    )
+    g_other.add_argument(
+        "--stop-on-first-crash",
+        action="store_true",
+        default=False,
+        help="Force stopping on first crash, even if a work directory"
+        " was specified.",
+    )
+    g_other.add_argument(
+        "--notrack",
+        action="store_true",
+        default=False,
+        help="Opt-out of sending tracking information of this run to "
+        "the FMRIPREP developers. This information helps to "
+        "improve FMRIPREP and provides an indicator of real "
+        "world usage crucial for obtaining funding.",
+    )
+    g_other.add_argument(
+        "--sloppy",
+        dest="debug",
+        action="store_true",
+        default=False,
+        help="Use low-quality tools for speed - TESTING ONLY",
+    )
 
     latest = check_latest()
     if latest is not None and currentv < latest:
-        print("""\
+        print(
+            """\
 You are using fMRIPrep-%s, and a newer version of fMRIPrep is available: %s.
 Please check out our documentation about how and when to upgrade:
-https://fmriprep.readthedocs.io/en/latest/faq.html#upgrading""" % (
-            currentv, latest), file=sys.stderr)
+https://fmriprep.readthedocs.io/en/latest/faq.html#upgrading"""
+            % (currentv, latest),
+            file=sys.stderr,
+        )
 
     _blist = is_flagged()
     if _blist[0]:
-        _reason = _blist[1] or 'unknown'
-        print("""\
+        _reason = _blist[1] or "unknown"
+        print(
+            """\
 WARNING: Version %s of fMRIPrep (current) has been FLAGGED
 (reason: %s).
 That means some severe flaw was found in it and we strongly
-discourage its usage.""" % (config.environment.version, _reason), file=sys.stderr)
+discourage its usage."""
+            % (config.environment.version, _reason),
+            file=sys.stderr,
+        )
 
     return parser
 
@@ -332,34 +555,41 @@ def parse_args(args=None, namespace=None):
     build_log = config.loggers.cli
 
     if not check_valid_fs_license(lic=config.execution.fs_license_file):
-        raise RuntimeError("""\
+        raise RuntimeError(
+            """\
 ERROR: a valid license file is required for FreeSurfer to run. fMRIPrep looked for an existing \
 license file at several paths, in this order: 1) command line argument ``--fs-license-file``; \
 2) ``$FS_LICENSE`` environment variable; and 3) the ``$FREESURFER_HOME/license.txt`` path. Get it \
-(for free) by registering at https://surfer.nmr.mgh.harvard.edu/registration.html""")
+(for free) by registering at https://surfer.nmr.mgh.harvard.edu/registration.html"""
+        )
 
     # Load base plugin_settings from file if --use-plugin
     if opts.use_plugin is not None:
         from yaml import load as loadyml
+
         with open(opts.use_plugin) as f:
             plugin_settings = loadyml(f)
-        _plugin = plugin_settings.get('plugin')
+        _plugin = plugin_settings.get("plugin")
         if _plugin:
             config.nipype.plugin = _plugin
-            config.nipype.plugin_args = plugin_settings.get('plugin_args', {})
-            config.nipype.nprocs = config.nipype.plugin_args.get('nprocs', config.nipype.nprocs)
+            config.nipype.plugin_args = plugin_settings.get("plugin_args", {})
+            config.nipype.nprocs = config.nipype.plugin_args.get(
+                "nprocs", config.nipype.nprocs
+            )
 
     # Resource management options
     # Note that we're making strong assumptions about valid plugin args
     # This may need to be revisited if people try to use batch plugins
     if 1 < config.nipype.nprocs < config.nipype.omp_nthreads:
         build_log.warning(
-            f'Per-process threads (--omp-nthreads={config.nipype.omp_nthreads}) exceed '
-            f'total threads (--nthreads/--n_cpus={config.nipype.nprocs})')
+            f"Per-process threads (--omp-nthreads={config.nipype.omp_nthreads}) exceed "
+            f"total threads (--nthreads/--n_cpus={config.nipype.nprocs})"
+        )
 
     # Inform the user about the risk of using brain-extracted images
     if config.workflow.skull_strip_t1w == "auto":
-        build_log.warning("""\
+        build_log.warning(
+            """\
 Option ``--skull-strip-t1w`` was set to 'auto'. A heuristic will be \
 applied to determine whether the input T1w image(s) have already been skull-stripped.
 If that were the case, brain extraction and INU correction will be skipped for those T1w \
@@ -368,7 +598,8 @@ processing workflows across participants. To determine whether a participant has
 through the shortcut pipeline (meaning, brain extraction was skipped), please check the \
 citation boilerplate. When reporting results with varying pipelines, please make sure you \
 mention this particular variant of fMRIPrep listing the participants for which it was \
-applied.""")
+applied."""
+        )
 
     bids_dir = config.execution.bids_dir
     output_dir = config.execution.output_dir
@@ -376,11 +607,12 @@ applied.""")
     version = config.environment.version
 
     if config.execution.fs_subjects_dir is None:
-        config.execution.fs_subjects_dir = output_dir / 'freesurfer'
+        config.execution.fs_subjects_dir = output_dir / "freesurfer"
 
     # Wipe out existing work_dir
     if opts.clean_workdir and work_dir.exists():
         from niworkflows.utils.misc import clean_directory
+
         build_log.info(f"Clearing previous fMRIPrep working directory: {work_dir}")
         if not clean_directory(work_dir):
             build_log.warning(
@@ -390,28 +622,33 @@ applied.""")
     # Ensure input and output folders are not the same
     if output_dir == bids_dir:
         parser.error(
-            'The selected output folder is the same as the input BIDS folder. '
-            'Please modify the output path (suggestion: %s).'
-            % bids_dir / 'derivatives' / ('fmriprep-%s' % version.split('+')[0])
+            "The selected output folder is the same as the input BIDS folder. "
+            "Please modify the output path (suggestion: %s)."
+            % bids_dir
+            / "derivatives"
+            / ("fmriprep-%s" % version.split("+")[0])
         )
 
     if bids_dir in work_dir.parents:
         parser.error(
-            'The selected working directory is a subdirectory of the input BIDS folder. '
-            'Please modify the output path.'
+            "The selected working directory is a subdirectory of the input BIDS folder. "
+            "Please modify the output path."
         )
 
     # Validate inputs
     if not opts.skip_bids_validation:
         from ..utils.bids import validate_input_dir
+
         build_log.info(
             "Making sure the input data is BIDS compliant (warnings can be ignored in most "
             "cases)."
         )
-        validate_input_dir(config.environment.exec_env, opts.bids_dir, opts.participant_label)
+        validate_input_dir(
+            config.environment.exec_env, opts.bids_dir, opts.participant_label
+        )
 
     # Setup directories
-    config.execution.log_dir = output_dir / 'fmriprep' / 'logs'
+    config.execution.log_dir = output_dir / "fmriprep" / "logs"
     # Check and create output and working directories
     config.execution.log_dir.mkdir(exist_ok=True, parents=True)
     output_dir.mkdir(exist_ok=True, parents=True)
@@ -428,7 +665,8 @@ applied.""")
     if missing_subjects:
         parser.error(
             "One or more participant labels were not found in the BIDS directory: "
-            "%s." % ", ".join(missing_subjects))
+            "%s." % ", ".join(missing_subjects)
+        )
 
     config.execution.participant_label = sorted(participant_label)
     config.workflow.skull_strip_template = config.workflow.skull_strip_template[0]

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -117,13 +117,14 @@ def main():
             sentry_sdk.capture_message(success_message, level="info")
 
         # Bother users with the boilerplate only iff the workflow went okay.
-        _boiler_file = config.execution.output_dir / "fmriprep" / "logs" / "CITATION.md"
-        if _boiler_file.exists():
-            _boiler_file = _boiler_file.relative_to(config.execution.output_dir)
+        boiler_file = config.execution.output_dir / "fmriprep" / "logs" / "CITATION.md"
+        if boiler_file.exists():
+            if str(config.execution.output_dir) == "/out
+                boiler_file = Path("<output_dir>") / boiler_file.relative_to(config.execution.output_dir)
             config.loggers.workflow.log(
                 25,
                 "Works derived from this fMRIPrep execution should include the "
-                f"boilerplate text found in <output_dir>/{_boiler_file}.",
+                f"boilerplate text found in {boiler_file}.",
             )
 
         if config.workflow.run_reconall:

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -19,12 +19,13 @@ def main():
     if not config.execution.notrack:
         import sentry_sdk
         from ..utils.sentry import sentry_setup
+
         sentry_setup()
 
     # CRITICAL Save the config to a file. This is necessary because the execution graph
     # is built as a separate process to keep the memory footprint low. The most
     # straightforward way to communicate with the child process is via the filesystem.
-    config_file = config.execution.work_dir / '.fmriprep.toml'
+    config_file = config.execution.work_dir / ".fmriprep.toml"
     config.to_filename(config_file)
 
     # CRITICAL Call build_workflow(config_file, retval) in a subprocess.
@@ -32,13 +33,14 @@ def main():
     # workflow construction jailed within a process preempts excessive VM buildup.
     with Manager() as mgr:
         from .workflow import build_workflow
+
         retval = mgr.dict()
         p = Process(target=build_workflow, args=(str(config_file), retval))
         p.start()
         p.join()
 
-        retcode = p.exitcode or retval.get('return_code', 0)
-        fmriprep_wf = retval.get('workflow', None)
+        retcode = p.exitcode or retval.get("return_code", 0)
+        fmriprep_wf = retval.get("workflow", None)
 
     # CRITICAL Load the config from the file. This is necessary because the ``build_workflow``
     # function executed constrained in a process may change the config (and thus the global
@@ -49,7 +51,7 @@ def main():
         sys.exit(int(retcode > 0))
 
     if fmriprep_wf and config.execution.write_graph:
-        fmriprep_wf.write_graph(graph2use="colored", format='svg', simple_form=True)
+        fmriprep_wf.write_graph(graph2use="colored", format="svg", simple_form=True)
 
     retcode = retcode or (fmriprep_wf is None) * os.EX_SOFTWARE
     if retcode != 0:
@@ -58,8 +60,8 @@ def main():
     # Generate boilerplate
     with Manager() as mgr:
         from .workflow import build_boilerplate
-        p = Process(target=build_boilerplate,
-                    args=(str(config_file), fmriprep_wf))
+
+        p = Process(target=build_boilerplate, args=(str(config_file), fmriprep_wf))
         p.start()
         p.join()
 
@@ -72,40 +74,47 @@ def main():
     # Sentry tracking
     if sentry_sdk is not None:
         with sentry_sdk.configure_scope() as scope:
-            scope.set_tag('run_uuid', config.execution.run_uuid)
-            scope.set_tag('npart', len(config.execution.participant_label))
-        sentry_sdk.add_breadcrumb(message='fMRIPrep started', level='info')
-        sentry_sdk.capture_message('fMRIPrep started', level='info')
+            scope.set_tag("run_uuid", config.execution.run_uuid)
+            scope.set_tag("npart", len(config.execution.participant_label))
+        sentry_sdk.add_breadcrumb(message="fMRIPrep started", level="info")
+        sentry_sdk.capture_message("fMRIPrep started", level="info")
 
-    config.loggers.workflow.log(15, '\n'.join(
-        ['fMRIPrep config:'] + ['\t\t%s' % s for s in config.dumps().splitlines()])
+    config.loggers.workflow.log(
+        15,
+        "\n".join(
+            ["fMRIPrep config:"] + ["\t\t%s" % s for s in config.dumps().splitlines()]
+        ),
     )
-    config.loggers.workflow.log(25, 'fMRIPrep started!')
+    config.loggers.workflow.log(25, "fMRIPrep started!")
     errno = 1  # Default is error exit unless otherwise set
     try:
         fmriprep_wf.run(**config.nipype.get_plugin())
     except Exception as e:
         if not config.execution.notrack:
             from ..utils.sentry import process_crashfile
+
             crashfolders = [
-                config.execution.output_dir / 'fmriprep'
-                / 'sub-{}'.format(s) / 'log' / config.execution.run_uuid
+                config.execution.output_dir
+                / "fmriprep"
+                / "sub-{}".format(s)
+                / "log"
+                / config.execution.run_uuid
                 for s in config.execution.participant_label
             ]
             for crashfolder in crashfolders:
-                for crashfile in crashfolder.glob('crash*.*'):
+                for crashfile in crashfolder.glob("crash*.*"):
                     process_crashfile(crashfile)
 
             if "Workflow did not execute cleanly" not in str(e):
                 sentry_sdk.capture_exception(e)
-        config.loggers.workflow.critical('fMRIPrep failed: %s', e)
+        config.loggers.workflow.critical("fMRIPrep failed: %s", e)
         raise
     else:
-        config.loggers.workflow.log(25, 'fMRIPrep finished successfully!')
+        config.loggers.workflow.log(25, "fMRIPrep finished successfully!")
         if not config.execution.notrack:
-            success_message = 'fMRIPrep finished without errors'
-            sentry_sdk.add_breadcrumb(message=success_message, level='info')
-            sentry_sdk.capture_message(success_message, level='info')
+            success_message = "fMRIPrep finished without errors"
+            sentry_sdk.add_breadcrumb(message=success_message, level="info")
+            sentry_sdk.capture_message(success_message, level="info")
 
         # Bother users with the boilerplate only iff the workflow went okay.
         _boiler_file = config.execution.output_dir / "fmriprep" / "logs" / "CITATION.md"
@@ -120,11 +129,18 @@ def main():
         if config.workflow.run_reconall:
             from templateflow import api
             from niworkflows.utils.misc import _copy_any
-            dseg_tsv = str(api.get('fsaverage', suffix='dseg', extension=['.tsv']))
-            _copy_any(dseg_tsv,
-                      str(config.execution.output_dir / 'fmriprep' / 'desc-aseg_dseg.tsv'))
-            _copy_any(dseg_tsv,
-                      str(config.execution.output_dir / 'fmriprep' / 'desc-aparcaseg_dseg.tsv'))
+
+            dseg_tsv = str(api.get("fsaverage", suffix="dseg", extension=[".tsv"]))
+            _copy_any(
+                dseg_tsv,
+                str(config.execution.output_dir / "fmriprep" / "desc-aseg_dseg.tsv"),
+            )
+            _copy_any(
+                dseg_tsv,
+                str(
+                    config.execution.output_dir / "fmriprep" / "desc-aparcaseg_dseg.tsv"
+                ),
+            )
         errno = 0
     finally:
         from niworkflows.reports import generate_reports
@@ -135,19 +151,23 @@ def main():
             config.execution.participant_label,
             config.execution.output_dir,
             config.execution.run_uuid,
-            config=pkgrf('fmriprep', 'data/reports-spec.yml'),
-            packagename='fmriprep')
+            config=pkgrf("fmriprep", "data/reports-spec.yml"),
+            packagename="fmriprep",
+        )
         write_derivative_description(
-            config.execution.bids_dir,
-            config.execution.output_dir / 'fmriprep')
+            config.execution.bids_dir, config.execution.output_dir / "fmriprep"
+        )
 
         if failed_reports and not config.execution.notrack:
             sentry_sdk.capture_message(
-                'Report generation failed for %d subjects' % failed_reports,
-                level='error')
+                "Report generation failed for %d subjects" % failed_reports,
+                level="error",
+            )
         sys.exit(int((errno + failed_reports) > 0))
 
 
-if __name__ == '__main__':
-    raise RuntimeError("fmriprep/cli/run.py should not be run directly;\n"
-                       "Please `pip install` fmriprep and use the `fmriprep` command")
+if __name__ == "__main__":
+    raise RuntimeError(
+        "fmriprep/cli/run.py should not be run directly;\n"
+        "Please `pip install` fmriprep and use the `fmriprep` command"
+    )

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -6,7 +6,8 @@ from .. import config
 
 def main():
     """Entry point."""
-    import os
+    from os import EX_SOFTWARE
+    from pathlib import Path
     import sys
     import gc
     from multiprocessing import Process, Manager
@@ -53,7 +54,7 @@ def main():
     if fmriprep_wf and config.execution.write_graph:
         fmriprep_wf.write_graph(graph2use="colored", format="svg", simple_form=True)
 
-    retcode = retcode or (fmriprep_wf is None) * os.EX_SOFTWARE
+    retcode = retcode or (fmriprep_wf is None) * EX_SOFTWARE
     if retcode != 0:
         sys.exit(retcode)
 
@@ -119,8 +120,9 @@ def main():
         # Bother users with the boilerplate only iff the workflow went okay.
         boiler_file = config.execution.output_dir / "fmriprep" / "logs" / "CITATION.md"
         if boiler_file.exists():
-            if str(config.execution.output_dir) == "/out
-                boiler_file = Path("<output_dir>") / boiler_file.relative_to(config.execution.output_dir)
+            if config.environment.exec_env in ("singularity", "docker", "fmriprep-docker"):
+                boiler_file = Path("<OUTPUT_PATH>") / boiler_file.relative_to(
+                    config.execution.output_dir)
             config.loggers.workflow.log(
                 25,
                 "Works derived from this fMRIPrep execution should include the "

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -108,11 +108,13 @@ def main():
             sentry_sdk.capture_message(success_message, level='info')
 
         # Bother users with the boilerplate only iff the workflow went okay.
-        if (config.execution.output_dir / 'fmriprep' / 'logs' / 'CITATION.md').exists():
+        _boiler_file = config.execution.output_dir / "fmriprep" / "logs" / "CITATION.md"
+        if _boiler_file.exists():
+            _boiler_file = _boiler_file.relative_to(config.execution.output_dir)
             config.loggers.workflow.log(
-                25, 'Works derived from this fMRIPrep execution should '
-                'include the following boilerplate:\n\n%s',
-                (config.execution.output_dir / 'fmriprep' / 'logs' / 'CITATION.md').read_text()
+                25,
+                "Works derived from this fMRIPrep execution should include the "
+                f"boilerplate text found in <output_dir>/{_boiler_file}.",
             )
 
         if config.workflow.run_reconall:

--- a/fmriprep/cli/tests/test_parser.py
+++ b/fmriprep/cli/tests/test_parser.py
@@ -5,15 +5,18 @@ from ..parser import _build_parser
 from .. import version as _version
 from ... import config
 
-MIN_ARGS = ['data/', 'out/', 'participant']
+MIN_ARGS = ["data/", "out/", "participant"]
 
 
-@pytest.mark.parametrize('args,code', [
-    ([], 2),
-    (MIN_ARGS, 2),  # bids_dir does not exist
-    (MIN_ARGS + ['--fs-license-file'], 2),
-    (MIN_ARGS + ['--fs-license-file', 'fslicense.txt'], 2),
-])
+@pytest.mark.parametrize(
+    "args,code",
+    [
+        ([], 2),
+        (MIN_ARGS, 2),  # bids_dir does not exist
+        (MIN_ARGS + ["--fs-license-file"], 2),
+        (MIN_ARGS + ["--fs-license-file", "fslicense.txt"], 2),
+    ],
+)
 def test_parser_errors(args, code):
     """Check behavior of the parser."""
     with pytest.raises(SystemExit) as error:
@@ -22,59 +25,54 @@ def test_parser_errors(args, code):
     assert error.value.code == code
 
 
-@pytest.mark.parametrize('args', [
-    MIN_ARGS,
-    MIN_ARGS + ['--fs-license-file'],
-])
+@pytest.mark.parametrize("args", [MIN_ARGS, MIN_ARGS + ["--fs-license-file"]])
 def test_parser_valid(tmp_path, args):
     """Check valid arguments."""
-    datapath = (tmp_path / 'data')
+    datapath = tmp_path / "data"
     datapath.mkdir(exist_ok=True)
     args[0] = str(datapath)
 
-    if '--fs-license-file' in args:
-        _fs_file = tmp_path / 'license.txt'
-        _fs_file.write_text('')
-        args.insert(args.index('--fs-license-file') + 1,
-                    str(_fs_file.absolute()))
+    if "--fs-license-file" in args:
+        _fs_file = tmp_path / "license.txt"
+        _fs_file.write_text("")
+        args.insert(args.index("--fs-license-file") + 1, str(_fs_file.absolute()))
 
     opts = _build_parser().parse_args(args)
 
     assert opts.bids_dir == datapath
 
 
-@pytest.mark.parametrize('argval,gb', [
-    ('1G', 1),
-    ('1GB', 1),
-    ('1000', 1),    # Default units are MB
-    ('32000', 32),  # Default units are MB
-    ('4000', 4),    # Default units are MB
-    ('1000M', 1),
-    ('1000MB', 1),
-    ('1T', 1000),
-    ('1TB', 1000),
-    ('%dK' % 1e6, 1),
-    ('%dKB' % 1e6, 1),
-    ('%dB' % 1e9, 1),
-])
+@pytest.mark.parametrize(
+    "argval,gb",
+    [
+        ("1G", 1),
+        ("1GB", 1),
+        ("1000", 1),  # Default units are MB
+        ("32000", 32),  # Default units are MB
+        ("4000", 4),  # Default units are MB
+        ("1000M", 1),
+        ("1000MB", 1),
+        ("1T", 1000),
+        ("1TB", 1000),
+        ("%dK" % 1e6, 1),
+        ("%dKB" % 1e6, 1),
+        ("%dB" % 1e9, 1),
+    ],
+)
 def test_memory_arg(tmp_path, argval, gb):
     """Check the correct parsing of the memory argument."""
-    datapath = (tmp_path / 'data')
+    datapath = tmp_path / "data"
     datapath.mkdir(exist_ok=True)
-    _fs_file = tmp_path / 'license.txt'
-    _fs_file.write_text('')
+    _fs_file = tmp_path / "license.txt"
+    _fs_file.write_text("")
 
-    args = MIN_ARGS + ['--fs-license-file', str(_fs_file)] \
-        + ['--mem', argval]
+    args = MIN_ARGS + ["--fs-license-file", str(_fs_file)] + ["--mem", argval]
     opts = _build_parser().parse_args(args)
 
     assert opts.memory_gb == gb
 
 
-@pytest.mark.parametrize('current,latest', [
-    ('1.0.0', '1.3.2'),
-    ('1.3.2', '1.3.2')
-])
+@pytest.mark.parametrize("current,latest", [("1.0.0", "1.3.2"), ("1.3.2", "1.3.2")])
 def test_get_parser_update(monkeypatch, capsys, current, latest):
     """Make sure the out-of-date banner is shown."""
     expectation = Version(current) < Version(latest)
@@ -82,8 +80,8 @@ def test_get_parser_update(monkeypatch, capsys, current, latest):
     def _mock_check_latest(*args, **kwargs):
         return Version(latest)
 
-    monkeypatch.setattr(config.environment, 'version', current)
-    monkeypatch.setattr(_version, 'check_latest', _mock_check_latest)
+    monkeypatch.setattr(config.environment, "version", current)
+    monkeypatch.setattr(_version, "check_latest", _mock_check_latest)
 
     _build_parser()
     captured = capsys.readouterr().err
@@ -91,26 +89,28 @@ def test_get_parser_update(monkeypatch, capsys, current, latest):
     msg = """\
 You are using fMRIPrep-%s, and a newer version of fMRIPrep is available: %s.
 Please check out our documentation about how and when to upgrade:
-https://fmriprep.readthedocs.io/en/latest/faq.html#upgrading""" % (current, latest)
+https://fmriprep.readthedocs.io/en/latest/faq.html#upgrading""" % (
+        current,
+        latest,
+    )
 
     assert (msg in captured) is expectation
 
 
-@pytest.mark.parametrize('flagged', [
-    (True, None),
-    (True, 'random reason'),
-    (False, None),
-])
+@pytest.mark.parametrize(
+    "flagged", [(True, None), (True, "random reason"), (False, None)]
+)
 def test_get_parser_blacklist(monkeypatch, capsys, flagged):
     """Make sure the blacklisting banner is shown."""
+
     def _mock_is_bl(*args, **kwargs):
         return flagged
 
-    monkeypatch.setattr(_version, 'is_flagged', _mock_is_bl)
+    monkeypatch.setattr(_version, "is_flagged", _mock_is_bl)
 
     _build_parser()
     captured = capsys.readouterr().err
 
-    assert ('FLAGGED' in captured) is flagged[0]
+    assert ("FLAGGED" in captured) is flagged[0]
     if flagged[0]:
-        assert ((flagged[1] or 'reason: unknown') in captured)
+        assert (flagged[1] or "reason: unknown") in captured

--- a/fmriprep/cli/tests/test_version.py
+++ b/fmriprep/cli/tests/test_version.py
@@ -13,12 +13,7 @@ class MockResponse:
 
     status_code = 200
     _json = {
-        "releases": {
-            '1.0.0': None,
-            '1.0.1': None,
-            '1.1.0': None,
-            '1.1.1rc1': None
-        }
+        "releases": {"1.0.0": None, "1.0.1": None, "1.1.0": None, "1.1.1rc1": None}
     }
 
     def __init__(self, code=200, json=None):
@@ -35,47 +30,52 @@ class MockResponse:
 def test_check_latest1(tmpdir, monkeypatch):
     """Test latest version check."""
     tmpdir.chdir()
-    monkeypatch.setenv('HOME', str(tmpdir))
+    monkeypatch.setenv("HOME", str(tmpdir))
     assert str(Path.home()) == str(tmpdir)
 
     def mock_get(*args, **kwargs):
         return MockResponse()
+
     monkeypatch.setattr(requests, "get", mock_get)
 
     # Initially, cache should not exist
-    cachefile = Path.home() / '.cache' / 'fmriprep' / 'latest'
+    cachefile = Path.home() / ".cache" / "fmriprep" / "latest"
     assert not cachefile.exists()
 
     # First check actually fetches from pypi
     v = check_latest()
     assert cachefile.exists()
     assert isinstance(v, Version)
-    assert v == Version('1.1.0')
-    assert cachefile.read_text().split('|') == [str(v), datetime.now().strftime(DATE_FMT)]
+    assert v == Version("1.1.0")
+    assert cachefile.read_text().split("|") == [
+        str(v),
+        datetime.now().strftime(DATE_FMT),
+    ]
 
     # Second check - test the cache file is read
-    cachefile.write_text('|'.join(('1.0.0', cachefile.read_text().split('|')[1])))
+    cachefile.write_text("|".join(("1.0.0", cachefile.read_text().split("|")[1])))
     v = check_latest()
     assert isinstance(v, Version)
-    assert v == Version('1.0.0')
+    assert v == Version("1.0.0")
 
     # Third check - forced oudating of cache
-    cachefile.write_text('2.0.0|20180121')
+    cachefile.write_text("2.0.0|20180121")
     v = check_latest()
     assert isinstance(v, Version)
-    assert v == Version('1.1.0')
+    assert v == Version("1.1.0")
 
     # Mock timeouts
     def mock_get(*args, **kwargs):
         raise requests.exceptions.Timeout
+
     monkeypatch.setattr(requests, "get", mock_get)
 
-    cachefile.write_text('|'.join(('1.0.0', cachefile.read_text().split('|')[1])))
+    cachefile.write_text("|".join(("1.0.0", cachefile.read_text().split("|")[1])))
     v = check_latest()
     assert isinstance(v, Version)
-    assert v == Version('1.0.0')
+    assert v == Version("1.0.0")
 
-    cachefile.write_text('2.0.0|20180121')
+    cachefile.write_text("2.0.0|20180121")
     v = check_latest()
     assert v is None
 
@@ -84,20 +84,24 @@ def test_check_latest1(tmpdir, monkeypatch):
     assert v is None
 
 
-@pytest.mark.parametrize(('result', 'code', 'json'), [
-    (None, 404, None),
-    (None, 200, {'releases': {'1.0.0rc1': None}}),
-    (Version('1.1.0'), 200, None),
-    (Version('1.0.0'), 200, {'releases': {'1.0.0': None}}),
-])
+@pytest.mark.parametrize(
+    ("result", "code", "json"),
+    [
+        (None, 404, None),
+        (None, 200, {"releases": {"1.0.0rc1": None}}),
+        (Version("1.1.0"), 200, None),
+        (Version("1.0.0"), 200, {"releases": {"1.0.0": None}}),
+    ],
+)
 def test_check_latest2(tmpdir, monkeypatch, result, code, json):
     """Test latest version check with varying server responses."""
     tmpdir.chdir()
-    monkeypatch.setenv('HOME', str(tmpdir))
+    monkeypatch.setenv("HOME", str(tmpdir))
     assert str(Path.home()) == str(tmpdir)
 
     def mock_get(*args, **kwargs):
         return MockResponse(code=code, json=json)
+
     monkeypatch.setattr(requests, "get", mock_get)
 
     v = check_latest()
@@ -108,47 +112,55 @@ def test_check_latest2(tmpdir, monkeypatch, result, code, json):
         assert v == result
 
 
-@pytest.mark.parametrize('bad_cache', [
-    '3laj#r???d|3akajdf#',
-    '2.0.0|3akajdf#',
-    '|'.join(('2.0.0', datetime.now().strftime(DATE_FMT), '')),
-    ''
-])
+@pytest.mark.parametrize(
+    "bad_cache",
+    [
+        "3laj#r???d|3akajdf#",
+        "2.0.0|3akajdf#",
+        "|".join(("2.0.0", datetime.now().strftime(DATE_FMT), "")),
+        "",
+    ],
+)
 def test_check_latest3(tmpdir, monkeypatch, bad_cache):
     """Test latest version check when the cache file is corrupted."""
     tmpdir.chdir()
-    monkeypatch.setenv('HOME', str(tmpdir))
+    monkeypatch.setenv("HOME", str(tmpdir))
     assert str(Path.home()) == str(tmpdir)
 
     def mock_get(*args, **kwargs):
         return MockResponse()
+
     monkeypatch.setattr(requests, "get", mock_get)
 
     # Initially, cache should not exist
-    cachefile = Path.home() / '.cache' / 'fmriprep' / 'latest'
+    cachefile = Path.home() / ".cache" / "fmriprep" / "latest"
     cachefile.parent.mkdir(parents=True, exist_ok=True)
     assert not cachefile.exists()
 
     cachefile.write_text(bad_cache)
     v = check_latest()
     assert isinstance(v, Version)
-    assert v == Version('1.1.0')
+    assert v == Version("1.1.0")
 
 
-@pytest.mark.parametrize(('result', 'version', 'code', 'json'), [
-    (False, '1.2.1', 200, {'flagged': {'1.0.0': None}}),
-    (True, '1.2.1', 200, {'flagged': {'1.2.1': None}}),
-    (True, '1.2.1', 200, {'flagged': {'1.2.1': 'FATAL Bug!'}}),
-    (False, '1.2.1', 404, {'flagged': {'1.0.0': None}}),
-    (False, '1.2.1', 200, {'flagged': []}),
-    (False, '1.2.1', 200, {}),
-])
+@pytest.mark.parametrize(
+    ("result", "version", "code", "json"),
+    [
+        (False, "1.2.1", 200, {"flagged": {"1.0.0": None}}),
+        (True, "1.2.1", 200, {"flagged": {"1.2.1": None}}),
+        (True, "1.2.1", 200, {"flagged": {"1.2.1": "FATAL Bug!"}}),
+        (False, "1.2.1", 404, {"flagged": {"1.0.0": None}}),
+        (False, "1.2.1", 200, {"flagged": []}),
+        (False, "1.2.1", 200, {}),
+    ],
+)
 def test_is_flagged(monkeypatch, result, version, code, json):
     """Test that the flagged-versions check is correct."""
     monkeypatch.setattr(_version, "__version__", version)
 
     def mock_get(*args, **kwargs):
         return MockResponse(code=code, json=json)
+
     monkeypatch.setattr(requests, "get", mock_get)
 
     val, reason = is_flagged()
@@ -156,7 +168,7 @@ def test_is_flagged(monkeypatch, result, version, code, json):
 
     test_reason = None
     if val:
-        test_reason = json.get('flagged', {}).get(version, None)
+        test_reason = json.get("flagged", {}).get(version, None)
 
     if test_reason is not None:
         assert reason == test_reason
@@ -166,17 +178,18 @@ def test_is_flagged(monkeypatch, result, version, code, json):
 
 def test_readonly(tmp_path, monkeypatch):
     """Test behavior when $HOME/.cache/fmriprep/latest can't be written out."""
-    home_path = Path('/home/readonly') if getenv('TEST_READONLY_FILESYSTEM') \
-        else tmp_path
-    monkeypatch.setenv('HOME', str(home_path))
-    cachedir = home_path / '.cache'
+    home_path = (
+        Path("/home/readonly") if getenv("TEST_READONLY_FILESYSTEM") else tmp_path
+    )
+    monkeypatch.setenv("HOME", str(home_path))
+    cachedir = home_path / ".cache"
 
-    if getenv('TEST_READONLY_FILESYSTEM') is None:
+    if getenv("TEST_READONLY_FILESYSTEM") is None:
         cachedir.mkdir(mode=0o555, exist_ok=True)
 
     # Make sure creating the folder will raise the exception.
     with pytest.raises(OSError):
-        (cachedir / 'fmriprep').mkdir(parents=True)
+        (cachedir / "fmriprep").mkdir(parents=True)
 
     # Should not raise
     check_latest()

--- a/fmriprep/cli/version.py
+++ b/fmriprep/cli/version.py
@@ -8,7 +8,7 @@ import requests
 from .. import __version__
 
 RELEASE_EXPIRY_DAYS = 14
-DATE_FMT = '%Y%m%d'
+DATE_FMT = "%Y%m%d"
 
 
 def check_latest():
@@ -18,7 +18,7 @@ def check_latest():
     latest = None
     date = None
     outdated = None
-    cachefile = Path.home() / '.cache' / 'fmriprep' / 'latest'
+    cachefile = Path.home() / ".cache" / "fmriprep" / "latest"
     try:
         cachefile.parent.mkdir(parents=True, exist_ok=True)
     except OSError:
@@ -26,7 +26,7 @@ def check_latest():
 
     if cachefile and cachefile.exists():
         try:
-            latest, date = cachefile.read_text().split('|')
+            latest, date = cachefile.read_text().split("|")
         except Exception:
             pass
         else:
@@ -41,12 +41,14 @@ def check_latest():
 
     if latest is None or outdated is True:
         try:
-            response = requests.get(url='https://pypi.org/pypi/fmriprep/json', timeout=1.0)
+            response = requests.get(
+                url="https://pypi.org/pypi/fmriprep/json", timeout=1.0
+            )
         except Exception:
             response = None
 
         if response and response.status_code == 200:
-            versions = [Version(rel) for rel in response.json()['releases'].keys()]
+            versions = [Version(rel) for rel in response.json()["releases"].keys()]
             versions = [rel for rel in versions if not rel.is_prerelease]
             if versions:
                 latest = sorted(versions)[-1]
@@ -55,7 +57,9 @@ def check_latest():
 
     if cachefile is not None and latest is not None:
         try:
-            cachefile.write_text('|'.join(('%s' % latest, datetime.now().strftime(DATE_FMT))))
+            cachefile.write_text(
+                "|".join(("%s" % latest, datetime.now().strftime(DATE_FMT)))
+            )
         except Exception:
             pass
 
@@ -67,13 +71,16 @@ def is_flagged():
     # https://raw.githubusercontent.com/poldracklab/fmriprep/master/.versions.json
     flagged = tuple()
     try:
-        response = requests.get(url="""\
-https://raw.githubusercontent.com/poldracklab/fmriprep/master/.versions.json""", timeout=1.0)
+        response = requests.get(
+            url="""\
+https://raw.githubusercontent.com/poldracklab/fmriprep/master/.versions.json""",
+            timeout=1.0,
+        )
     except Exception:
         response = None
 
     if response and response.status_code == 200:
-        flagged = response.json().get('flagged', {}) or {}
+        flagged = response.json().get("flagged", {}) or {}
 
     if __version__ in flagged:
         return True, flagged[__version__]

--- a/fmriprep/cli/workflow.py
+++ b/fmriprep/cli/workflow.py
@@ -83,8 +83,9 @@ def build_workflow(config_file, retval):
     if missing:
         build_log.critical(
             "Cannot run fMRIPrep. Missing dependencies:%s",
-            '\n\t* %s'.join(["{} (Interface: {})".format(cmd, iface)
-                             for iface, cmd in missing])
+            "\n\t* ".join(
+                [""] + [f"{cmd} (Interface: {iface})" for iface, cmd in missing]
+            ),
         )
         retval['return_code'] = 127  # 127 == command not found.
         return retval

--- a/fmriprep/cli/workflow.py
+++ b/fmriprep/cli/workflow.py
@@ -24,40 +24,43 @@ def build_workflow(config_file, retval):
     output_dir = config.execution.output_dir
     version = config.environment.version
 
-    retval['return_code'] = 1
-    retval['workflow'] = None
+    retval["return_code"] = 1
+    retval["workflow"] = None
 
     # warn if older results exist: check for dataset_description.json in output folder
     msg = check_pipeline_version(
-        version, output_dir / 'fmriprep' / 'dataset_description.json'
+        version, output_dir / "fmriprep" / "dataset_description.json"
     )
     if msg is not None:
         build_log.warning(msg)
 
     # Please note this is the input folder's dataset_description.json
-    dset_desc_path = config.execution.bids_dir / 'dataset_description.json'
+    dset_desc_path = config.execution.bids_dir / "dataset_description.json"
     if dset_desc_path.exists():
         from hashlib import sha256
+
         desc_content = dset_desc_path.read_bytes()
         config.execution.bids_description_hash = sha256(desc_content).hexdigest()
 
     # First check that bids_dir looks like a BIDS folder
     subject_list = collect_participants(
-        config.execution.layout,
-        participant_label=config.execution.participant_label
+        config.execution.layout, participant_label=config.execution.participant_label
     )
 
     # Called with reports only
     if config.execution.reports_only:
         from pkg_resources import resource_filename as pkgrf
 
-        build_log.log(25, 'Running --reports-only on participants %s', ', '.join(subject_list))
-        retval['return_code'] = generate_reports(
+        build_log.log(
+            25, "Running --reports-only on participants %s", ", ".join(subject_list)
+        )
+        retval["return_code"] = generate_reports(
             subject_list,
             config.execution.output_dir,
             config.execution.run_uuid,
-            config=pkgrf('fmriprep', 'data/reports-spec.yml'),
-            packagename='fmriprep')
+            config=pkgrf("fmriprep", "data/reports-spec.yml"),
+            packagename="fmriprep",
+        )
         return retval
 
     # Build main workflow
@@ -68,18 +71,21 @@ def build_workflow(config_file, retval):
       * Run identifier: {uuid}.
       * Output spaces: {spaces}.
     """.format
-    build_log.log(25, INIT_MSG(
-        version=config.environment.version,
-        bids_dir=config.execution.bids_dir,
-        subject_list=subject_list,
-        uuid=config.execution.run_uuid,
-        spaces=config.execution.output_spaces)
+    build_log.log(
+        25,
+        INIT_MSG(
+            version=config.environment.version,
+            bids_dir=config.execution.bids_dir,
+            subject_list=subject_list,
+            uuid=config.execution.run_uuid,
+            spaces=config.execution.output_spaces,
+        ),
     )
 
-    retval['workflow'] = init_fmriprep_wf()
+    retval["workflow"] = init_fmriprep_wf()
 
     # Check workflow for missing commands
-    missing = check_deps(retval['workflow'])
+    missing = check_deps(retval["workflow"])
     if missing:
         build_log.critical(
             "Cannot run fMRIPrep. Missing dependencies:%s",
@@ -87,15 +93,15 @@ def build_workflow(config_file, retval):
                 [""] + [f"{cmd} (Interface: {iface})" for iface, cmd in missing]
             ),
         )
-        retval['return_code'] = 127  # 127 == command not found.
+        retval["return_code"] = 127  # 127 == command not found.
         return retval
 
     config.to_filename(config_file)
     build_log.info(
         "fMRIPrep workflow graph with %d nodes built successfully.",
-        len(retval['workflow']._get_all_nodes())
+        len(retval["workflow"]._get_all_nodes()),
     )
-    retval['return_code'] = 0
+    retval["return_code"] = 0
     return retval
 
 
@@ -104,11 +110,10 @@ def build_boilerplate(config_file, workflow):
     from .. import config
 
     config.load(config_file)
-    logs_path = config.execution.output_dir / 'fmriprep' / 'logs'
+    logs_path = config.execution.output_dir / "fmriprep" / "logs"
     boilerplate = workflow.visit_desc()
     citation_files = {
-        ext: logs_path / ('CITATION.%s' % ext)
-        for ext in ('bib', 'tex', 'md', 'html')
+        ext: logs_path / ("CITATION.%s" % ext) for ext in ("bib", "tex", "md", "html")
     }
 
     if boilerplate:
@@ -121,40 +126,57 @@ def build_boilerplate(config_file, workflow):
             except FileNotFoundError:
                 pass
 
-    citation_files['md'].write_text(boilerplate)
+    citation_files["md"].write_text(boilerplate)
 
-    if not config.execution.md_only_boilerplate and citation_files['md'].exists():
+    if not config.execution.md_only_boilerplate and citation_files["md"].exists():
         from subprocess import check_call, CalledProcessError, TimeoutExpired
         from pkg_resources import resource_filename as pkgrf
         from shutil import copyfile
+
         # Generate HTML file resolving citations
-        cmd = ['pandoc', '-s', '--bibliography',
-               pkgrf('fmriprep', 'data/boilerplate.bib'),
-               '--filter', 'pandoc-citeproc',
-               '--metadata', 'pagetitle="fMRIPrep citation boilerplate"',
-               str(citation_files['md']),
-               '-o', str(citation_files['html'])]
+        cmd = [
+            "pandoc",
+            "-s",
+            "--bibliography",
+            pkgrf("fmriprep", "data/boilerplate.bib"),
+            "--filter",
+            "pandoc-citeproc",
+            "--metadata",
+            'pagetitle="fMRIPrep citation boilerplate"',
+            str(citation_files["md"]),
+            "-o",
+            str(citation_files["html"]),
+        ]
 
         config.loggers.cli.info(
-            'Generating an HTML version of the citation boilerplate...')
+            "Generating an HTML version of the citation boilerplate..."
+        )
         try:
             check_call(cmd, timeout=10)
         except (FileNotFoundError, CalledProcessError, TimeoutExpired):
             config.loggers.cli.warning(
-                'Could not generate CITATION.html file:\n%s', ' '.join(cmd))
+                "Could not generate CITATION.html file:\n%s", " ".join(cmd)
+            )
 
         # Generate LaTex file resolving citations
-        cmd = ['pandoc', '-s', '--bibliography',
-               pkgrf('fmriprep', 'data/boilerplate.bib'),
-               '--natbib', str(citation_files['md']),
-               '-o', str(citation_files['tex'])]
+        cmd = [
+            "pandoc",
+            "-s",
+            "--bibliography",
+            pkgrf("fmriprep", "data/boilerplate.bib"),
+            "--natbib",
+            str(citation_files["md"]),
+            "-o",
+            str(citation_files["tex"]),
+        ]
         config.loggers.cli.info(
-            'Generating a LaTeX version of the citation boilerplate...')
+            "Generating a LaTeX version of the citation boilerplate..."
+        )
         try:
             check_call(cmd, timeout=10)
         except (FileNotFoundError, CalledProcessError, TimeoutExpired):
             config.loggers.cli.warning(
-                'Could not generate CITATION.tex file:\n%s', ' '.join(cmd))
+                "Could not generate CITATION.tex file:\n%s", " ".join(cmd)
+            )
         else:
-            copyfile(pkgrf('fmriprep', 'data/boilerplate.bib'),
-                     citation_files['bib'])
+            copyfile(pkgrf("fmriprep", "data/boilerplate.bib"), citation_files["bib"])


### PR DESCRIPTION
This PR stops the printing of the full boilerplate in the standard output.

I have run ``black`` on the cli module and fixed a tiny bug with a formatting argument not being interpolated when reporting missing dependencies.