### PR TITLE
ENH: Enable filtering for ANY or NONE in ``--bids-filter-file``

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -253,7 +253,7 @@ Only modifications of these queries will have any effect. You may filter on any 
 in the PyBIDS
 `config file <https://github.com/bids-standard/pybids/blob/master/bids/layout/config/bids.json>`__.
 To select images that do not have the entity set, use json value: ``null``.
-To select images that have any non-empty value for an entity use string: ``'__any__'``
+To select images that have any non-empty value for an entity use string: ``'*'``
 
 Can *fMRIPrep* continue to run after encountering an error?
 -----------------------------------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -250,8 +250,10 @@ fMRIPrep uses the following queries, by default::
   }
 
 Only modifications of these queries will have any effect. You may filter on any entity defined
-in the the PyBIDS
+in the PyBIDS
 `config file <https://github.com/bids-standard/pybids/blob/master/bids/layout/config/bids.json>`__.
+To select images that do not have the entity set, use json value: ``null``.
+To select images that have any non-empty value for an entity use string: ``'__any__'``
 
 Can *fMRIPrep* continue to run after encountering an error?
 -----------------------------------------------------------

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -40,10 +40,19 @@ def _build_parser():
         value = str(value)
         return value.lstrip('sub-')
 
+    def _filter_pybids_none_any(dct):
+        import bids
+        for k,v in dct.items():
+            if v is None:
+                dct[k] = bids.layout.Query.NONE
+            elif v == '__any__':
+                dct[k] = bids.layout.Query.ANY
+        return dct
+
     def _bids_filter(value):
         from json import loads
         if value and Path(value).exists():
-            return loads(Path(value).read_text())
+            return loads(Path(value).read_text(), object_hook=_filter_pybids_none_any)
 
     verstr = f'fMRIPrep v{config.environment.version}'
     currentv = Version(config.environment.version)

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -43,9 +43,7 @@ def _build_parser():
     def _filter_pybids_none_any(dct):
         import bids
         for k, v in dct.items():
-            if v is None:
-                dct[k] = bids.layout.Query.NONE
-            elif v == '__any__':
+            if v == '__any__':
                 dct[k] = bids.layout.Query.ANY
         return dct
 

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -42,10 +42,8 @@ def _build_parser():
 
     def _filter_pybids_none_any(dct):
         import bids
-        for k, v in dct.items():
-            if v == '__any__':
-                dct[k] = bids.layout.Query.ANY
-        return dct
+        return {k: bids.layout.Query.ANY if v == "*" else v
+                for k, v in dct.items()}
 
     def _bids_filter(value):
         from json import loads

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -42,7 +42,7 @@ def _build_parser():
 
     def _filter_pybids_none_any(dct):
         import bids
-        for k,v in dct.items():
+        for k, v in dct.items():
             if v is None:
                 dct[k] = bids.layout.Query.NONE
             elif v == '__any__':


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->

When loading from `bids-filter-file` from json the pybids query values NONE and ANY cannot be used (cannot be serialized).

Here is a quick fix for that problem, will need to be pushed to smriprep as well, and tested.
json `null` is converted to bids.layout.Query.NONE
json string `'__any__'` is converted to bids.layout.Query.ANY (could change the naming if we prefer `'*'` but it usually means anything including empty, maybe `'+'` then ?)

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->

The FAQ section on how to select images when multiple one available.

<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
