### PR TITLE
FIX: correct previous recon-all reporting

### DIFF
--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -16,7 +16,7 @@ from nipype.interfaces.base import (
     traits, TraitedSpec, BaseInterfaceInputSpec,
     File, Directory, InputMultiObject, Str, isdefined,
     SimpleInterface)
-from nipype.interfaces import freesurfer as fs
+from smriprep.interfaces.freesurfer import ReconAll
 from niworkflows.utils.bids import BIDS_NAME
 
 
@@ -103,10 +103,10 @@ class SubjectSummary(SummaryInterface):
         if not isdefined(self.inputs.subjects_dir):
             freesurfer_status = 'Not run'
         else:
-            recon = fs.ReconAll(subjects_dir=self.inputs.subjects_dir,
-                                subject_id=self.inputs.subject_id,
-                                T1_files=self.inputs.t1w,
-                                flags='-noskullstrip')
+            recon = ReconAll(subjects_dir=self.inputs.subjects_dir,
+                             subject_id='sub-' + self.inputs.subject_id,
+                             T1_files=self.inputs.t1w,
+                             flags='-noskullstrip')
             if recon.cmdline.startswith('echo'):
                 freesurfer_status = 'Pre-existing directory'
             else:


### PR DESCRIPTION
Closes https://github.com/poldracklab/fmriprep/issues/2049

Turns out we weren't passing in the `sub-` identifier, which in turn made ReconAll (rightfully) assume the subject wasn't run.

This also imports the modified `ReconAll` interface used in smriprep.