### PR TITLE
FIX: Generate proper LTA transform prior BOLD sampling on surfaces

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -736,7 +736,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             name='bold_surf_wf')
         workflow.connect([
             (inputnode, bold_surf_wf, [
-                ('t1w_preproc', 'inputnode.t1w_preproc'),
                 ('subjects_dir', 'inputnode.subjects_dir'),
                 ('subject_id', 'inputnode.subject_id'),
                 ('t1w2fsnative_xfm', 'inputnode.t1w2fsnative_xfm')]),

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -89,7 +89,6 @@ The BOLD time-series were resampled onto the following surfaces
 
     get_fsnative = pe.Node(FreeSurferSource(), name='get_fsnative',
                            run_without_submitting=True)
-    tonii = pe.Node(fs.MRIConvert(out_type='niigz'), name='tonii')
 
     def select_target(subject_id, space):
         """Get the target subject ID, given a source subject ID and a target space."""
@@ -129,8 +128,7 @@ The BOLD time-series were resampled onto the following surfaces
         (inputnode, rename_src, [('source_file', 'in_file')]),
         (inputnode, itk2lta, [('source_file', 'src_file'),
                               ('t1w2fsnative_xfm', 'in_file')]),
-        (get_fsnative, tonii, [('T1', 'in_file')]),
-        (tonii, itk2lta, [('out_file', 'dst_file')]),
+        (get_fsnative, itk2lta, [('T1', 'dst_file')]),
         (inputnode, sampler, [('subjects_dir', 'subjects_dir'),
                               ('subject_id', 'subject_id')]),
         (itersource, targets, [('target', 'space')]),

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -69,13 +69,8 @@ def init_bold_surf_wf(
         BOLD series, resampled to FreeSurfer surfaces
 
     """
+    from nipype.interfaces.io import FreeSurferSource
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-    from niworkflows.interfaces.nitransforms import ConcatenateXFMs
-
-    # See https://github.com/poldracklab/fmriprep/issues/768
-    from niworkflows.interfaces.freesurfer import (
-        PatchedLTAConvert as LTAConvert
-    )
     from niworkflows.interfaces.surf import GiftiSetAnatomicalStructure
 
     workflow = Workflow(name=name)
@@ -86,11 +81,15 @@ The BOLD time-series were resampled onto the following surfaces
 """.format(out_spaces=', '.join(['*%s*' % s for s in surface_spaces]))
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=['source_file', 't1w_preproc', 'subject_id', 'subjects_dir',
+        niu.IdentityInterface(fields=['source_file', 'subject_id', 'subjects_dir',
                                       't1w2fsnative_xfm']),
         name='inputnode')
     itersource = pe.Node(niu.IdentityInterface(fields=['target']), name='itersource')
     itersource.iterables = [('target', surface_spaces)]
+
+    get_fsnative = pe.Node(FreeSurferSource(), name='get_fsnative',
+                           run_without_submitting=True)
+    tonii = pe.Node(fs.MRIConvert(out_type='niigz'), name='tonii')
 
     def select_target(subject_id, space):
         """Get the target subject ID, given a source subject ID and a target space."""
@@ -103,11 +102,8 @@ The BOLD time-series were resampled onto the following surfaces
     rename_src = pe.Node(niu.Rename(format_string='%(subject)s', keep_ext=True),
                          name='rename_src', run_without_submitting=True,
                          mem_gb=DEFAULT_MEMORY_MIN_GB)
-    resampling_xfm = pe.Node(LTAConvert(in_lta='identity.nofile', out_lta=True),
-                             name='resampling_xfm')
-    merge_xfm = pe.Node(niu.Merge(2), name="merge_xfm", run_without_submitting=True)
-    concat_xfm = pe.Node(ConcatenateXFMs(out_fmt="fs"), name="concat_xfm")
-
+    itk2lta = pe.Node(niu.Function(function=_itk2lta), name="itk2lta",
+                      run_without_submitting=True)
     sampler = pe.MapNode(
         fs.SampleToSurface(
             cortex_mask=True,
@@ -127,20 +123,19 @@ The BOLD time-series were resampled onto the following surfaces
                              joinsource='itersource', name='outputnode')
 
     workflow.connect([
+        (inputnode, get_fsnative, [('subject_id', 'subject_id'),
+                                   ('subjects_dir', 'subjects_dir')]),
         (inputnode, targets, [('subject_id', 'subject_id')]),
         (inputnode, rename_src, [('source_file', 'in_file')]),
-        (inputnode, resampling_xfm, [('source_file', 'source_file'),
-                                     ('t1w_preproc', 'target_file')]),
-        (inputnode, concat_xfm, [('source_file', 'moving'),
-                                 ('t1w_preproc', 'reference')]),
-        (inputnode, merge_xfm, [('t1w2fsnative_xfm', 'in2')]),
+        (inputnode, itk2lta, [('source_file', 'src_file'),
+                              ('t1w2fsnative_xfm', 'in_file')]),
+        (get_fsnative, tonii, [('T1', 'in_file')]),
+        (tonii, itk2lta, [('out_file', 'dst_file')]),
         (inputnode, sampler, [('subjects_dir', 'subjects_dir'),
                               ('subject_id', 'subject_id')]),
         (itersource, targets, [('target', 'space')]),
         (itersource, rename_src, [('target', 'subject')]),
-        (resampling_xfm, merge_xfm, [('out_lta', 'in1')]),
-        (merge_xfm, concat_xfm, [('out', 'in_xfms')]),
-        (concat_xfm, sampler, [('out_xfm', 'reg_file')]),
+        (itk2lta, sampler, [('out', 'reg_file')]),
         (targets, sampler, [('out', 'target_subject')]),
         (rename_src, sampler, [('out_file', 'source_file')]),
         (update_metadata, outputnode, [('out_file', 'surfaces')]),
@@ -774,3 +769,12 @@ def _is_native(in_value):
         in_value.get('resolution') == 'native'
         or in_value.get('res') == 'native'
     )
+
+
+def _itk2lta(in_file, src_file, dst_file):
+    import nitransforms as nt
+    from pathlib import Path
+    out_file = Path("out.lta").absolute()
+    nt.linear.load(in_file, fmt="itk", reference=src_file).to_filename(
+        out_file, moving=dst_file, fmt="fs")
+    return str(out_file)

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -775,6 +775,9 @@ def _itk2lta(in_file, src_file, dst_file):
     import nitransforms as nt
     from pathlib import Path
     out_file = Path("out.lta").absolute()
-    nt.linear.load(in_file, fmt="itk", reference=src_file).to_filename(
-        out_file, moving=dst_file, fmt="fs")
+    nt.linear.load(
+        in_file,
+        fmt="fs" if in_file.endswith(".lta") else "itk",
+        reference=src_file).to_filename(
+            out_file, moving=dst_file, fmt="fs")
     return str(out_file)


### PR DESCRIPTION
This is a temporary patch before we go all the way in with NiTransforms
in the sampling of BOLD on surfaces.

The anatomical _fast-track_ required to expose the fsnative-to-T1w
transform in the derivatives folder (which we were already doing in ITK
format).

When fMRIPrep ran without the fast-track, then the LTA transform would
be directly passed in without conversions. The fast-track PR forced the
implementation to use the ITK version.

This, in conjunction with the little trick to stick the BOLD shape and
zooms into the LTA (i.e., using ``lta_concatenate`` with an identity
transform with those features, shape and zooms, as moving) resulted in
an overly complex workflow that I partially implemented with
NiTransforms.

This PR gets rid of the concatenation with identity trick, using
NiTransforms to generate a transform equivalent to the concatenated LTA
we used to generate before the fast-track was introduced.

Resolves: #2145
Related: #2118, #2041, #2121.