### PR TITLE
FIX: ``MultiLabel`` interpolations should not use ``float=True``

### DIFF
--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -576,10 +576,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             FixHeaderApplyTransforms as ApplyTransforms
         )
 
-        boldmask_to_t1w = pe.Node(
-            ApplyTransforms(interpolation='MultiLabel', float=True),
-            name='boldmask_to_t1w', mem_gb=0.1
-        )
+        boldmask_to_t1w = pe.Node(ApplyTransforms(interpolation='MultiLabel'),
+                                  name='boldmask_to_t1w', mem_gb=0.1)
         workflow.connect([
             (bold_reg_wf, boldmask_to_t1w, [
                 ('outputnode.itk_bold_to_t1', 'transforms')]),

--- a/fmriprep/workflows/bold/confounds.py
+++ b/fmriprep/workflows/bold/confounds.py
@@ -492,11 +492,11 @@ def init_carpetplot_wf(mem_gb, metadata, cifti_output, name="bold_carpet_wf"):
 
     # Warp segmentation into EPI space
     resample_parc = pe.Node(ApplyTransforms(
-        float=True,
+        dimension=3,
         input_image=str(get_template(
             'MNI152NLin2009cAsym', resolution=1, desc='carpet',
             suffix='dseg', extension=['.nii', '.nii.gz'])),
-        dimension=3, default_value=0, interpolation='MultiLabel'),
+        interpolation='MultiLabel'),
         name='resample_parc')
 
     # Carpetplot and confounds plot

--- a/fmriprep/workflows/bold/registration.py
+++ b/fmriprep/workflows/bold/registration.py
@@ -286,10 +286,8 @@ def init_bold_t1_trans_wf(freesurfer, mem_gb, omp_nthreads, multiecho=False, use
     gen_ref = pe.Node(GenerateSamplingReference(), name='gen_ref',
                       mem_gb=0.3)  # 256x256x256 * 64 / 8 ~ 150MB
 
-    mask_t1w_tfm = pe.Node(
-        ApplyTransforms(interpolation='MultiLabel', float=True),
-        name='mask_t1w_tfm', mem_gb=0.1
-    )
+    mask_t1w_tfm = pe.Node(ApplyTransforms(interpolation='MultiLabel'),
+                           name='mask_t1w_tfm', mem_gb=0.1)
 
     workflow.connect([
         (inputnode, gen_ref, [('ref_bold_brain', 'moving_image'),
@@ -304,10 +302,10 @@ def init_bold_t1_trans_wf(freesurfer, mem_gb, omp_nthreads, multiecho=False, use
     if freesurfer:
         # Resample aseg and aparc in T1w space (no transforms needed)
         aseg_t1w_tfm = pe.Node(
-            ApplyTransforms(interpolation='MultiLabel', transforms='identity', float=True),
+            ApplyTransforms(interpolation='MultiLabel', transforms='identity'),
             name='aseg_t1w_tfm', mem_gb=0.1)
         aparc_t1w_tfm = pe.Node(
-            ApplyTransforms(interpolation='MultiLabel', transforms='identity', float=True),
+            ApplyTransforms(interpolation='MultiLabel', transforms='identity'),
             name='aparc_t1w_tfm', mem_gb=0.1)
 
         workflow.connect([

--- a/fmriprep/workflows/bold/resampling.py
+++ b/fmriprep/workflows/bold/resampling.py
@@ -335,11 +335,8 @@ preprocessed BOLD runs*: {tpl}.
     gen_ref = pe.Node(GenerateSamplingReference(), name='gen_ref',
                       mem_gb=0.3)  # 256x256x256 * 64 / 8 ~ 150MB)
 
-    mask_std_tfm = pe.Node(
-        ApplyTransforms(interpolation='MultiLabel', float=True),
-        name='mask_std_tfm',
-        mem_gb=1
-    )
+    mask_std_tfm = pe.Node(ApplyTransforms(interpolation='MultiLabel'),
+                           name='mask_std_tfm', mem_gb=1)
 
     # Write corrected file in the designated output dir
     mask_merge_tfms = pe.Node(niu.Merge(2), name='mask_merge_tfms', run_without_submitting=True,
@@ -412,12 +409,10 @@ preprocessed BOLD runs*: {tpl}.
 
     if freesurfer:
         # Sample the parcellation files to functional space
-        aseg_std_tfm = pe.Node(
-            ApplyTransforms(interpolation='MultiLabel', float=True),
-            name='aseg_std_tfm', mem_gb=1)
-        aparc_std_tfm = pe.Node(
-            ApplyTransforms(interpolation='MultiLabel', float=True),
-            name='aparc_std_tfm', mem_gb=1)
+        aseg_std_tfm = pe.Node(ApplyTransforms(interpolation='MultiLabel'),
+                               name='aseg_std_tfm', mem_gb=1)
+        aparc_std_tfm = pe.Node(ApplyTransforms(interpolation='MultiLabel'),
+                                name='aparc_std_tfm', mem_gb=1)
 
         workflow.connect([
             (inputnode, aseg_std_tfm, [('bold_aseg', 'input_image')]),


### PR DESCRIPTION
This is the root cause of #2142 (although our posterior handling of
the data types in the DerivativesDatasink wasn't great and that
justified nipreps/niworkflows#527).

I found many instances where ``ApplyTransforms`` was used in combination
with ``float=True``. This is why the data array contained floating point
values.

After using this patch, most of the ``_dseg.nii.gz`` files in the output
dropped from ~400KB down to ~25KB (confirming the size is changing on
hard disk). Visually checking one of these files seemed to give the
same labels.

Resolves: #2142
