### PR TITLE
FIX: ensure commandline aliases are respected

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -587,7 +587,7 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
             config.nipype.plugin = _plugin
             config.nipype.plugin_args = plugin_settings.get("plugin_args", {})
             config.nipype.nprocs = config.nipype.plugin_args.get(
-                "nprocs", config.nipype.nprocs
+                "n_procs", config.nipype.nprocs
             )
 
     # Resource management options

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -586,7 +586,7 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
         if _plugin:
             config.nipype.plugin = _plugin
             config.nipype.plugin_args = plugin_settings.get("plugin_args", {})
-            config.nipype.nprocs = config.nipype.plugin_args.get(
+            config.nipype.nprocs = opts.nprocs or config.nipype.plugin_args.get(
                 "n_procs", config.nipype.nprocs
             )
 

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -150,6 +150,7 @@ def _build_parser():
         "--nthreads",
         "--n_cpus",
         "--n-cpus",
+        dest='nprocs',
         action="store",
         type=PositiveInt,
         help="maximum number of threads across all processes",

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -272,7 +272,7 @@ class nipype(_Config):
             'plugin_args': cls.plugin_args,
         }
         if cls.plugin in ('MultiProc', 'LegacyMultiProc'):
-            out['plugin_args']['nprocs'] = int(cls.nprocs)
+            out['plugin_args']['n_procs'] = int(cls.nprocs)
             if cls.memory_gb:
                 out['plugin_args']['memory_gb'] = float(cls.memory_gb)
         return out


### PR DESCRIPTION
Fixes #2151 

There are many aliases for the `nprocs` option, but we were not being consistent with the dest variable.

Also fixes an invalid nipype plugin argument (https://github.com/poldracklab/fmriprep/issues/2153#issuecomment-636205196)