### PR TITLE
MAINT: Improve the questions on the bug-report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ assignees: ''
 
 ### What is the exact command-line you used?
 ```
-<replace your command line here>
+<place your command line here>
 ```
 
 ### Have you checked that your inputs are BIDS valid?

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,15 +6,35 @@ labels: 'bug'
 assignees: ''
 
 ---
-<!--
-For your bug report, include this information:
--------------------------
-What version of fMRIPrep are you using?
-What were you trying to do?
-What did you expect will happen?
-What actually happened?
-Can you replicate the behavior? If yes, how?
+<!-- For your bug report, include this information: -->
 
+### What version of fMRIPrep are you using?
+
+### What kind of installation are you using? Containers (Singularity, Docker), or "bare-metal"?
+
+### What is the exact command-line you used?
+```
+<replace your command line here>
+```
+
+### Have you checked that your inputs are BIDS valid?
+
+### Did fMRIPrep generate the visual report for this particular subject? If yes, could you share it?
+<!-- we can download links from Dropbox, Box, Google Drive, etc. You can send them privately to nipreps@gmail.com.
+     Reports do not contain data usable with personal identification or other research purposes -->
+
+### Can you find some traces of the error reported in the visual report (at the bottom) or in *crashfiles*?
+```
+<please copy&paste all the information you can gather about errors>
+```
+
+### Are you reusing previously computed results (e.g., FreeSurfer, Anatomical derivatives, work directory of previous run)?
+
+
+### fMRIPrep log
+If you have access to the output logged by fMRIPrep, please make sure to attach it as a text file to this issue.
+
+<!--
 List the steps you performed that revealed the bug to you.
 Include any code samples. Enclose them in triple back-ticks (```)
 Like this:


### PR DESCRIPTION
I thought we could make more targeted questions. In particular, we always want to know the command line they executed and whether the report was generated.