### PR TITLE
ENH: Ensure nipype telemetry is just pinged once

### DIFF
--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -244,6 +244,8 @@ class nipype(_Config):
 
     crashfile_format = 'txt'
     """The file format for crashfiles, either text or pickle."""
+    disable_telemetry = bool(os.getenv("NIPYPE_NO_ET") is None)
+    """Disable interface telemetry"""
     get_linked_libs = False
     """Run NiPype's tool to enlist linked libraries for every interface."""
     memory_gb = None
@@ -293,6 +295,12 @@ class nipype(_Config):
             })
             ncfg.enable_resource_monitor()
 
+        if not cls.disable_telemetry:
+            # check for latest version
+            from nipype import check_latest_version
+            check_latest_version()
+            os.environ["NIPYPE_NO_ET"] = "1"
+
         # Nipype config (logs and execution)
         ncfg.update_config({
             'execution': {
@@ -300,6 +308,7 @@ class nipype(_Config):
                 'crashfile_format': cls.crashfile_format,
                 'get_linked_libs': cls.get_linked_libs,
                 'stop_on_first_crash': cls.stop_on_first_crash,
+                'check_version': False,  # disable future telemetry
             }
         })
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     psutil >= 5.4
     pybids >= 0.10.2
     pyyaml
+    requests
     sdcflows ~= 1.3.1
     smriprep ~= 0.6.1
     tedana >= 0.0.9a1, < 0.0.10


### PR DESCRIPTION
Closes #2140 

adds `disable_telemetry` property to `config.nipype` to control whether the initial latest version is done. afterwards, both `NIPYPE_NO_ET` and the config value `check_version` are set to disable future checks

