### PR TITLE
REF: Split final boldref generation from BOLD-BOLD resampling, eliminate extra per-echo computation

### DIFF
--- a/fmriprep/utils/misc.py
+++ b/fmriprep/utils/misc.py
@@ -11,22 +11,3 @@ def check_deps(workflow):
         for node in workflow._get_all_nodes()
         if (hasattr(node.interface, '_cmd')
             and which(node.interface._cmd.split()[0]) is None))
-
-
-def select_first(in_files):
-    """
-    Select the first file from a list of filenames.
-    Used to grab the first echo's file when processing
-    multi-echo data through workflows that only accept
-    a single file.
-
-    Examples
-    --------
-    >>> select_first('some/file.nii.gz')
-    'some/file.nii.gz'
-    >>> select_first(['some/file1.nii.gz', 'some/file2.nii.gz'])
-    'some/file1.nii.gz'
-    """
-    if isinstance(in_files, (list, tuple)):
-        return in_files[0]
-    return in_files

--- a/fmriprep/utils/misc.py
+++ b/fmriprep/utils/misc.py
@@ -11,3 +11,22 @@ def check_deps(workflow):
         for node in workflow._get_all_nodes()
         if (hasattr(node.interface, '_cmd') and
             which(node.interface._cmd.split()[0]) is None))
+
+
+def select_first(in_files):
+    """
+    Select the first file from a list of filenames.
+    Used to grab the first echo's file when processing
+    multi-echo data through workflows that only accept
+    a single file.
+
+    Examples
+    --------
+    >>> select_first('some/file.nii.gz')
+    'some/file.nii.gz'
+    >>> select_first(['some/file1.nii.gz', 'some/file2.nii.gz'])
+    'some/file1.nii.gz'
+    """
+    if isinstance(in_files, (list, tuple)):
+        return in_files[0]
+    return in_files

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -408,7 +408,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                                  joinsource=('meepi_echos' if run_stc is True else 'boldbuffer'),
                                  joinfield=['bold_files'],
                                  name='join_echos')
-        # join_echos2 = join_echos.clone(name='join_echos2')
 
         # create optimal combination, adaptive T2* map
         bold_t2s_wf = init_bold_t2s_wf(echo_times=tes,
@@ -690,6 +689,17 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             # Already applied in bold_bold_trans_wf, which inputs to bold_t2s_wf
             bold_std_trans_wf.inputs.inputnode.fieldwarp = 'identity'
             bold_std_trans_wf.inputs.inputnode.hmc_xforms = 'identity'
+
+        if freesurfer:
+            workflow.connect([
+                (bold_std_trans_wf, func_derivatives_wf, [
+                    ('outputnode.bold_aseg_std', 'inputnode.bold_aseg_std'),
+                    ('outputnode.bold_aparc_std', 'inputnode.bold_aparc_std'),
+                ]),
+                (bold_std_trans_wf, outputnode, [
+                    ('outputnode.bold_aseg_std', 'bold_aseg_std'),
+                    ('outputnode.bold_aparc_std', 'bold_aparc_std')]),
+            ])
 
         # func_derivatives_wf internally parametrizes over snapshotted spaces.
         workflow.connect([

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -662,8 +662,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 ('t1w_aparc', 'inputnode.bold_aparc')]),
             (bold_reg_wf, bold_std_trans_wf, [
                 ('outputnode.itk_bold_to_t1', 'inputnode.itk_bold_to_t1')]),
-            (bold_bold_trans_wf, bold_std_trans_wf, [
-                ('outputnode.bold_mask', 'inputnode.bold_mask')]),
             (bold_std_trans_wf, outputnode, [('outputnode.bold_std', 'bold_std'),
                                              ('outputnode.bold_std_ref', 'bold_std_ref'),
                                              ('outputnode.bold_mask_std', 'bold_mask_std')]),
@@ -682,8 +680,10 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ])
         else:
             workflow.connect([
+                (join_echos, bold_std_trans_wf, [
+                    (('bold_masks', pop_file), 'inputnode.bold_mask')]),
                 (split_opt_comb, bold_std_trans_wf, [
-                    ('out_files', 'inputnode.bold_split')])
+                    ('out_files', 'inputnode.bold_split')]),
             ])
 
             # Already applied in bold_bold_trans_wf, which inputs to bold_t2s_wf

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -662,11 +662,18 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             workflow.connect([
                 (bold_bold_trans_wf, bold_std_trans_wf, [
                     ('outputnode.bold_mask', 'inputnode.bold_mask')]),
+                (bold_split, bold_std_trans_wf, [
+                    ('out_files', 'inputnode.bold_split')]),
             ])
         else:
+            split_opt_comb = bold_split.clone(name='split_opt_comb')
             workflow.connect([
-                (join_echos, func_derivatives_wf, [
-                    (('bold_masks', select_first), 'inputnode.bold_mask_native')]),
+                (join_echos, bold_std_trans_wf, [
+                    (('bold_masks', select_first), 'inputnode.bold_mask')]),
+                (bold_t2s_wf, split_opt_comb, [
+                    ('outputnode.bold', 'in_file')]),
+                (split_opt_comb, bold_std_trans_wf, [
+                    ('out_files', 'inputnode.bold_split')]),
             ])
 
         if freesurfer:
@@ -678,21 +685,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 (bold_std_trans_wf, outputnode, [
                     ('outputnode.bold_aseg_std', 'bold_aseg_std'),
                     ('outputnode.bold_aparc_std', 'bold_aparc_std')]),
-            ])
-
-        if not multiecho:
-            workflow.connect([
-                (bold_split, bold_std_trans_wf, [
-                    ('out_files', 'inputnode.bold_split')])
-            ])
-        else:
-            split_opt_comb = bold_split.clone(name='split_opt_comb')
-            workflow.connect([
-                (bold_t2s_wf, split_opt_comb, [
-                    ('outputnode.bold', 'in_file')]),
-                (split_opt_comb, bold_std_trans_wf, [
-                    ('out_files', 'inputnode.bold_split')
-                ])
             ])
 
         # func_derivatives_wf internally parametrizes over snapshotted spaces.

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -625,7 +625,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             (bold_t1_trans_wf, boldmask_to_t1w, [
                 ('outputnode.bold_mask_t1', 'reference_image')]),
             (final_boldref_wf, boldmask_to_t1w, [
-                ('outputnode.bold_mask', 'input_image')])
+                ('outputnode.bold_mask', 'input_image')]),
             (boldmask_to_t1w, outputnode, [
                 ('output_image', 'bold_mask_t1')]),
         ])

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -632,7 +632,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     if nonstd_spaces.intersection(('func', 'run', 'bold', 'boldref', 'sbref')):
         workflow.connect([
             (final_boldref_wf, func_derivatives_wf, [
-                ('outputnode.bold_ref', 'inputnode.bold_native_ref'),
+                ('outputnode.ref_image', 'inputnode.bold_native_ref'),
                 ('outputnode.bold_mask', 'inputnode.bold_mask_native')]),
             (bold_bold_trans_wf if not multiecho else bold_t2s_wf, outputnode, [
                 ('outputnode.bold', 'bold_native')])

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -628,7 +628,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             (bold_bold_trans_wf, outputnode, [
                 ('outputnode.bold', 'bold_native')]),
             (bold_bold_trans_wf, func_derivatives_wf, [
-                ('outputnode.bold_ref', 'inputnode.bold_native_ref')
+                ('outputnode.bold_ref', 'inputnode.bold_native_ref'),
             ]),
         ])
         if not multiecho:

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -416,7 +416,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         join_echos = pe.JoinNode(
             niu.IdentityInterface(fields=['bold_files', 'skullstripped_bold_files']),
             joinsource=('meepi_echos' if run_stc is True else 'boldbuffer'),
-            joinfield=['bold_files'],
+            joinfield=['bold_files', 'skullstripped_bold_files'],
             name='join_echos'
         )
 

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -544,7 +544,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             (bold_t2s_wf, split_opt_comb, [
                 ('outputnode.bold', 'in_file')]),
             (split_opt_comb, bold_t1_trans_wf, [
-                ('out_files', 'inputnode.bold_split')])
+                ('out_files', 'inputnode.bold_split')]),
         ])
 
         # Already applied in bold_bold_trans_wf, which inputs to bold_t2s_wf
@@ -666,6 +666,17 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                                              ('outputnode.bold_mask_std', 'bold_mask_std')]),
         ])
 
+        if freesurfer:
+            workflow.connect([
+                (bold_std_trans_wf, func_derivatives_wf, [
+                    ('outputnode.bold_aseg_std', 'inputnode.bold_aseg_std'),
+                    ('outputnode.bold_aparc_std', 'inputnode.bold_aparc_std'),
+                ]),
+                (bold_std_trans_wf, outputnode, [
+                    ('outputnode.bold_aseg_std', 'bold_aseg_std'),
+                    ('outputnode.bold_aparc_std', 'bold_aparc_std')]),
+            ])
+
         if not multiecho:
             workflow.connect([
                 (bold_split, bold_std_trans_wf, [
@@ -678,23 +689,12 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         else:
             workflow.connect([
                 (split_opt_comb, bold_std_trans_wf, [
-                    ('out_files', 'inputnode.bold_split')]),
+                    ('out_files', 'inputnode.bold_split')])
             ])
 
             # Already applied in bold_bold_trans_wf, which inputs to bold_t2s_wf
             bold_std_trans_wf.inputs.inputnode.fieldwarp = 'identity'
             bold_std_trans_wf.inputs.inputnode.hmc_xforms = 'identity'
-
-        if freesurfer:
-            workflow.connect([
-                (bold_std_trans_wf, func_derivatives_wf, [
-                    ('outputnode.bold_aseg_std', 'inputnode.bold_aseg_std'),
-                    ('outputnode.bold_aparc_std', 'inputnode.bold_aparc_std'),
-                ]),
-                (bold_std_trans_wf, outputnode, [
-                    ('outputnode.bold_aseg_std', 'bold_aseg_std'),
-                    ('outputnode.bold_aparc_std', 'bold_aparc_std')]),
-            ])
 
         # func_derivatives_wf internally parametrizes over snapshotted spaces.
         workflow.connect([

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -21,7 +21,6 @@ from niworkflows.utils.connections import pop_file, listify
 
 
 from ...utils.meepi import combine_meepi_source
-from ...utils.misc import select_first
 
 from ...interfaces import DerivativesDataSink
 from ...interfaces.reports import FunctionalSummary
@@ -526,7 +525,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             (bold_bold_trans_wf, join_echos, [
                 ('outputnode.bold_mask', 'bold_masks')]),
             (join_echos, bold_confounds_wf, [
-                (('bold_masks', select_first), 'inputnode.bold_mask')
+                (('bold_masks', pop_file), 'inputnode.bold_mask')
             ])
         ])
 
@@ -614,7 +613,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         else:
             workflow.connect([
                 (join_echos, boldmask_to_t1w, [
-                    (('bold_masks', select_first), 'input_image')]),
+                    (('bold_masks', pop_file), 'input_image')]),
             ])
 
     if nonstd_spaces.intersection(('func', 'run', 'bold', 'boldref', 'sbref')):
@@ -633,7 +632,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         else:
             workflow.connect([
                 (join_echos, func_derivatives_wf, [
-                    (('bold_masks', select_first), 'inputnode.bold_mask_native')]),
+                    (('bold_masks', pop_file), 'inputnode.bold_mask_native')]),
             ])
 
     if spaces.get_spaces(nonstandard=False, dim=(3,)):
@@ -677,7 +676,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             split_opt_comb = bold_split.clone(name='split_opt_comb')
             workflow.connect([
                 (join_echos, bold_std_trans_wf, [
-                    (('bold_masks', select_first), 'inputnode.bold_mask')]),
+                    (('bold_masks', pop_file), 'inputnode.bold_mask')]),
                 (bold_t2s_wf, split_opt_comb, [
                     ('outputnode.bold', 'in_file')]),
                 (split_opt_comb, bold_std_trans_wf, [
@@ -843,7 +842,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             else:
                 workflow.connect([
                     (join_echos, carpetplot_wf, [
-                        (('bold_masks', select_first), 'inputnode.bold_mask')]),
+                        (('bold_masks', pop_file), 'inputnode.bold_mask')]),
                 ])
 
         workflow.connect([

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -515,7 +515,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             (bold_bold_trans_wf, bold_confounds_wf, [
                 ('outputnode.bold', 'inputnode.bold')]),
             (bold_bold_trans_wf, final_boldref_wf, [
-                ('outputnode.bold', 'inputnode.bold')]),
+                ('outputnode.bold', 'inputnode.bold_file')]),
             (bold_split, bold_t1_trans_wf, [
                 ('out_files', 'inputnode.bold_split')]),
             (bold_hmc_wf, bold_t1_trans_wf, [
@@ -531,7 +531,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             (bold_bold_trans_wf, join_echos, [
                 ('outputnode.bold', 'bold_files')]),
             (join_echos, final_boldref_wf, [
-                ('bold_files', 'inputnode.bold')]),
+                ('bold_files', 'inputnode.bold_file')]),
             (bold_bold_trans_wf, skullstrip_bold_wf, [
                 ('outputnode.bold', 'inputnode.in_file')]),
             (skullstrip_bold_wf, join_echos, [

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -370,7 +370,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     # This BOLD references *does not use* single-band reference images.
     final_boldref_wf = init_bold_reference_wf(
         name='final_boldref_wf',
-        omp_nthreads=omp_nthreads
+        omp_nthreads=omp_nthreads,
+        multiecho=multiecho,
     )
     final_boldref_wf.__desc__ = None  # Unset description to avoid second appearance
 

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -17,7 +17,7 @@ from nipype.interfaces.fsl import Split as FSLSplit
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
 
-from niworkflows.utils.connections import listify
+from niworkflows.utils.connections import listify, pop_file
 
 
 from ...utils.meepi import combine_meepi_source
@@ -513,7 +513,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             (inputnode, func_derivatives_wf, [
                 ('bold_file', 'inputnode.source_file')]),
             (bold_bold_trans_wf, bold_confounds_wf, [
-                ('outputnode.bold', 'inputnode.bold')],
+                ('outputnode.bold', 'inputnode.bold')]),
             (bold_bold_trans_wf, final_boldref_wf, [
                 ('outputnode.bold', 'inputnode.bold')]),
             (bold_split, bold_t1_trans_wf, [

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -17,7 +17,7 @@ from nipype.interfaces.fsl import Split as FSLSplit
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
 
-from niworkflows.utils.connections import listify, pop_file
+from niworkflows.utils.connections import pop_file, listify
 
 
 from ...utils.meepi import combine_meepi_source
@@ -491,6 +491,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ('outputnode.itk_t1_to_bold', 'inputnode.t1_bold_xform')]),
         (initial_boldref_wf, bold_confounds_wf, [
             ('outputnode.skip_vols', 'inputnode.skip_vols')]),
+        (final_boldref_wf, bold_confounds_wf, [
+            ('outputnode.bold_mask', 'inputnode.bold_mask')]),
         (bold_confounds_wf, outputnode, [
             ('outputnode.confounds_file', 'confounds'),
         ]),
@@ -502,8 +504,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ('out_files', 'inputnode.bold_file')]),
         (bold_hmc_wf, bold_bold_trans_wf, [
             ('outputnode.xforms', 'inputnode.hmc_xforms')]),
-        (final_boldref_wf, bold_confounds_wf, [
-            ('outputnode.bold_mask', 'inputnode.bold_mask')]),
         # Summary
         (outputnode, summary, [('confounds', 'confounds_file')]),
     ])
@@ -624,10 +624,10 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 ('outputnode.itk_bold_to_t1', 'transforms')]),
             (bold_t1_trans_wf, boldmask_to_t1w, [
                 ('outputnode.bold_mask_t1', 'reference_image')]),
-            (boldmask_to_t1w, outputnode, [
-                ('output_image', 'bold_mask_t1')]),
             (final_boldref_wf, boldmask_to_t1w, [
                 ('outputnode.bold_mask', 'input_image')])
+            (boldmask_to_t1w, outputnode, [
+                ('output_image', 'bold_mask_t1')]),
         ])
 
     if nonstd_spaces.intersection(('func', 'run', 'bold', 'boldref', 'sbref')):
@@ -832,10 +832,10 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                     ('std2anat_xfm', 'inputnode.std2anat_xfm')]),
                 (bold_bold_trans_wf if not multiecho else bold_t2s_wf, carpetplot_wf, [
                     ('outputnode.bold', 'inputnode.bold')]),
-                (bold_reg_wf, carpetplot_wf, [
-                    ('outputnode.itk_t1_to_bold', 'inputnode.t1_bold_xform')]),
                 (final_boldref_wf, carpetplot_wf, [
                     ('outputnode.bold_mask', 'inputnode.bold_mask')]),
+                (bold_reg_wf, carpetplot_wf, [
+                    ('outputnode.itk_t1_to_bold', 'inputnode.t1_bold_xform')]),
             ])
 
         workflow.connect([


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->
Closes #2175. It appears that dropping the tedana-based mask in #2109 led to un-joined echo-specific masks being used _after_ echo combination throughout the workflow. This led to many redundant nodes in the workflow being created, including multiple runs of ICA-AROMA, although those nodes should be duplicates of one another except for the difference, if any, in masks.

## Changes proposed in this pull request
- Move final reference image creation step out of `init_bold_preproc_trans_wf` and into `init_func_preproc_wf`. The workflow is called `final_boldref_wf`.
- Rename `bold_reference_wf` in `init_func_preproc_wf` to `initial_boldref_wf`.
- Replace `bold_files` in `join_echos` JoinNode with reference native-space BOLD files from `bold_bold_trans_wf`.
- Add `skullstripped_bold_files` to `join_echos` JoinNode, to combine skullstripped BOLD files from `skullstrip_bold_wf ` and feed them to `bold_t2s_wf`. (These _were_ the `bold_files` in `join_echos` before.)
<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
None


<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
