### PR TITLE
ENH: Report number of echoes in BOLD summary.

### DIFF
--- a/fmriprep/interfaces/reports.py
+++ b/fmriprep/interfaces/reports.py
@@ -32,6 +32,7 @@ FUNCTIONAL_TEMPLATE = """\
 \t\t<ul class="elem-desc">
 \t\t\t<li>Repetition time (TR): {tr:.03g}s</li>
 \t\t\t<li>Phase-encoding (PE) direction: {pedir}</li>
+\t\t\t<li>{multiecho}</li>
 \t\t\t<li>Slice timing correction: {stc}</li>
 \t\t\t<li>Susceptibility distortion correction: {sdc}</li>
 \t\t\t<li>Registration: {registration}</li>
@@ -171,6 +172,7 @@ class FunctionalSummaryInputSpec(BaseInterfaceInputSpec):
     tr = traits.Float(desc='Repetition time', mandatory=True)
     dummy_scans = traits.Either(traits.Int(), None, desc='number of dummy scans specified by user')
     algo_dummy_scans = traits.Int(desc='number of dummy scans determined by algorithm')
+    echo_idx = traits.List([], usedefault=True, desc="BIDS echo identifiers")
 
 
 class FunctionalSummary(SummaryInterface):
@@ -218,10 +220,20 @@ class FunctionalSummary(SummaryInterface):
         else:
             dummy_scan_msg = dummy_scan_tmp.format(n_dum=self.inputs.algo_dummy_scans)
 
+        multiecho = "Single-echo EPI sequence."
+        n_echos = len(self.inputs.echo_idx)
+        if n_echos == 1:
+            multiecho = (
+                f"Multi-echo EPI sequence: only echo {self.inputs.echo_idx[0]} processed "
+                "in single-echo mode."
+            )
+        if n_echos > 2:
+            multiecho = (f"Multi-echo EPI sequence: {n_echos} echoes.")
+
         return FUNCTIONAL_TEMPLATE.format(
             pedir=pedir, stc=stc, sdc=self.inputs.distortion_correction, registration=reg,
             confounds=re.sub(r'[\t ]+', ', ', conflist), tr=self.inputs.tr,
-            dummy_scan_desc=dummy_scan_msg)
+            dummy_scan_desc=dummy_scan_msg, multiecho=multiecho)
 
 
 class AboutSummaryInputSpec(BaseInterfaceInputSpec):

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -267,6 +267,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             registration_dof=config.workflow.bold2t1w_dof,
             registration_init=config.workflow.bold2t1w_init,
             pe_direction=metadata.get("PhaseEncodingDirection"),
+            echo_idx=echo_idxs,
             tr=metadata.get("RepetitionTime")),
         name='summary', mem_gb=config.DEFAULT_MEMORY_MIN_GB, run_without_submitting=True)
     summary.inputs.dummy_scans = config.workflow.dummy_scans


### PR DESCRIPTION
Builds on the new echo list extraction of #1803 to determine whether the
dataset is single-echo, multi-echo (and how many echoes are processed),
or multi-echo but processing only one of the echoes (e.g., using
``--bids-filter``).

Resolves: #2174.
