### PR TITLE
FIX: skip t1w check if anat-derivatives provided.

### DIFF
--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -138,6 +138,7 @@ def init_single_subject_wf(subject_id):
         subject_data['t2w'] = []
 
     anat_only = config.workflow.anat_only
+    anat_precomp = config.execution.anat_derivatives is not None
     # Make sure we always go through these two checks
     if not anat_only and not subject_data['bold']:
         task_id = config.execution.task_id

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -276,7 +276,7 @@ It is released under the [CC0]\
         ])
     else:
         workflow.connect([
-            (anat_preproc_wf, bids_info, [('outputnode.t1w_preproc', 'in_file')]),
+            (bidssrc, bids_info, [(('bold', fix_multi_T1w_source_name), 'in_file')]),
             (anat_preproc_wf, summary, [('outputnode.t1w_preproc', 't1w')]),
             (anat_preproc_wf, ds_report_summary, [('outputnode.t1w_preproc', 'source_file')]),
             (anat_preproc_wf, ds_report_about, [('outputnode.t1w_preproc', 'source_file')]),

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -148,10 +148,6 @@ def init_single_subject_wf(subject_id):
                 subject_id, task_id if task_id else '<all>')
         )
 
-    if not anat_derivatives and not subject_data['t1w']:
-        raise Exception("No T1w images found for participant {}. "
-                        "All workflows require T1w images.".format(subject_id))
-
     workflow = Workflow(name=name)
     workflow.__desc__ = """
 Results included in this manuscript come from preprocessing
@@ -232,6 +228,10 @@ Attempted to access pre-existing anatomical derivatives at \
 <{config.execution.anat_derivatives}>, however not all expectations of fMRIPrep \
 were met (for participant <{subject_id}>, spaces <{', '.join(std_spaces)}>, \
 reconall <{config.workflow.run_reconall}>).""")
+
+    if not anat_derivatives and not subject_data['t1w']:
+        raise Exception("No T1w images found for participant {}. "
+                        "All workflows require T1w images.".format(subject_id))
 
     # Preprocessing of T1w (includes registration to MNI)
     anat_preproc_wf = init_anat_preproc_wf(

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -254,22 +254,33 @@ It is released under the [CC0]\
 
     workflow.connect([
         (inputnode, anat_preproc_wf, [('subjects_dir', 'inputnode.subjects_dir')]),
-        (bidssrc, bids_info, [(('t1w', fix_multi_T1w_source_name), 'in_file')]),
         (inputnode, summary, [('subjects_dir', 'subjects_dir')]),
-        (bidssrc, summary, [('t1w', 't1w'),
-                            ('t2w', 't2w'),
-                            ('bold', 'bold')]),
+        (bidssrc, summary, [('bold', 'bold')]),
         (bids_info, summary, [('subject', 'subject_id')]),
         (bids_info, anat_preproc_wf, [(('subject', _prefix), 'inputnode.subject_id')]),
         (bidssrc, anat_preproc_wf, [('t1w', 'inputnode.t1w'),
                                     ('t2w', 'inputnode.t2w'),
                                     ('roi', 'inputnode.roi'),
                                     ('flair', 'inputnode.flair')]),
-        (bidssrc, ds_report_summary, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
         (summary, ds_report_summary, [('out_report', 'in_file')]),
-        (bidssrc, ds_report_about, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
         (about, ds_report_about, [('out_report', 'in_file')]),
     ])
+
+    if not anat_derivatives:
+        workflow.connect([
+            (bidssrc, bids_info, [(('t1w', fix_multi_T1w_source_name), 'in_file')]),
+            (bidssrc, summary, [('t1w', 't1w'),
+                                ('t2w', 't2w')]),
+            (bidssrc, ds_report_summary, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
+            (bidssrc, ds_report_about, [(('t1w', fix_multi_T1w_source_name), 'source_file')]),
+        ])
+    else:
+        workflow.connect([
+            (anat_preproc_wf, bids_info, [('outputnode.t1w_preproc', 'in_file')]),
+            (anat_preproc_wf, summary, [('outputnode.t1w_preproc', 't1w')]),
+            (anat_preproc_wf, ds_report_summary, [('outputnode.t1w_preproc', 'source_file')]),
+            (anat_preproc_wf, ds_report_about, [('outputnode.t1w_preproc', 'source_file')]),
+        ])
 
     # Overwrite ``out_path_base`` of smriprep's DataSinks
     for node in workflow.list_node_names():

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -138,7 +138,7 @@ def init_single_subject_wf(subject_id):
         subject_data['t2w'] = []
 
     anat_only = config.workflow.anat_only
-    anat_precomp = config.execution.anat_derivatives is not None
+    anat_derivatives = config.execution.anat_derivatives
     # Make sure we always go through these two checks
     if not anat_only and not subject_data['bold']:
         task_id = config.execution.task_id
@@ -148,7 +148,7 @@ def init_single_subject_wf(subject_id):
                 subject_id, task_id if task_id else '<all>')
         )
 
-    if not anat_precomp and not subject_data['t1w']:
+    if not anat_derivatives and not subject_data['t1w']:
         raise Exception("No T1w images found for participant {}. "
                         "All workflows require T1w images.".format(subject_id))
 
@@ -217,7 +217,6 @@ It is released under the [CC0]\
                             dismiss_entities=("echo",)),
         name='ds_report_about', run_without_submitting=True)
 
-    anat_derivatives = config.execution.anat_derivatives
     if anat_derivatives:
         from smriprep.utils.bids import collect_derivatives
         std_spaces = spaces.get_spaces(nonstandard=False, dim=(3,))

--- a/fmriprep/workflows/base.py
+++ b/fmriprep/workflows/base.py
@@ -148,7 +148,7 @@ def init_single_subject_wf(subject_id):
                 subject_id, task_id if task_id else '<all>')
         )
 
-    if not subject_data['t1w']:
+    if not anat_precomp and not subject_data['t1w']:
         raise Exception("No T1w images found for participant {}. "
                         "All workflows require T1w images.".format(subject_id))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     nipype >= 1.5
     nitime
     nitransforms >= 20.0.0rc3,<20.2
-    niworkflows @ git+https://github.com/nipreps/niworkflows.git@master
+    niworkflows @ git+https://github.com/nipreps/niworkflows.git@refs/pull/545/head
     numpy
     pandas
     psutil >= 5.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     nipype >= 1.5
     nitime
     nitransforms >= 20.0.0rc3,<20.2
-    niworkflows @ git+https://github.com/nipreps/niworkflows.git@refs/pull/545/head
+    niworkflows @ git+https://github.com/nipreps/niworkflows.git@master
     numpy
     pandas
     psutil >= 5.4


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

Fixes #2197 .
In the case where a precomputed anatomical derivatives are provided with `--anat-derivatives`, skip the check for an existing T1w.

For now the side-tracking of smriprep will produce a warning when the anat-derivatives does not match the necessary input. Should it produce an error and die instead?. I think that this option will be mainly used by skilled users, and they would rather know if fast-track didn't work.

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPrep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
