### PR TITLE
ENH: Leverage BIDSLayout's database_path

### DIFF
--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -156,7 +156,7 @@ def _build_parser():
         "with an alternative processing tool (NOT RECOMMENDED).",
     )
     g_bids.add_argument(
-        "--database-path",
+        "--bids-database-dir",
         metavar="PATH",
         type=PathExists,
         help="Path to an existing PyBIDS database folder, for faster indexing "

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -155,6 +155,12 @@ def _build_parser():
         help="Reuse the anatomical derivatives from another fMRIPrep run or calculated "
         "with an alternative processing tool (NOT RECOMMENDED).",
     )
+    g_bids.add_argument(
+        "--database-path",
+        metavar="PATH",
+        type=PathExists,
+        help="Path to SQLite database indicies for BIDS dataset"
+    )
 
     g_perfm = parser.add_argument_group("Options to handle performance")
     g_perfm.add_argument(

--- a/fmriprep/cli/parser.py
+++ b/fmriprep/cli/parser.py
@@ -159,7 +159,8 @@ def _build_parser():
         "--database-path",
         metavar="PATH",
         type=PathExists,
-        help="Path to SQLite database indicies for BIDS dataset"
+        help="Path to an existing PyBIDS database folder, for faster indexing "
+             "(especially useful for large datasets)."
     )
 
     g_perfm = parser.add_argument_group("Options to handle performance")

--- a/fmriprep/cli/run.py
+++ b/fmriprep/cli/run.py
@@ -26,7 +26,8 @@ def main():
     # CRITICAL Save the config to a file. This is necessary because the execution graph
     # is built as a separate process to keep the memory footprint low. The most
     # straightforward way to communicate with the child process is via the filesystem.
-    config_file = config.execution.work_dir / f"config-{config.execution.run_uuid}.toml"
+    config_file = config.execution.work_dir / config.execution.run_uuid / "config.toml"
+    config_file.parent.mkdir(exist_ok=True, parents=True)
     config.to_filename(config_file)
 
     # CRITICAL Call build_workflow(config_file, retval) in a subprocess.

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -332,14 +332,14 @@ class execution(_Config):
     """A path where anatomical derivatives are found to fast-track *sMRIPrep*."""
     bids_dir = None
     """An existing path to the dataset, which must be BIDS-compliant."""
+    bids_database_dir = None
+    """Path to the directory containing SQLite database indices for the input BIDS dataset."""
     bids_description_hash = None
     """Checksum (SHA256) of the ``dataset_description.json`` of the BIDS dataset."""
     bids_filters = None
     """A dictionary of BIDS selection filters."""
     boilerplate_only = False
     """Only generate a boilerplate."""
-    database_path = None
-    """Path to the directory containing SQLite database indices for the input BIDS dataset."""
     debug = False
     """Run in sloppy mode (meaning, suboptimal parameters that minimize run-time)."""
     echo_idx = None
@@ -385,7 +385,7 @@ class execution(_Config):
     _paths = (
         'anat_derivatives',
         'bids_dir',
-        'database_path',
+        'bids_database_dir',
         'fs_license_file',
         'fs_subjects_dir',
         'layout',
@@ -404,16 +404,16 @@ class execution(_Config):
         if cls._layout is None:
             import re
             from bids.layout import BIDSLayout
-            _db_path = cls.database_path or (cls.work_dir / cls.run_uuid / 'bids.db')
+            _db_path = cls.bids_database_dir or (cls.work_dir / cls.run_uuid / 'bids_db')
             _db_path.mkdir(exist_ok=True, parents=True)
             cls._layout = BIDSLayout(
                 str(cls.bids_dir),
                 validate=False,
                 database_path=_db_path,
-                reset_database=cls.database_path is None,
+                reset_database=cls.bids_database_dir is None,
                 ignore=("code", "stimuli", "sourcedata", "models",
                         "derivatives", re.compile(r'^\.')))
-            cls.database_path = _db_path
+            cls.bids_database_dir = _db_path
         cls.layout = cls._layout
         if cls.bids_filters:
             from bids.layout import Query

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -339,7 +339,7 @@ class execution(_Config):
     boilerplate_only = False
     """Only generate a boilerplate."""
     database_path = None
-    """Path to directory containing SQLite database indicies for BIDS dataset"""
+    """Path to the directory containing SQLite database indices for the input BIDS dataset."""
     debug = False
     """Run in sloppy mode (meaning, suboptimal parameters that minimize run-time)."""
     echo_idx = None

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -338,6 +338,8 @@ class execution(_Config):
     """A dictionary of BIDS selection filters."""
     boilerplate_only = False
     """Only generate a boilerplate."""
+    database_path = None
+    """Path to directory containing SQLite database indicies for BIDS dataset"""
     debug = False
     """Run in sloppy mode (meaning, suboptimal parameters that minimize run-time)."""
     echo_idx = None
@@ -383,6 +385,7 @@ class execution(_Config):
     _paths = (
         'anat_derivatives',
         'bids_dir',
+        'database_path',
         'fs_license_file',
         'fs_subjects_dir',
         'layout',
@@ -401,12 +404,14 @@ class execution(_Config):
         if cls._layout is None:
             import re
             from bids.layout import BIDSLayout
-            work_dir = cls.work_dir / 'bids.db'
-            work_dir.mkdir(exist_ok=True, parents=True)
+            _db_path = cls.database_path or (cls.work_dir / cls.run_uuid / 'bids.db')
+            _db_path.mkdir(exist_ok=True, parents=True)
+            _reset_db = bool(cls.database_path is not None)
             cls._layout = BIDSLayout(
                 str(cls.bids_dir),
                 validate=False,
-                # database_path=str(work_dir),
+                database_path=_db_path,
+                reset_database=_reset_db,
                 ignore=("code", "stimuli", "sourcedata", "models",
                         "derivatives", re.compile(r'^\.')))
         cls.layout = cls._layout

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -406,14 +406,14 @@ class execution(_Config):
             from bids.layout import BIDSLayout
             _db_path = cls.database_path or (cls.work_dir / cls.run_uuid / 'bids.db')
             _db_path.mkdir(exist_ok=True, parents=True)
-            _reset_db = bool(cls.database_path is not None)
             cls._layout = BIDSLayout(
                 str(cls.bids_dir),
                 validate=False,
                 database_path=_db_path,
-                reset_database=_reset_db,
+                reset_database=cls.database_path is None,
                 ignore=("code", "stimuli", "sourcedata", "models",
                         "derivatives", re.compile(r'^\.')))
+            cls.database_path = _db_path
         cls.layout = cls._layout
         if cls.bids_filters:
             from bids.layout import Query

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -166,6 +166,7 @@ def merge_help(wrapper_help, target_help):
     overlap = set(w_flags).intersection(t_flags)
     expected_overlap = {
         'anat-derivatives',
+        'database-path',
         'fs-license-file',
         'fs-subjects-dir',
         'h',
@@ -306,6 +307,9 @@ the spatial normalization.""" % (', '.join('"%s"' % s for s in TF_TEMPLATES),
     g_wrap.add_argument(
         '--use-plugin', metavar='PATH', action='store', default=None,
         type=os.path.abspath, help='nipype plugin configuration file')
+    g_wrap.add_argument(
+        '--database-path', metavar='PATH', type=os.path.abspath,
+        help="Path to SQLite database indicies for BIDS dataset")
 
     # Developer patch/shell options
     g_dev = parser.add_argument_group(
@@ -460,6 +464,10 @@ def main():
         command.extend(['-v', ':'.join((opts.use_plugin, '/tmp/plugin.yml',
                                         'ro'))])
         unknown_args.extend(['--use-plugin', '/tmp/plugin.yml'])
+
+    if opts.database_path:
+        command.extend(['-v', ':'.join((opts.database_path, '/tmp/bids.db'))])
+        unknown_args.extend(['--database-path', '/tmp/bids.db'])
 
     if opts.output_spaces:
         spaces = []

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -166,7 +166,7 @@ def merge_help(wrapper_help, target_help):
     overlap = set(w_flags).intersection(t_flags)
     expected_overlap = {
         'anat-derivatives',
-        'database-path',
+        'bids-database-dir',
         'fs-license-file',
         'fs-subjects-dir',
         'h',
@@ -308,8 +308,9 @@ the spatial normalization.""" % (', '.join('"%s"' % s for s in TF_TEMPLATES),
         '--use-plugin', metavar='PATH', action='store', default=None,
         type=os.path.abspath, help='nipype plugin configuration file')
     g_wrap.add_argument(
-        '--database-path', metavar='PATH', type=os.path.abspath,
-        help="Path to SQLite database indicies for BIDS dataset")
+        '--bids-database-dir', metavar='PATH', type=os.path.abspath,
+        help="Path to an existing PyBIDS database folder, for faster indexing "
+             "(especially useful for large datasets).")
 
     # Developer patch/shell options
     g_dev = parser.add_argument_group(
@@ -465,9 +466,9 @@ def main():
                                         'ro'))])
         unknown_args.extend(['--use-plugin', '/tmp/plugin.yml'])
 
-    if opts.database_path:
-        command.extend(['-v', ':'.join((opts.database_path, '/tmp/bids.db'))])
-        unknown_args.extend(['--database-path', '/tmp/bids.db'])
+    if opts.bids_database_dir:
+        command.extend(['-v', ':'.join((opts.bids_database_dir, '/tmp/bids_db'))])
+        unknown_args.extend(['--bids-database-dir', '/tmp/bids_db'])
 
     if opts.output_spaces:
         spaces = []


### PR DESCRIPTION
Closes #2019 

### Additions
- Adds support for `BIDSLayout.database_path`
  - If no database path is specified, one will be created in `<working-directory>/<run-uuid>`
  - If it is specified, will just use that path

### Changes
- A `<run-uuid>` directory is created at the top level of the `<working-directory>`, and the previously generated `config-<run-uuid>.toml` files are now located within each directory and renamed to `config.toml`