### PR TITLE
ENH: Add --no-tty option to fmriprep-docker.py

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,6 +2,13 @@
   "title": "fMRIPrep: a robust preprocessing pipeline for functional MRI",
   "description": "<p>fMRIPrep is a robust and easy-to-use pipeline for preprocessing of diverse fMRI data. The transparent workflow dispenses of manual intervention, thereby ensuring the reproducibility of the results.</p>",
   "contributors": [
+      
+    {
+        "affiliation": "Department of Radiology, Weill Cornell Medicine",
+        "name": "Jamison, Keith W.",
+        "orcid": "0000-0001-7139-6661",
+        "type": "Researcher"
+    },
     {
       "affiliation": "Department of Psychology, Florida International University",
       "name": "Salo, Taylor",

--- a/wrapper/fmriprep_docker.py
+++ b/wrapper/fmriprep_docker.py
@@ -325,6 +325,8 @@ the spatial normalization.""" % (', '.join('"%s"' % s for s in TF_TEMPLATES),
     g_dev.add_argument('--network', action='store',
                        help='Run container with a different network driver '
                             '("none" to simulate no internet connection)')
+    g_dev.add_argument('--no-tty', action='store_true',
+                       help='Run docker without TTY flag -it')
 
     return parser
 
@@ -393,8 +395,11 @@ def main():
                          stdout=subprocess.PIPE)
     docker_version = ret.stdout.decode('ascii').strip()
 
-    command = ['docker', 'run', '--rm', '-it', '-e',
+    command = ['docker', 'run', '--rm', '-e',
                'DOCKER_VERSION_8395080871=%s' % docker_version]
+
+    if not opts.no_tty:
+        command.append('-it')
 
     # Patch working repositories into installed package directories
     if opts.patch:


### PR DESCRIPTION
Adding an option to the wrapper to omit the "-it" argument to docker, which avoids crashes in non-interactive environments (See https://github.com/nipreps/smriprep/issues/209 and https://github.com/nipreps/smriprep/pull/216#issuecomment-649134073)