### PR TITLE
MNT: Silence pybids warning by setting extension mode

### DIFF
--- a/fmriprep/__init__.py
+++ b/fmriprep/__init__.py
@@ -15,3 +15,13 @@ __all__ = [
     '__packagename__',
     '__version__',
 ]
+
+# Silence PyBIDS warning for extension entity behavior
+# Can be removed once minimum PyBIDS dependency hits 0.14
+try:
+    import bids
+    bids.config.set_option('extension_initial_dot', True)
+except (ImportError, ValueError):
+    pass
+else:
+    del bids

--- a/fmriprep/workflows/bold/base.py
+++ b/fmriprep/workflows/bold/base.py
@@ -194,7 +194,7 @@ def init_func_preproc_wf(bold_file):
 
     # Find associated sbref, if possible
     entities['suffix'] = 'sbref'
-    entities['extension'] = ['nii', 'nii.gz']  # Overwrite extensions
+    entities['extension'] = ['.nii', '.nii.gz']  # Overwrite extensions
     sbref_files = layout.get(return_type='file', **entities)
 
     sbref_msg = f"No single-band-reference found for {os.path.basename(ref_file)}."
@@ -931,13 +931,13 @@ def extract_entities(file_list):
     Examples
     --------
     >>> extract_entities('sub-01/anat/sub-01_T1w.nii.gz')
-    {'subject': '01', 'suffix': 'T1w', 'datatype': 'anat', 'extension': 'nii.gz'}
+    {'subject': '01', 'suffix': 'T1w', 'datatype': 'anat', 'extension': '.nii.gz'}
     >>> extract_entities(['sub-01/anat/sub-01_T1w.nii.gz'] * 2)
-    {'subject': '01', 'suffix': 'T1w', 'datatype': 'anat', 'extension': 'nii.gz'}
+    {'subject': '01', 'suffix': 'T1w', 'datatype': 'anat', 'extension': '.nii.gz'}
     >>> extract_entities(['sub-01/anat/sub-01_run-1_T1w.nii.gz',
     ...                   'sub-01/anat/sub-01_run-2_T1w.nii.gz'])
     {'subject': '01', 'run': [1, 2], 'suffix': 'T1w', 'datatype': 'anat',
-     'extension': 'nii.gz'}
+     'extension': '.nii.gz'}
 
     """
     from collections import defaultdict


### PR DESCRIPTION
## Changes proposed in this pull request

PyBIDS changed its behavior around the extension entity. The old behavior was to ignore the initial dot (`.`), which remains the default. The planned behavior will be to include the initial dot, as of 0.14. This PR accepts the new behavior, suppressing the warning.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/poldracklab/fmriprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of fMRIPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/poldracklab/fmriprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
