### PR TITLE
FIX: Dependency conflict between niworkflows and templateflow

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,12 +31,12 @@ install_requires =
     numpy
     pandas
     psutil >= 5.4
-    pybids >= 0.10.2
+    pybids ~= 0.10.2
     pyyaml
     sdcflows ~= 1.3.1
     smriprep ~= 0.6.1
     tedana >= 0.0.9a1, < 0.0.10
-    templateflow ~= 0.6
+    templateflow >=0.4.2, < 0.6.3
     toml
 test_requires =
     coverage


### PR DESCRIPTION
Addresses:

```
ERROR: niworkflows 1.2.9 has requirement pybids~=0.10.2, but you'll have pybids 0.12.1 which is incompatible.
ERROR: niworkflows 1.2.9 has requirement templateflow<0.6.3,>=0.4.2, but you'll have templateflow 0.6.3 which is incompatible.
```

References: #2264
References: #2266

IMPORTANT: this commit should not be merged into master.
